### PR TITLE
fix: install permission profiles to profiles/ subdirectory (closes #11)

### DIFF
--- a/scripts/gen-sea-config.mjs
+++ b/scripts/gen-sea-config.mjs
@@ -18,16 +18,17 @@ const distDir = join(root, 'dist');
 mkdirSync(distDir, { recursive: true });
 
 // Collect files recursively
-function collectFiles(dir, base) {
+function collectFiles(dir, base, rootBase) {
+  const effectiveRootBase = rootBase ?? base;
   const results = {};
   if (!existsSync(dir)) return results;
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const fullPath = join(dir, entry.name);
     const relPath = join(base, entry.name).replace(/\\/g, '/');
     if (entry.isDirectory()) {
-      Object.assign(results, collectFiles(fullPath, relPath));
+      Object.assign(results, collectFiles(fullPath, relPath, effectiveRootBase));
     } else {
-      results[relative(base, relPath).replace(/\\/g, '/')] = relPath;
+      results[relative(effectiveRootBase, relPath).replace(/\\/g, '/')] = relPath;
     }
   }
   return results;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -53,16 +53,17 @@ function findProjectRoot(): string {
 }
 
 // Collect files recursively — used by dev-mode manifest generation
-function collectFilesRec(dir: string, base: string): Record<string, string> {
+function collectFilesRec(dir: string, base: string, rootBase?: string): Record<string, string> {
+  const effectiveRootBase = rootBase ?? base;
   const results: Record<string, string> = {};
   if (!fs.existsSync(dir)) return results;
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name);
     const relPath = path.join(base, entry.name).replace(/\\/g, '/');
     if (entry.isDirectory()) {
-      Object.assign(results, collectFilesRec(fullPath, relPath));
+      Object.assign(results, collectFilesRec(fullPath, relPath, effectiveRootBase));
     } else {
-      results[path.relative(base, relPath).replace(/\\/g, '/')] = relPath;
+      results[path.relative(effectiveRootBase, relPath).replace(/\\/g, '/')] = relPath;
     }
   }
   return results;


### PR DESCRIPTION
## Summary
Fixes #11 — the installer was placing permission profile files (base-dev.json, node.json, etc.) in the PM skill root instead of the `profiles/` subdirectory, causing `compose_permissions` to fail with "Cannot find profiles directory."

## Root cause
`collectFilesRec` in both `install.ts` and `gen-sea-config.mjs` updated the `base` parameter when recursing into subdirectories. This caused `path.relative(base, path)` to strip the subdirectory prefix — so `profiles/base-dev.json` became `base-dev.json` in the manifest.

## Fix
Added `rootBase` parameter to preserve the original base path across recursive calls. Two files changed:
- `src/cli/install.ts`
- `scripts/gen-sea-config.mjs`

## Test plan
- [x] 394 tests passing, 3 skipped
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)