### PR TITLE
fix(#31): cleanup fleet control files before merge, not after

### DIFF
--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -17,7 +17,7 @@ You are a Project Manager (PM) that orchestrates work across fleet members.
 - `/pm pair <member> <member>` — Pair doer↔reviewer. Update icons (doer=circle, reviewer=square, same color) via `update_member` — this is mandatory, not optional. See doer-reviewer.md.
 - `/pm deploy <member>` — Run `<project>/deploy.md` steps via `execute_command`, then verify
 - `/pm recover <project>` — After PM restart: inspect each member's state and present recovery options. See below.
-- `/pm cleanup <project>` — After merge: remove fleet control files from doer and reviewer. On each member run via `execute_command`: `git rm PLAN.md progress.json feedback.md 2>/dev/null; rm -f CLAUDE.md; git commit -m "cleanup: remove fleet control files" && git push`. Run on both doer and reviewer after merge.
+- `/pm cleanup <project>` — Before merge: remove fleet control files from doer and reviewer. On each member run via `execute_command`: `git rm PLAN.md progress.json feedback.md 2>/dev/null; rm -f CLAUDE.md; git commit -m "cleanup: remove fleet control files" && git push`. Run on both doer and reviewer before merge.
 
 ## Core Rules
 

--- a/skills/pm/doer-reviewer.md
+++ b/skills/pm/doer-reviewer.md
@@ -41,9 +41,9 @@ Verify reviewer is at the correct commit before starting review:
 
 4. Reviewer reads deliverables + diff, conducts cumulative review (all phases up to current, not just the latest) per its CLAUDE.md. Commits findings to feedback.md, pushes, and outputs verdict: APPROVED or CHANGES NEEDED
 5. PM reads verdict:
-   - **APPROVED** → merge → cleanup → next phase
+   - **APPROVED** → cleanup → merge → next phase
    - **CHANGES NEEDED** → PM sends feedback to doer → doer fixes → back to step 1 → PM re-dispatches REVIEWER
-6. **Post-merge cleanup** — `execute_command` on doer: `git rm PLAN.md progress.json feedback.md 2>/dev/null; rm -f CLAUDE.md; git commit -m "cleanup: remove fleet control files"`. These are transport files — git history preserves the content.
+6. **Pre-merge cleanup** — `execute_command` on doer: `git rm PLAN.md progress.json feedback.md 2>/dev/null; rm -f CLAUDE.md; git commit -m "cleanup: remove fleet control files" && git push`. These are transport files — git history preserves the content. Run cleanup and push before merging the PR.
 7. Loop until all phases APPROVED
 
 ## Safeguards


### PR DESCRIPTION
Moves cleanup step before PR merge so PLAN.md, progress.json, feedback.md never land on main.