### PR TITLE
feat: add server_version to all JSON tool outputs

### DIFF
--- a/src/tools/list-members.ts
+++ b/src/tools/list-members.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { getAllAgents } from '../services/registry.js';
 import { DEFAULT_ICON } from '../services/icons.js';
+import { serverVersion } from '../version.js';
 
 export const listMembersSchema = z.object({
   format: z.enum(['compact', 'json']).default('compact').describe('Output format: "compact" (default, few lines) or "json" (structured data for detailed rendering)'),
@@ -16,6 +17,7 @@ export async function listMembers(input?: ListMembersInput): Promise<string> {
 
   if (format === 'json') {
     return JSON.stringify({
+      server_version: serverVersion,
       total: agents.length,
       members: agents.map(a => ({
         id: a.id,

--- a/src/tools/member-detail.ts
+++ b/src/tools/member-detail.ts
@@ -9,6 +9,7 @@ import { DEFAULT_ICON } from '../services/icons.js';
 import { writeStatusline } from '../services/statusline.js';
 import { awsProvider } from '../services/cloud/aws.js';
 import { estimateCost, formatUptimeDuration, uptimeHoursFromLaunch } from '../services/cloud/cost.js';
+import { serverVersion } from '../version.js';
 
 export const memberDetailSchema = z.object({
   member_id: z.string().describe('UUID or friendly name of the member (worker) to inspect'),
@@ -28,6 +29,7 @@ export async function memberDetail(input: MemberDetailInput): Promise<string> {
   const strategy = getStrategy(agent);
 
   const result: Record<string, unknown> = {
+    server_version: serverVersion,
     name: agent.friendlyName,
     icon: agent.icon ?? DEFAULT_ICON,
     id: agent.id,


### PR DESCRIPTION
Instead of adding a dedicated `server_info` tool, inject `server_version` into every JSON-format tool response. This reduces tool count while making the running version visible whenever structured output is requested.

**Changes:**
- `list_members(format="json")` — adds `server_version` field
- `member_detail(format="json")` — adds `server_version` field (included even on early-exit offline path)
- `fleet_status(format="json")` — already had `version` field, unchanged

**Usage:** Call any tool with `format="json"` and `server_version` appears at the top of the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)