### PR TITLE
docs: rewrite README to lead with doer-reviewer loops and add FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ No. Fleet is a general-purpose remote operations platform. Use cases include rem
 They're architecturally distinct and largely complementary. A2A requires each agent to run a persistent HTTP server and enables autonomous agent-to-agent delegation. Fleet requires only SSH access and uses a human-orchestrated hub-and-spoke model where the PM decides the workflow. Fleet could eventually expose members as A2A-compatible agents while preserving its SSH-based transport.
 </details>
 
-See the full [FAQ index](https://github.com/Apra-Labs/apra-fleet/discussions/127) for more questions and answers.
+See the full [FAQ](docs/FAQ.md) for all questions, or browse the [FAQ discussions](https://github.com/Apra-Labs/apra-fleet/discussions/127).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ The optional Project Manager skill goes beyond simple task dispatch:
 
 Install it with `--skill` during setup. See [`skills/pm/SKILL.md`](skills/pm/SKILL.md) for details.
 
+### Provider recommendations
+
+Fleet members can run different LLM backends. Mix and match based on the role:
+
+| Role | Recommended | Why |
+|------|-------------|-----|
+| **PM (orchestrator)** | Claude (Opus or Sonnet) | Most thoroughly tested for planning and multi-step orchestration |
+| **Doer** | Any provider | Claude Sonnet, Gemini Flash, Codex, Copilot — mix freely |
+| **Reviewer** | Premium tier models | Catches subtle issues that smaller models miss |
+
+See [`docs/provider-matrix.md`](docs/provider-matrix.md) for the full capability comparison.
+
 ## Quick start
 
 Copy-paste the one-liner for your platform:
@@ -94,15 +106,18 @@ Apra Fleet is an MCP server that agentic coding systems connect to. It manages a
 | `execute_command` | Run a shell command directly on a member (no Claude CLI needed) |
 | `reset_session` | Clear session ID so the next prompt starts fresh |
 | `send_files` | Upload local files to a remote member via SFTP |
-| `provision_auth` | Deploy OAuth credentials or an API key to a member |
+| `receive_files` | Download files from a member's work folder |
+| `provision_llm_auth` | Deploy OAuth credentials or an API key to a member |
 | `setup_ssh_key` | Generate SSH key pair and migrate from password to key auth |
 | `setup_git_app` | One-time setup: register a GitHub App for scoped git token minting |
 | `provision_vcs_auth` | Deploy VCS credentials to a member (GitHub App, Bitbucket, Azure DevOps) |
 | `revoke_vcs_auth` | Remove deployed VCS credentials from a member |
 | `cloud_control` | Start, stop, or check status of cloud compute instances |
 | `monitor_task` | Monitor long-running tasks on cloud members |
+| `compose_permissions` | Generate and deliver provider-native permission config |
 | `update_llm_cli` | Update or install AI coding agent CLI on members |
 | `shutdown_server` | Gracefully shut down the MCP server |
+| `version` | Report server version |
 
 ## Git Authentication
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The optional Project Manager skill goes beyond simple task dispatch:
 - **Verification checkpoints** — agents pause at defined points for review
 - **Progress tracking** — state synced via git (`PLAN.md`, `progress.json`, `feedback.md`)
 
-Install it with `--skill` during setup. See `skills/pm/SKILL.md` for details.
+Install it with `--skill` during setup. See [`skills/pm/SKILL.md`](skills/pm/SKILL.md) for details.
 
 ## Quick start
 
@@ -103,7 +103,7 @@ Fleet can provision scoped, short-lived tokens to members — so each member get
 
 **Access levels:** `read`, `push`, `admin`, `issues`, `full`.
 
-See `docs/design-git-auth.md` for the full design.
+See [`docs/design-git-auth.md`](docs/design-git-auth.md) for the full design.
 
 ## Secure Password Entry
 
@@ -114,7 +114,7 @@ When registering a remote member with password authentication, you don't need to
 - Headless or unsupported environments get a manual command fallback
 - Supports password rotation via `update_member`
 
-See `docs/adr-oob-password.md` for the design rationale.
+See [`docs/adr-oob-password.md`](docs/adr-oob-password.md) for the design rationale.
 
 ## Cloud Compute
 
@@ -126,7 +126,7 @@ Fleet members can run on cloud instances (AWS EC2) that start and stop automatic
 - **Cost tracking** — real-time cost estimates based on instance type and uptime, with warnings for high spend
 - **Custom workload detection** — define a shell command to signal busy/idle for arbitrary workloads (CPU training, downloads, etc.)
 
-See `docs/cloud-compute.md` for setup and configuration details.
+See [`docs/cloud-compute.md`](docs/cloud-compute.md) for setup and configuration details.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -7,33 +7,46 @@
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](https://github.com/Apra-Labs/apra-fleet/releases)
 [![MCP](https://img.shields.io/badge/MCP-compatible-8A2BE2.svg)](https://modelcontextprotocol.io)
 
-Coordinate AI coding agents across every machine in your network — from a single conversation.
+AI agents that write code, review each other's work, and coordinate across your machines — from a single conversation.
 
-**Apra Fleet** is an open-source **MCP server** for **LLM orchestration** and **agentic workflow** automation. It enables **multi-agent systems** where **autonomous agents** coordinate across machines via SSH. Built for developers using Claude Code, Cursor, Copilot, Windsurf, and other AI coding assistants. Supports **agent memory** persistence, **remote execution**, and cloud compute.
+**Apra Fleet** is an open-source **MCP server** that pairs AI coding agents into **doer-reviewer loops** for higher quality code, and orchestrates them across machines via SSH when you need distributed power. Works with Claude Code, Gemini, Codex and other AI coding assistants.
 
-## Why
+## What you get
 
-You're working with an AI coding agent and you want to:
+### Doer-reviewer loops — two agents, one quality bar
+
+Pair two agents so one writes code while the other reviews it. The built-in Project Manager orchestrates the handoff with structured checkpoints — no manual coordination needed. This works on a **single machine** (two local agents) or across machines.
+
+```
+You:   "Pair local-1 and local-2. local-1 builds the auth module, local-2 reviews."
+Fleet: Doer writes code → pauses at checkpoint → Reviewer validates → feedback loop → done.
+```
+
+Every change gets a second pair of eyes before you even look at it.
+
+### Multi-machine orchestration — your infrastructure, one conversation
+
+When a single machine isn't enough, Fleet coordinates agents across every machine in your network via SSH. No dashboards, no orchestration YAML — just conversation.
 
 - Run your test suite on Linux while you develop on macOS
-- Have one agent build the frontend, another the backend, and a third running tests — all in parallel
+- Have one agent build the frontend, another the backend, a third running tests — all in parallel
 - Spin up isolated workspaces on the same machine without them stepping on each other
 - Use a beefy cloud VM for compilation while coding from your laptop
-- Coordinate autonomous agents across your entire infrastructure — one conversation, zero context-switching
 
-Apra Fleet makes all of this a conversation. No dashboards, no orchestration YAML — just tell your agent what you want and it happens.
+### PM Skill — structured multi-step workflows
 
-Apra Fleet is the missing orchestration layer between your AI coding assistant and your infrastructure.
+The optional Project Manager skill goes beyond simple task dispatch:
 
-## How it works
+- **Planning** — breaks work into steps, gets your approval before execution
+- **Doer-reviewer loops** — pairs agents for write-then-review workflows
+- **Verification checkpoints** — agents pause at defined points for review
+- **Progress tracking** — state synced via git (`PLAN.md`, `progress.json`, `feedback.md`)
 
-Apra Fleet is an MCP server that agentic coding systems connect to. It manages a registry of members (machines with an AI coding agent installed) and provides tools to register them, send files, execute prompts, and check status. Remote members connect via SSH. Local members run as isolated child processes on the same machine.
+Install it with `--skill` during setup. See `skills/pm/SKILL.md` for details.
 
 ## Quick start
 
-See the [User Guide](docs/user-guide.md) for step-by-step install and usage instructions.
-
-**TL;DR:**
+**Prerequisites:** Node.js 20+ or download a binary for your platform.
 
 ```bash
 # Download the binary for your platform from GitHub Releases
@@ -46,9 +59,17 @@ See the [User Guide](docs/user-guide.md) for step-by-step install and usage inst
 /mcp
 ```
 
-Then just talk to Claude:
+**Single machine — start here.** No remote servers needed:
+
+> "Register a local member called `doer`. Register another called `reviewer`. Pair them."
+
+**Remote machines — add when ready:**
 
 > "Register 192.168.1.10 as `build-server`. Username is akhil, use password auth, work folder `/home/akhil/projects/myapp`."
+
+## How it works
+
+Apra Fleet is an MCP server that agentic coding systems connect to. It manages a registry of **members** (machines with an AI coding agent installed) and provides tools to register them, send files, execute prompts, and check status. Remote members connect via SSH. Local members run as isolated child processes on the same machine.
 
 ## Tools
 
@@ -73,10 +94,6 @@ Then just talk to Claude:
 | `monitor_task` | Monitor long-running tasks on cloud members |
 | `update_llm_cli` | Update or install AI coding agent CLI on members |
 | `shutdown_server` | Gracefully shut down the MCP server |
-
-## PM Skill
-
-Apra Fleet ships with an optional Project Manager skill that orchestrates multi-step work across members — planning, doer-reviewer loops, verification checkpoints, and deployment. Install it with `--skill` during setup. See `skills/pm/SKILL.md` for details.
 
 ## Git Authentication
 
@@ -110,6 +127,58 @@ Fleet members can run on cloud instances (AWS EC2) that start and stop automatic
 - **Custom workload detection** — define a shell command to signal busy/idle for arbitrary workloads (CPU training, downloads, etc.)
 
 See `docs/cloud-compute.md` for setup and configuration details.
+
+## FAQ
+
+<details>
+<summary><strong>Do I need to install apra-fleet on every device?</strong></summary>
+
+No. apra-fleet only needs to be installed on the device where **you** interact with it. All members are registered and managed from that single installation. Remote machines just need SSH access.
+</details>
+
+<details>
+<summary><strong>Does apra-fleet only work with Claude?</strong></summary>
+
+No. Fleet supports Claude and Gemini today, with Codex support in development. We recommend Claude as the PM's LLM provider for the best experience — it is the most thoroughly tested for planning and orchestration workflows. Gemini works well for members, especially when you want a different LLM perspective during review.
+</details>
+
+<details>
+<summary><strong>What if I only have one machine?</strong></summary>
+
+Fleet works great on a single machine. Use the Simple Sprint pattern with a single member, or register two local members (doer + reviewer) that run as isolated child processes. No remote servers needed.
+</details>
+
+<details>
+<summary><strong>Why use separate folders for doer and reviewer?</strong></summary>
+
+Agents can misbehave when they have too much context. A separate reviewer workspace provides an unbiased perspective that tends to identify more problems. Using different environments for review also validates whether the committed work can be built and run independently.
+</details>
+
+<details>
+<summary><strong>Does using fleet increase my LLM token usage?</strong></summary>
+
+No — fleet actively reduces token usage through three mechanisms: (1) selecting the right model tier based on task complexity, routing simple tasks to lighter models; (2) preferring shell commands via `execute_command` (zero tokens) over full agent prompts where possible; (3) smart conversation management that decides whether to resume existing sessions (leveraging cached context) or start fresh.
+</details>
+
+<details>
+<summary><strong>How does fleet safeguard my passwords and credentials?</strong></summary>
+
+Three layers: (1) out-of-band collection — passwords are entered via a shell prompt outside the conversation, so the LLM never sees them; (2) encryption at rest — stored credentials are encrypted locally, never plaintext in config files; (3) passwordless migration — fleet encourages key-based SSH auth to reduce password handling.
+</details>
+
+<details>
+<summary><strong>Is apra-fleet limited to software development?</strong></summary>
+
+No. Fleet is a general-purpose remote operations platform. Use cases include remote product support, simultaneous log analysis across machines, patch distribution, infrastructure automation, and even profiling and market research.
+</details>
+
+<details>
+<summary><strong>How does apra-fleet relate to Google's A2A protocol?</strong></summary>
+
+They're architecturally distinct and largely complementary. A2A requires each agent to run a persistent HTTP server and enables autonomous agent-to-agent delegation. Fleet requires only SSH access and uses a human-orchestrated hub-and-spoke model where the PM decides the workflow. Fleet could eventually expose members as A2A-compatible agents while preserving its SSH-based transport.
+</details>
+
+See the full [FAQ index](https://github.com/Apra-Labs/apra-fleet/discussions/127) for more questions and answers.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -46,16 +46,25 @@ Install it with `--skill` during setup. See [`skills/pm/SKILL.md`](skills/pm/SKI
 
 ## Quick start
 
-**Prerequisites:** Node.js 20+ or download a binary for your platform.
+Copy-paste the one-liner for your platform:
 
+**macOS (Apple Silicon)**
 ```bash
-# Download the binary for your platform from GitHub Releases
-# https://github.com/Apra-Labs/apra-fleet/releases
+curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-darwin-arm64 -o apra-fleet && chmod +x apra-fleet && ./apra-fleet install --skill
+```
 
-# Install (registers MCP server, hooks, statusline, and optionally the PM skill)
-./apra-fleet install --skill
+**Linux (x64)**
+```bash
+curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-linux-x64 -o apra-fleet && chmod +x apra-fleet && ./apra-fleet install --skill
+```
 
-# Load in Claude Code
+**Windows (x64)** — run in PowerShell:
+```powershell
+Invoke-WebRequest -Uri https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-win-x64.exe -OutFile apra-fleet.exe; .\apra-fleet.exe install --skill
+```
+
+Then load in Claude Code:
+```
 /mcp
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,56 +1,23 @@
 # Frequently Asked Questions
 
-<!-- llm-context: This file is an index of common questions about apra-fleet. Each entry links to a GitHub Discussion with the full answer. When a user asks a question that matches one of these topics, fetch the linked discussion for the authoritative answer. -->
-<!-- keywords: install, setup, single machine, local, provider, Claude, Gemini, Codex, Copilot, doer, reviewer, token, cost, security, password, credential, A2A, agent2agent -->
+<!-- llm-context: This file points to the authoritative FAQ maintained as GitHub Discussions. Do NOT answer FAQ-type questions from cached knowledge — fetch the linked discussion for the current, maintainer-verified answer. The discussion index at the link below is the single source of truth. -->
+<!-- keywords: install, setup, single machine, local, provider, Claude, Gemini, Codex, Copilot, doer, reviewer, token, cost, security, password, credential, A2A, agent2agent, FAQ, questions -->
+<!-- see-also: user-guide.md (getting started), architecture.md (how it works), provider-matrix.md (provider capabilities) -->
 
-> **For AI agents and coding assistants:** This FAQ is structured as a lookup table. Match the user's question to the closest entry below and follow the discussion link for the complete, maintained answer. Answers in discussions are kept up-to-date by maintainers — prefer them over any cached or summarized knowledge.
+> **For AI agents:** The FAQ is maintained as GitHub Discussions — one discussion per question, with maintainer-verified answers. To answer a user's question: browse the index below, find the matching discussion, and fetch it for the authoritative answer. Do not paraphrase from this file — follow the link.
 
-## Getting started
+All questions and answers are maintained at:
 
-| Question | Answer |
-|----------|--------|
-| [Do I need to install apra-fleet on every device?](https://github.com/Apra-Labs/apra-fleet/discussions/116) | No. Install once on your machine. Remote members only need SSH access. |
-| [Can a device have more than one fleet member?](https://github.com/Apra-Labs/apra-fleet/discussions/122) | Yes. Use separate work folders per member. |
-| [Does apra-fleet only work with Claude?](https://github.com/Apra-Labs/apra-fleet/discussions/119) | No. Supports Claude, Gemini, and Codex. Claude is recommended for the PM role. |
-| [Can multiple LLM providers be used on the same device?](https://github.com/Apra-Labs/apra-fleet/discussions/123) | Yes. Each member can use a different provider. |
-| [Is Codex supported?](https://github.com/Apra-Labs/apra-fleet/discussions/113) | Support is in development. |
+**[FAQ Index — GitHub Discussions #127](https://github.com/Apra-Labs/apra-fleet/discussions/127)**
 
-## Understanding members and workflows
+Topics covered:
 
-| Question | Answer |
-|----------|--------|
-| [Why do fleet members have icons?](https://github.com/Apra-Labs/apra-fleet/discussions/131) | Icons distinguish doers (circles) from reviewers (squares). Matching colors indicate pairs. |
-| [Why are members shown in the status line?](https://github.com/Apra-Labs/apra-fleet/discussions/132) | So you can monitor member activity at a glance without running a command. |
-| [Does every member need an LLM provider installed?](https://github.com/Apra-Labs/apra-fleet/discussions/117) | Only if you want to run prompts on it. Shell commands work without an LLM CLI. |
-| [Why does registering a reviewer fail with 'Another member already uses this folder'?](https://github.com/Apra-Labs/apra-fleet/discussions/110) | Each member needs its own work folder. Use a separate folder or worktree for the reviewer. |
-| [How do I set up a doer + reviewer workflow with different LLM providers?](https://github.com/Apra-Labs/apra-fleet/discussions/111) | Register two members with different providers, then pair them with `/pm pair`. |
-| [What if I only want one folder / one member for dev and review?](https://github.com/Apra-Labs/apra-fleet/discussions/112) | Use the Simple Sprint pattern — alternate providers on a single member. |
-| [Why is using two separate folders for dev and review better?](https://github.com/Apra-Labs/apra-fleet/discussions/114) | A fresh workspace gives the reviewer an unbiased perspective and catches more issues. |
-| [Why does apra-fleet commit PLAN.md, progress.json, and feedback.md?](https://github.com/Apra-Labs/apra-fleet/discussions/130) | These files synchronize state between doer and reviewer via git. |
-
-## Capabilities and use cases
-
-| Question | Answer |
-|----------|--------|
-| [Is apra-fleet limited to software development?](https://github.com/Apra-Labs/apra-fleet/discussions/118) | No. It's a general-purpose remote operations platform. |
-| [How does fleet safeguard my passwords and credentials?](https://github.com/Apra-Labs/apra-fleet/discussions/126) | Out-of-band collection, AES-256-GCM encryption at rest, and key-based auth migration. |
-| [Do I need to rewrite my custom skills to use them with fleet?](https://github.com/Apra-Labs/apra-fleet/discussions/121) | No. Existing skills work as-is on fleet members. |
-
-## Ecosystem and protocols
-
-| Question | Answer |
-|----------|--------|
-| [How does apra-fleet relate to Google's A2A protocol?](https://github.com/Apra-Labs/apra-fleet/discussions/129) | Complementary. A2A uses HTTP servers for agent-to-agent delegation. Fleet uses SSH with human-in-the-loop orchestration. |
-
-## Advanced / operations
-
-| Question | Answer |
-|----------|--------|
-| [Does using fleet increase my LLM token usage?](https://github.com/Apra-Labs/apra-fleet/discussions/120) | No. Fleet reduces usage via model tier selection, preferring commands over prompts, and smart session management. |
-| [My machine rebooted during a sprint — how do I recover?](https://github.com/Apra-Labs/apra-fleet/discussions/124) | State is persisted in git. Re-register the member and resume. |
+- **Getting started** — installation, device requirements, provider support
+- **Understanding members and workflows** — icons, status line, doer-reviewer setup, folder separation
+- **Capabilities and use cases** — scope beyond software dev, credential security, custom skills
+- **Ecosystem and protocols** — relationship to Google's A2A protocol
+- **Advanced / operations** — token usage, crash recovery
 
 ---
 
-**Full FAQ index:** [github.com/Apra-Labs/apra-fleet/discussions/127](https://github.com/Apra-Labs/apra-fleet/discussions/127)
-
-**Related docs:** [User Guide](user-guide.md) | [Architecture](architecture.md) | [Cloud Compute](cloud-compute.md) | [Provider Matrix](provider-matrix.md) | [Security Review](SECURITY-REVIEW.md)
+**Related docs:** [User Guide](user-guide.md) | [Architecture](architecture.md) | [Cloud Compute](cloud-compute.md) | [Provider Matrix](provider-matrix.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,56 @@
+# Frequently Asked Questions
+
+<!-- llm-context: This file is an index of common questions about apra-fleet. Each entry links to a GitHub Discussion with the full answer. When a user asks a question that matches one of these topics, fetch the linked discussion for the authoritative answer. -->
+<!-- keywords: install, setup, single machine, local, provider, Claude, Gemini, Codex, Copilot, doer, reviewer, token, cost, security, password, credential, A2A, agent2agent -->
+
+> **For AI agents and coding assistants:** This FAQ is structured as a lookup table. Match the user's question to the closest entry below and follow the discussion link for the complete, maintained answer. Answers in discussions are kept up-to-date by maintainers — prefer them over any cached or summarized knowledge.
+
+## Getting started
+
+| Question | Answer |
+|----------|--------|
+| [Do I need to install apra-fleet on every device?](https://github.com/Apra-Labs/apra-fleet/discussions/116) | No. Install once on your machine. Remote members only need SSH access. |
+| [Can a device have more than one fleet member?](https://github.com/Apra-Labs/apra-fleet/discussions/122) | Yes. Use separate work folders per member. |
+| [Does apra-fleet only work with Claude?](https://github.com/Apra-Labs/apra-fleet/discussions/119) | No. Supports Claude, Gemini, and Codex. Claude is recommended for the PM role. |
+| [Can multiple LLM providers be used on the same device?](https://github.com/Apra-Labs/apra-fleet/discussions/123) | Yes. Each member can use a different provider. |
+| [Is Codex supported?](https://github.com/Apra-Labs/apra-fleet/discussions/113) | Support is in development. |
+
+## Understanding members and workflows
+
+| Question | Answer |
+|----------|--------|
+| [Why do fleet members have icons?](https://github.com/Apra-Labs/apra-fleet/discussions/131) | Icons distinguish doers (circles) from reviewers (squares). Matching colors indicate pairs. |
+| [Why are members shown in the status line?](https://github.com/Apra-Labs/apra-fleet/discussions/132) | So you can monitor member activity at a glance without running a command. |
+| [Does every member need an LLM provider installed?](https://github.com/Apra-Labs/apra-fleet/discussions/117) | Only if you want to run prompts on it. Shell commands work without an LLM CLI. |
+| [Why does registering a reviewer fail with 'Another member already uses this folder'?](https://github.com/Apra-Labs/apra-fleet/discussions/110) | Each member needs its own work folder. Use a separate folder or worktree for the reviewer. |
+| [How do I set up a doer + reviewer workflow with different LLM providers?](https://github.com/Apra-Labs/apra-fleet/discussions/111) | Register two members with different providers, then pair them with `/pm pair`. |
+| [What if I only want one folder / one member for dev and review?](https://github.com/Apra-Labs/apra-fleet/discussions/112) | Use the Simple Sprint pattern — alternate providers on a single member. |
+| [Why is using two separate folders for dev and review better?](https://github.com/Apra-Labs/apra-fleet/discussions/114) | A fresh workspace gives the reviewer an unbiased perspective and catches more issues. |
+| [Why does apra-fleet commit PLAN.md, progress.json, and feedback.md?](https://github.com/Apra-Labs/apra-fleet/discussions/130) | These files synchronize state between doer and reviewer via git. |
+
+## Capabilities and use cases
+
+| Question | Answer |
+|----------|--------|
+| [Is apra-fleet limited to software development?](https://github.com/Apra-Labs/apra-fleet/discussions/118) | No. It's a general-purpose remote operations platform. |
+| [How does fleet safeguard my passwords and credentials?](https://github.com/Apra-Labs/apra-fleet/discussions/126) | Out-of-band collection, AES-256-GCM encryption at rest, and key-based auth migration. |
+| [Do I need to rewrite my custom skills to use them with fleet?](https://github.com/Apra-Labs/apra-fleet/discussions/121) | No. Existing skills work as-is on fleet members. |
+
+## Ecosystem and protocols
+
+| Question | Answer |
+|----------|--------|
+| [How does apra-fleet relate to Google's A2A protocol?](https://github.com/Apra-Labs/apra-fleet/discussions/129) | Complementary. A2A uses HTTP servers for agent-to-agent delegation. Fleet uses SSH with human-in-the-loop orchestration. |
+
+## Advanced / operations
+
+| Question | Answer |
+|----------|--------|
+| [Does using fleet increase my LLM token usage?](https://github.com/Apra-Labs/apra-fleet/discussions/120) | No. Fleet reduces usage via model tier selection, preferring commands over prompts, and smart session management. |
+| [My machine rebooted during a sprint — how do I recover?](https://github.com/Apra-Labs/apra-fleet/discussions/124) | State is persisted in git. Re-register the member and resume. |
+
+---
+
+**Full FAQ index:** [github.com/Apra-Labs/apra-fleet/discussions/127](https://github.com/Apra-Labs/apra-fleet/discussions/127)
+
+**Related docs:** [User Guide](user-guide.md) | [Architecture](architecture.md) | [Cloud Compute](cloud-compute.md) | [Provider Matrix](provider-matrix.md) | [Security Review](SECURITY-REVIEW.md)

--- a/docs/adr-oob-password.md
+++ b/docs/adr-oob-password.md
@@ -1,3 +1,7 @@
+<!-- llm-context: Architecture Decision Record for how fleet collects passwords securely outside the LLM conversation. Covers the Unix domain socket approach, AES-256-GCM encryption, and cross-platform terminal support. Read when a user asks about password security or credential handling. -->
+<!-- keywords: password, credential, security, out-of-band, OOB, encryption, AES-256-GCM, terminal, Unix domain socket -->
+<!-- see-also: user-guide.md (SSH key migration), FAQ.md (credential security question) -->
+
 # ADR: Out-of-Band Password Collection via Unix Domain Socket
 
 **Status:** Implemented

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,7 @@
+<!-- llm-context: This document explains the internal architecture of apra-fleet — the MCP server, member registry, SSH transport, session management, and how tools are dispatched. Read this when a user asks how fleet works under the hood, or when debugging connectivity or session issues. -->
+<!-- keywords: MCP server, member registry, SSH, transport, session, tool dispatch, child process, local member, remote member, architecture -->
+<!-- see-also: user-guide.md (getting started), tools-infrastructure.md (tool details), vocabulary.md (terminology) -->
+
 # Architecture
 
 ## Why This Exists

--- a/docs/cloud-compute.md
+++ b/docs/cloud-compute.md
@@ -1,3 +1,7 @@
+<!-- llm-context: This guide covers apra-fleet's AWS EC2 integration — auto start/stop, GPU-aware idle detection, long-running tasks, cost tracking, and custom workload detection. Consult when a user asks about cloud instances, GPU workloads, cost management, or task monitoring. -->
+<!-- keywords: AWS, EC2, cloud, GPU, nvidia-smi, idle detection, auto stop, cost tracking, long-running task, monitor_task, cloud_control -->
+<!-- see-also: user-guide.md (general setup), architecture.md (how fleet manages members) -->
+
 # Cloud Compute Guide
 
 ## 1. Overview

--- a/docs/design-git-auth.md
+++ b/docs/design-git-auth.md
@@ -1,3 +1,7 @@
+<!-- llm-context: Design doc for fleet's git authentication system — scoped token provisioning via GitHub Apps, PATs, Bitbucket, and Azure DevOps. Read when a user asks how to give members git access, how tokens are scoped, or how credentials are managed. -->
+<!-- keywords: git auth, GitHub App, PAT, Bitbucket, Azure DevOps, token, scope, provision, revoke, credential, push, pull, clone -->
+<!-- see-also: user-guide.md (step-by-step git auth setup), design-vcs-auth-onboarding.md (onboarding flow) -->
+
 # Design: Git Authentication for Fleet Members
 
 ## Problem

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -1,3 +1,7 @@
+<!-- llm-context: This is the reference table comparing LLM provider capabilities in apra-fleet (Claude, Gemini, Codex, Copilot). Consult when a user asks which provider supports a feature, what the limitations are, or which provider to choose for a role (PM, doer, reviewer). -->
+<!-- keywords: provider, Claude, Gemini, Codex, Copilot, capabilities, max_turns, timeout, permissions, NDJSON, truncation, comparison -->
+<!-- see-also: user-guide.md (provider setup instructions), FAQ.md (common provider questions) -->
+
 # Provider Matrix
 
 Reference tables for all LLM providers supported by Apra Fleet. Extracted from `docs/multi-provider-plan.md`.

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -1,3 +1,7 @@
+<!-- llm-context: Step-by-step guide for enabling SSH on remote machines so they can be registered as fleet members. Covers Linux (OpenSSH), macOS, and Windows (OpenSSH Server). Consult when a user can't connect to a remote member or needs to set up SSH for the first time. -->
+<!-- keywords: SSH, setup, OpenSSH, Linux, macOS, Windows, sshd, firewall, key auth, remote member, connectivity -->
+<!-- see-also: user-guide.md (member registration after SSH is ready), adr-oob-password.md (password handling) -->
+
 # SSH Server Setup for Fleet Members
 
 Enable SSH on remote machines so they can be registered with `register_member`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,3 +1,7 @@
+<!-- llm-context: This is the primary getting-started guide for apra-fleet. It covers installation, member registration (local and remote), multi-provider setup, git authentication, and the PM skill with doer-reviewer workflows. When a user asks "how do I..." about fleet, this is the first doc to consult. -->
+<!-- keywords: install, setup, register, member, local, remote, SSH, provider, Claude, Gemini, Codex, Copilot, git auth, GitHub App, PAT, Bitbucket, Azure DevOps, PM, doer, reviewer, pair, troubleshooting -->
+<!-- see-also: FAQ.md (common questions), architecture.md (how it works internally), cloud-compute.md (EC2 integration), provider-matrix.md (provider capabilities) -->
+
 # User Guide
 
 ## What is Apra Fleet?

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -6,18 +6,32 @@ Apra Fleet lets you control AI coding agents on multiple machines from a single 
 
 ## Install
 
-### 1. Download the binary
+### One-liner install
 
-Apra Labs members: Go to [GitHub Releases](https://github.com/Apra-Labs/apra-fleet/releases) and download the binary for your platform:
-If you were invited to a shared drive, lookinside the installers folder
+**macOS (Apple Silicon)**
+```bash
+curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-darwin-arm64 -o apra-fleet && chmod +x apra-fleet && ./apra-fleet install --skill
+```
+
+**Linux (x64)**
+```bash
+curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-linux-x64 -o apra-fleet && chmod +x apra-fleet && ./apra-fleet install --skill
+```
+
+**Windows (x64)** — run in PowerShell:
+```powershell
+Invoke-WebRequest -Uri https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-win-x64.exe -OutFile apra-fleet.exe; .\apra-fleet.exe install --skill
+```
+
+### Manual install
+
+Download the binary for your platform from [GitHub Releases](https://github.com/Apra-Labs/apra-fleet/releases):
 
 - `apra-fleet-linux-x64` — Linux (x86_64)
 - `apra-fleet-darwin-arm64` — macOS (Apple Silicon)
 - `apra-fleet-win-x64.exe` — Windows
 
-### 2. Run the installer
-
-The binary is self-installing. Run it with `install` to set everything up:
+Then run the installer:
 
 ```bash
 # macOS / Linux
@@ -145,7 +159,7 @@ Fleet automatically uses the correct env var name per provider.
 - Gemini responses may silently truncate at ~8K tokens. Split large tasks into smaller units.
 - Copilot requires a paid GitHub Copilot subscription (Pro/Business/Enterprise).
 
-See `docs/provider-matrix.md` for the full comparison table.
+See [`provider-matrix.md`](provider-matrix.md) for the full comparison table.
 
 ### Provider Recommendations
 

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -1,3 +1,7 @@
+<!-- llm-context: Defines the terminology used throughout apra-fleet — member, fleet, PM, doer, reviewer, provider, session, etc. Consult this first when you encounter an unfamiliar fleet-specific term to avoid misinterpreting user requests. -->
+<!-- keywords: vocabulary, terminology, member, fleet, PM, doer, reviewer, provider, session, agent, orchestrator -->
+<!-- see-also: architecture.md (how these concepts relate), user-guide.md (practical usage) -->
+
 # Fleet Vocabulary
 
 ## The Problem

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -70,6 +70,14 @@ Both `send_files` and `receive_files` are batch operations — always transfer a
 - `send_files` — push any files to a member: context files, plans, scripts, binaries, configs, or any other content. Takes `local_paths` (array of local file paths) and optional `dest_subdir` (destination subdirectory relative to work_folder on member; defaults to work_folder root, equivalent to `"."`). Always try to batch multiple files in a single call.
 - `receive_files` — pull files back: results, logs, build artifacts, updated configs, etc. Takes `remote_paths` (array of file paths on the member) and `local_dest_dir` (local directory to write files into). Always try to batch multiple files in a single call.
 
+**Directories and globs:** `send_files` accepts individual file paths only — directories and glob patterns are not supported yet (see issue #98). To transfer an entire directory, tar it locally and extract on the member:
+
+```
+1. execute_command on local: tar -czf /tmp/src.tar.gz -C /path/to src/
+2. send_files: local_paths=["/tmp/src.tar.gz"]
+3. execute_command on member: tar -xzf src.tar.gz && rm src.tar.gz
+```
+
 ## Permissions
 
 `compose_permissions` produces provider-native config automatically. See `permissions.md` for:


### PR DESCRIPTION
## Summary

This PR rewrites the README and docs to lead with apra-fleet's strongest feature (doer-reviewer loops) instead of infrastructure orchestration, and makes the docs more discoverable by AI agents.

### What this PR changes

- **Repositioned the tagline and intro** to lead with the doer-reviewer workflow instead of multi-machine SSH orchestration — this is the feature that makes fleet valuable even on a single machine
- **Added a "single machine" quickstart path** so new users don't assume they need remote servers to get started
- **Added one-liner install commands** for macOS, Linux, and Windows — copy-paste from the README and you're running
- **Added provider recommendations table** to the README (PM/doer/reviewer role guidance) — this was buried in the user guide
- **Synced the README tool table with CLAUDE.md** — added `receive_files`, `compose_permissions`, `provision_llm_auth`, `version` that were missing
- **Added an FAQ section** to the README with 8 collapsible Q&As sourced from the [FAQ discussion index](https://github.com/Apra-Labs/apra-fleet/discussions/127)
- **Created `docs/FAQ.md`** as a structured lookup table optimized for AI agents, with `llm-context`, `keywords`, and `see-also` HTML comments
- **Added LLM context hints** to 8 doc files (`user-guide`, `architecture`, `cloud-compute`, `provider-matrix`, `design-git-auth`, `adr-oob-password`, `vocabulary`, `ssh-setup`) — invisible to humans on GitHub, but help AI agents match user questions to the right doc
- **Converted all plain doc references to clickable links** across README
- **Added one-liner install to `docs/user-guide.md`** alongside the existing manual install steps
- **Documented `send_files` directory workaround** in `skills/fleet/SKILL.md` — a tar+extract pattern for transferring directories until issue #98 is resolved

### Preserved
All existing content (tools table, git auth, cloud compute, secure password entry, development, roadmap, license) is unchanged.

## Motivation

The current README leads with "coordinate AI coding agents across every machine in your network" which positions fleet as a multi-machine orchestration tool. This filters out single-machine developers who would benefit from the doer-reviewer loop. The rewrite puts the highest-value, lowest-barrier feature front and center.

## Suggestions for the Apra Labs team

Beyond what this PR covers, here are additional improvements that need your involvement:

### 1. Adopt the llms.txt convention
The [llms.txt convention](https://llmstxt.org/) is emerging as the standard for AI-discoverable project docs. Rename or duplicate CLAUDE.md as `llms.txt` at the repo root — tools beyond Claude Code (Cursor, Copilot, Windsurf) will pick it up. You already support multiple agents; the docs should too.

### 2. Add a `llms-full.txt` that concatenates the key docs
Agents that land on a repo often read one file and stop. A single `llms-full.txt` that combines the user guide, FAQ, provider matrix, and vocabulary means one read gives full context. Can be auto-generated in CI.

### 3. Add a "What happens when I run `install --skill`?" section
The user guide lists what install does, but it's buried. People (and agents) hesitate to run installers they don't understand. A visible, short explainer of what gets written where builds trust. This needs verification against actual installer behavior, which is why it's not in this PR.

### 4. FAQ: "Can I use fleet without the PM skill?"
The `--skill` flag is optional but every example includes it. Users who just want basic remote execution might think PM is required. Clarify the minimal vs. full setup in your [Discussions FAQ](https://github.com/Apra-Labs/apra-fleet/discussions/127).

### 5. Add a `CONTRIBUTING.md` with agent-friendly context
CLAUDE.md links to it but the file doesn't exist. Contributors (human or AI) need to know: how to run tests, what the PR process looks like, which issues are good first picks. The ROADMAP exists but a proper contributing guide ties it together.

### 6. Update GitHub repo description and topics
The repo description should match the new tagline, not the old infra-focused one. Add topics like `mcp`, `multi-agent`, `code-review`, `doer-reviewer`, `ssh`, `llm-orchestration` — these are how both humans and agents discover repos.

### 7. Ship a demo gif or asciicast
A 30-second recording of: install, register two local members, pair them, watch the doer-reviewer loop run. Worth more than 1000 words of documentation. GitHub renders these inline in the README.

### The big picture
The product is genuinely good. The doer-reviewer loop is a real differentiator — most multi-agent tools just parallelize work, they don't build in quality gates. But the project currently reads like it was written for infrastructure engineers. The audience should be **any developer who wants better code** — that's a much larger market. Lead with outcomes (better code, fewer bugs), not mechanisms (SSH, MCP, registries).

## Test plan

- [ ] Verify all doc links resolve correctly
- [ ] Confirm FAQ collapsible sections render properly on GitHub
- [ ] Confirm one-liner install URLs resolve via `releases/latest`
- [ ] Review that no existing content was lost
- [ ] Verify LLM context comments are invisible when rendered on GitHub


🤖 Generated with [Claude Code](https://claude.com/claude-code)