### PR TITLE
ci: bump version.json via PR after release instead of direct push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,16 +316,23 @@ jobs:
             release-binaries/apra-fleet-win-x64.exe
           generate_release_notes: true
 
-      - name: Bump version.json
+      - name: Bump version.json via PR
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
           NEXT=$(node -e "const [ma,mi,pa]='${TAG}'.split('.');console.log([ma,mi,parseInt(pa)+1].join('.'))")
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin main
-          git checkout main
+          git checkout -b "chore/bump-version-${NEXT}" origin/main
           node -e "const fs=require('fs');const v=JSON.parse(fs.readFileSync('version.json','utf-8'));v.version='${NEXT}';fs.writeFileSync('version.json',JSON.stringify(v,null,2)+'\n')"
           git add version.json
-          git commit -m "chore: bump version to ${NEXT} [skip ci]"
-          git push origin main
+          git commit -m "chore: bump version to ${NEXT}"
+          git push origin "chore/bump-version-${NEXT}"
+          gh pr create \
+            --title "chore: bump version to ${NEXT}" \
+            --body "Automated post-release version bump v${TAG} → v${NEXT}." \
+            --base main \
+            --head "chore/bump-version-${NEXT}"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -545,7 +545,7 @@ Apache 2.0 — see [LICENSE](LICENSE) for the full text.
   <doc title="Vocabulary" desc="Shared terminology — member, task, skill, PM, fleet, doer/reviewer pattern.">
 <!-- llm-context: Defines the terminology used throughout apra-fleet — member, fleet, PM, doer, reviewer, provider, session, etc. Consult this first when you encounter an unfamiliar fleet-specific term to avoid misinterpreting user requests. -->
 <!-- keywords: vocabulary, terminology, member, fleet, PM, doer, reviewer, provider, session, agent, orchestrator -->
-<!-- see-also: architecture.md (how these concepts relate), ../readme.md (practical usage) -->
+<!-- see-also: architecture.md (how these concepts relate), ../README.md (practical usage) -->
 
 # Fleet Vocabulary
 
@@ -607,7 +607,7 @@ Members with different **providers** are interchangeable from the PM's perspecti
   <doc title="Provider Matrix" desc="Which LLM providers are supported, their capabilities, and how to configure them.">
 <!-- llm-context: This is the reference table comparing LLM provider capabilities in apra-fleet (Claude, Gemini, Codex, Copilot). Consult when a user asks which provider supports a feature, what the limitations are, or which provider to choose for a role (PM, doer, reviewer). -->
 <!-- keywords: provider, Claude, Gemini, Codex, Copilot, capabilities, max_turns, timeout, permissions, NDJSON, truncation, comparison -->
-<!-- see-also: ../readme.md (provider setup instructions), FAQ.md (common provider questions) -->
+<!-- see-also: ../README.md (provider setup instructions), FAQ.md (common provider questions) -->
 
 # Provider Matrix
 
@@ -723,7 +723,7 @@ When the PM sends task harness files via `send_files`, it renames `tpl-agent.md`
 
 <!-- llm-context: This file points to the authoritative FAQ maintained as GitHub Discussions. Do NOT answer FAQ-type questions from cached knowledge — fetch the linked discussion for the current, maintainer-verified answer. The discussion index at the link below is the single source of truth. -->
 <!-- keywords: install, setup, single machine, local, provider, Claude, Gemini, Codex, Copilot, doer, reviewer, token, cost, security, password, credential, A2A, agent2agent, FAQ, questions -->
-<!-- see-also: ../readme.md (getting started), architecture.md (how it works), provider-matrix.md (provider capabilities) -->
+<!-- see-also: ../README.md (getting started), architecture.md (how it works), provider-matrix.md (provider capabilities) -->
 
 > **For AI agents:** The FAQ is maintained as GitHub Discussions — one discussion per question, with maintainer-verified answers. To answer a user's question: browse the index below, find the matching discussion, and fetch it for the authoritative answer. Do not paraphrase from this file — follow the link.
 
@@ -741,13 +741,13 @@ Topics covered:
 
 ---
 
-**Related docs:** [Readme](../readme.md) | [Architecture](architecture.md) | [Cloud Compute](cloud-compute.md) | [Provider Matrix](provider-matrix.md)
+**Related docs:** [Readme](../README.md) | [Architecture](architecture.md) | [Cloud Compute](cloud-compute.md) | [Provider Matrix](provider-matrix.md)
   </doc>
 
   <doc title="Architecture" desc="How the fleet hub, MCP server, and members interact at a system level.">
 <!-- llm-context: This document explains the internal architecture of apra-fleet — the MCP server, member registry, SSH transport, session management, and how tools are dispatched. Read this when a user asks how fleet works under the hood, or when debugging connectivity or session issues. -->
 <!-- keywords: MCP server, member registry, SSH, transport, session, tool dispatch, child process, local member, remote member, architecture -->
-<!-- see-also: ../readme.md (getting started), tools-infrastructure.md (tool details), vocabulary.md (terminology) -->
+<!-- see-also: ../README.md (getting started), tools-infrastructure.md (tool details), vocabulary.md (terminology) -->
 
 # Architecture
 


### PR DESCRIPTION
## Summary

- Replaces the post-release direct push to `main` with an auto-created PR
- After a tag release, CI opens a `chore/bump-version-X.Y.Z` branch and raises a PR targeting `main`
- Fixes the branch protection failure in the v0.1.6 release job

## Why

Direct push to `main` from the release job was blocked by branch protection rules. This brings the version bump in line with the same pattern used for `llms-full.txt` — changes land via PR, not direct push.

## Test plan

- [ ] Merge and tag a release — verify a `chore/bump-version-*` PR is auto-created
- [ ] No direct push to `main` from CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)