### PR TITLE
fix(install): rename installer artifact to avoid collision with installed binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            binary: apra-fleet-linux-x64
+            binary: apra-fleet-installer-linux-x64
           - os: macos-latest
-            binary: apra-fleet-darwin-arm64
+            binary: apra-fleet-installer-darwin-arm64
           - os: windows-latest
-            binary: apra-fleet-win-x64.exe
+            binary: apra-fleet-installer-win-x64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -191,7 +191,7 @@ jobs:
       - name: Download Windows binary
         uses: actions/download-artifact@v4
         with:
-          name: apra-fleet-win-x64.exe
+          name: apra-fleet-installer-win-x64.exe
           path: to-sign
 
       - name: Azure Login (OIDC)
@@ -216,8 +216,8 @@ jobs:
       - name: Upload signed binary
         uses: actions/upload-artifact@v4
         with:
-          name: apra-fleet-win-x64.exe
-          path: to-sign/apra-fleet-win-x64.exe
+          name: apra-fleet-installer-win-x64.exe
+          path: to-sign/apra-fleet-installer-win-x64.exe
           retention-days: 30
           overwrite: true
 
@@ -311,9 +311,9 @@ jobs:
         with:
           files: |
             ${{ env.TARBALL_NAME }}
-            release-binaries/apra-fleet-linux-x64
-            release-binaries/apra-fleet-darwin-arm64
-            release-binaries/apra-fleet-win-x64.exe
+            release-binaries/apra-fleet-installer-linux-x64
+            release-binaries/apra-fleet-installer-darwin-arm64
+            release-binaries/apra-fleet-installer-win-x64.exe
           generate_release_notes: true
 
       - name: Bump version.json via PR

--- a/README.md
+++ b/README.md
@@ -62,17 +62,17 @@ Copy-paste the one-liner for your platform:
 
 **macOS (Apple Silicon)**
 ```bash
-curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-darwin-arm64 -o apra-fleet && chmod +x apra-fleet && ./apra-fleet install
+curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-installer-darwin-arm64 -o apra-fleet-installer && chmod +x apra-fleet-installer && ./apra-fleet-installer install
 ```
 
 **Linux (x64)**
 ```bash
-curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-linux-x64 -o apra-fleet && chmod +x apra-fleet && ./apra-fleet install
+curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-installer-linux-x64 -o apra-fleet-installer && chmod +x apra-fleet-installer && ./apra-fleet-installer install
 ```
 
 **Windows (x64)** — run in PowerShell:
 ```powershell
-Invoke-WebRequest -Uri https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-win-x64.exe -OutFile apra-fleet.exe; .\apra-fleet.exe install
+Invoke-WebRequest -Uri https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-installer-win-x64.exe -OutFile apra-fleet-installer.exe; .\apra-fleet-installer.exe install
 ```
 
 Then load in Claude Code:
@@ -93,19 +93,23 @@ Then load in Claude Code:
 
 Download the binary for your platform from [GitHub Releases](https://github.com/Apra-Labs/apra-fleet/releases):
 
-- `apra-fleet-linux-x64` — Linux (x86_64)
-- `apra-fleet-darwin-arm64` — macOS (Apple Silicon)
-- `apra-fleet-win-x64.exe` — Windows
+- `apra-fleet-installer-linux-x64` — Linux (x86_64)
+- `apra-fleet-installer-darwin-arm64` — macOS (Apple Silicon)
+- `apra-fleet-installer-win-x64.exe` — Windows
 
 Then run the installer:
 
 ```bash
-# macOS / Linux
-chmod +x apra-fleet-darwin-arm64
-./apra-fleet-darwin-arm64 install
+# macOS (Apple Silicon)
+chmod +x apra-fleet-installer-darwin-arm64 && ./apra-fleet-installer-darwin-arm64 install
 
+# Linux (x64)
+chmod +x apra-fleet-installer-linux-x64 && ./apra-fleet-installer-linux-x64 install
+```
+
+```powershell
 # Windows
-apra-fleet-win-x64.exe install
+.\apra-fleet-installer-win-x64.exe install
 ```
 
 </details>

--- a/deploy.md
+++ b/deploy.md
@@ -21,15 +21,15 @@ mkdir -p /tmp/fleet-deploy
 cd /tmp/fleet-deploy
 
 # From CI artifact (branch build)
-gh run download <run-id> --repo Apra-Labs/apra-fleet -n apra-fleet-win-x64.exe
+gh run download <run-id> --repo Apra-Labs/apra-fleet -n apra-fleet-installer-win-x64.exe
 
 # Or from release
-gh release download <tag> --repo Apra-Labs/apra-fleet -p "apra-fleet-win-x64.exe" -D /tmp/fleet-deploy
+gh release download <tag> --repo Apra-Labs/apra-fleet -p "apra-fleet-installer-win-x64.exe" -D /tmp/fleet-deploy
 ```
 
 ### 3. Install
 ```bash
-/tmp/fleet-deploy/apra-fleet-win-x64.exe install --skill
+/tmp/fleet-deploy/apra-fleet-installer-win-x64.exe install --skill
 ```
 This handles shutdown, binary replacement, skill installation, and restart in one step.
 
@@ -48,6 +48,6 @@ cp ~/.apra-fleet/bin/apra-fleet.exe.bak ~/.apra-fleet/bin/apra-fleet.exe
 ## Platform binaries
 | Platform | Artifact name |
 |----------|--------------|
-| Windows x64 | `apra-fleet-win-x64.exe` |
-| Linux x64 | `apra-fleet-linux-x64` |
-| macOS ARM | `apra-fleet-darwin-arm64` |
+| Windows x64 | `apra-fleet-installer-win-x64.exe` |
+| Linux x64 | `apra-fleet-installer-linux-x64` |
+| macOS ARM | `apra-fleet-installer-darwin-arm64` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -65,17 +65,17 @@ Copy-paste the one-liner for your platform:
 
 **macOS (Apple Silicon)**
 ```bash
-curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-darwin-arm64 -o apra-fleet && chmod +x apra-fleet && ./apra-fleet install
+curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-installer-darwin-arm64 -o apra-fleet-installer && chmod +x apra-fleet-installer && ./apra-fleet-installer install
 ```
 
 **Linux (x64)**
 ```bash
-curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-linux-x64 -o apra-fleet && chmod +x apra-fleet && ./apra-fleet install
+curl -fsSL https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-installer-linux-x64 -o apra-fleet-installer && chmod +x apra-fleet-installer && ./apra-fleet-installer install
 ```
 
 **Windows (x64)** — run in PowerShell:
 ```powershell
-Invoke-WebRequest -Uri https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-win-x64.exe -OutFile apra-fleet.exe; .\apra-fleet.exe install
+Invoke-WebRequest -Uri https://github.com/Apra-Labs/apra-fleet/releases/latest/download/apra-fleet-installer-win-x64.exe -OutFile apra-fleet-installer.exe; .\apra-fleet-installer.exe install
 ```
 
 Then load in Claude Code:
@@ -96,19 +96,23 @@ Then load in Claude Code:
 
 Download the binary for your platform from [GitHub Releases](https://github.com/Apra-Labs/apra-fleet/releases):
 
-- `apra-fleet-linux-x64` — Linux (x86_64)
-- `apra-fleet-darwin-arm64` — macOS (Apple Silicon)
-- `apra-fleet-win-x64.exe` — Windows
+- `apra-fleet-installer-linux-x64` — Linux (x86_64)
+- `apra-fleet-installer-darwin-arm64` — macOS (Apple Silicon)
+- `apra-fleet-installer-win-x64.exe` — Windows
 
 Then run the installer:
 
 ```bash
-# macOS / Linux
-chmod +x apra-fleet-darwin-arm64
-./apra-fleet-darwin-arm64 install
+# macOS (Apple Silicon)
+chmod +x apra-fleet-installer-darwin-arm64 && ./apra-fleet-installer-darwin-arm64 install
 
+# Linux (x64)
+chmod +x apra-fleet-installer-linux-x64 && ./apra-fleet-installer-linux-x64 install
+```
+
+```powershell
 # Windows
-apra-fleet-win-x64.exe install
+.\apra-fleet-installer-win-x64.exe install
 ```
 
 </details>

--- a/scripts/package-sea.mjs
+++ b/scripts/package-sea.mjs
@@ -27,7 +27,7 @@ const platform = process.platform;
 const arch = process.arch;
 const platformMap = { win32: 'win', darwin: 'darwin', linux: 'linux' };
 const ext = platform === 'win32' ? '.exe' : '';
-const binaryName = `apra-fleet-${platformMap[platform] || platform}-${arch}${ext}`;
+const binaryName = `apra-fleet-installer-${platformMap[platform] || platform}-${arch}${ext}`;
 const outputBinary = join(distDir, binaryName);
 
 console.log(`Packaging SEA binary: ${binaryName}`);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -328,9 +328,11 @@ export function isApraFleetRunning(): boolean {
         return match !== null && match[1] !== currentPid;
       });
     } else {
-      // -x = exact name match; pgrep excludes the calling process by default (NOTE 2)
-      execSync('pgrep -x apra-fleet', { stdio: 'ignore' });
-      return true;
+      // -x = exact name match; installer is apra-fleet-installer-* so won't match;
+      // exclude current PID to handle self-update (installed apra-fleet binary running install)
+      const out = execSync('pgrep -x apra-fleet', { encoding: 'utf-8', stdio: 'pipe' });
+      const currentPid = process.pid.toString();
+      return out.split('\n').some(line => line.trim() !== '' && line.trim() !== currentPid);
     }
   } catch {
     return false;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -320,10 +320,15 @@ function run(cmd: string, opts?: Record<string, unknown>): void {
 export function isApraFleetRunning(): boolean {
   try {
     if (process.platform === 'win32') {
-      const out = execSync('tasklist /FI "IMAGENAME eq apra-fleet.exe" /NH', { encoding: 'utf-8', stdio: 'pipe' });
-      return out.includes('apra-fleet.exe');
+      const out = execSync('tasklist /FI "IMAGENAME eq apra-fleet.exe" /NH /FO CSV', { encoding: 'utf-8', stdio: 'pipe' });
+      const currentPid = process.pid.toString();
+      // Each CSV line: "apra-fleet.exe","<PID>","..." — exclude the current installer process
+      return out.split('\n').some(line => {
+        const match = line.match(/"apra-fleet\.exe","(\d+)"/);
+        return match !== null && match[1] !== currentPid;
+      });
     } else {
-      // -x = exact name match; avoids matching the installer process itself (NOTE 2)
+      // -x = exact name match; pgrep excludes the calling process by default (NOTE 2)
       execSync('pgrep -x apra-fleet', { stdio: 'ignore' });
       return true;
     }

--- a/tests/install-force.test.ts
+++ b/tests/install-force.test.ts
@@ -48,8 +48,8 @@ function makeFsMock() {
 function mockServerRunning() {
   vi.mocked(execSync).mockImplementation((cmd: any) => {
     const c = cmd.toString();
-    if (c === 'pgrep -x apra-fleet') return 'apra-fleet' as any;
-    if (c.startsWith('tasklist')) return 'apra-fleet.exe  1234 Console' as any;
+    if (c === 'pgrep -x apra-fleet') return '5678\n' as any;
+    if (c.startsWith('tasklist')) return '"apra-fleet.exe","5678","Console","1","14,000 K"\n' as any;
     return '' as any;
   });
 }
@@ -146,7 +146,7 @@ describe('install --force (#96)', () => {
     const killCalls: string[] = [];
     vi.mocked(execSync).mockImplementation((cmd: any) => {
       const c = cmd.toString();
-      if (c.startsWith('tasklist')) return 'apra-fleet.exe  1234' as any;
+      if (c.startsWith('tasklist')) return '"apra-fleet.exe","5678","Console","1","14,000 K"\n' as any;
       if (c.startsWith('taskkill')) { killCalls.push(c); return '' as any; }
       return '' as any;
     });
@@ -208,27 +208,39 @@ describe('isApraFleetRunning / killApraFleet helpers (#96)', () => {
     Object.defineProperty(process, 'platform', { value: process.platform, configurable: true });
   });
 
-  it('isApraFleetRunning returns true when pgrep -x exits 0 (Linux)', () => {
+  it('isApraFleetRunning returns true when pgrep finds a different PID (Linux)', () => {
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-    vi.mocked(execSync).mockImplementation(() => '' as any);
+    vi.mocked(execSync).mockReturnValue('5678\n' as any);
     expect(isApraFleetRunning()).toBe(true);
   });
 
-  it('isApraFleetRunning returns false when pgrep -x exits non-zero (Linux)', () => {
+  it('isApraFleetRunning returns false when pgrep finds only the current PID (Linux)', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    vi.mocked(execSync).mockReturnValue(`${process.pid}\n` as any);
+    expect(isApraFleetRunning()).toBe(false);
+  });
+
+  it('isApraFleetRunning returns false when pgrep exits non-zero (Linux)', () => {
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
     vi.mocked(execSync).mockImplementation(() => { throw Object.assign(new Error('no match'), { status: 1 }); });
     expect(isApraFleetRunning()).toBe(false);
   });
 
-  it('isApraFleetRunning returns true when tasklist output contains apra-fleet.exe (Windows)', () => {
+  it('isApraFleetRunning returns true when tasklist CSV contains a different PID (Windows)', () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    vi.mocked(execSync).mockReturnValue('apra-fleet.exe  1234 Console' as any);
+    vi.mocked(execSync).mockReturnValue('"apra-fleet.exe","5678","Console","1","14,000 K"' as any);
     expect(isApraFleetRunning()).toBe(true);
   });
 
-  it('isApraFleetRunning returns false when tasklist output does not contain apra-fleet.exe (Windows)', () => {
+  it('isApraFleetRunning returns false when tasklist CSV contains only the current PID (Windows)', () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    vi.mocked(execSync).mockReturnValue('No tasks are running which match the specified criteria.' as any);
+    vi.mocked(execSync).mockReturnValue(`"apra-fleet.exe","${process.pid}","Console","1","14,000 K"` as any);
+    expect(isApraFleetRunning()).toBe(false);
+  });
+
+  it('isApraFleetRunning returns false when tasklist finds no match (Windows)', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    vi.mocked(execSync).mockReturnValue('INFO: No tasks are running which match the specified criteria.' as any);
     expect(isApraFleetRunning()).toBe(false);
   });
 


### PR DESCRIPTION
## Problem

When a user downloaded `apra-fleet.exe` (or `apra-fleet` on Unix) and ran `apra-fleet.exe install`, the running-process check detected the installer itself in the process list and falsely reported the server was already running — forcing users to add `--force` even when nothing was actually running.

## Fixes

### 1. Rename release artifacts (`package-sea.mjs`, `ci.yml`, docs)

All release binaries are now named `apra-fleet-installer-{platform}-{arch}[.exe]`:

| Before | After |
|--------|-------|
| `apra-fleet-win-x64.exe` | `apra-fleet-installer-win-x64.exe` |
| `apra-fleet-linux-x64` | `apra-fleet-installer-linux-x64` |
| `apra-fleet-darwin-arm64` | `apra-fleet-installer-darwin-arm64` |

The downloaded installer name never collides with the installed `~/.apra-fleet/bin/apra-fleet[.exe]` binary.

### 2. Harden `isApraFleetRunning()` on Windows (`src/cli/install.ts`)

Switches `tasklist` to CSV output format and excludes the current process PID, so self-updates (where the installed `apra-fleet.exe` itself runs `install`) work correctly without `--force`.

## CI / signing

- Matrix `binary` names updated → `package-sea.mjs` produces the matching filename
- `sign-windows` download/upload artifact names updated — file lands at `to-sign/apra-fleet-installer-win-x64.exe`, signed in-place, re-uploaded under the same name ✓
- Release `pattern: apra-fleet-*` still matches `apra-fleet-installer-*` ✓
- `llms-full.txt` intentionally not changed here — CI regenerates it from `README.md` on this PR

## Test plan
- [ ] Fresh install: download `apra-fleet-installer-win-x64.exe`, run `.\apra-fleet-installer.exe install` — should succeed without `--force`
- [ ] Self-update: run `apra-fleet install` from installed binary while server is stopped — should succeed
- [ ] Blocked correctly: run `apra-fleet install` while server is actually running — should still show the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)