### PR TITLE
fix(ci): checkout by SHA in update-llms-full to survive branch deletion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js 22.x
@@ -252,8 +252,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add llms-full.txt
-          git diff --cached --quiet || git commit -m "chore: regenerate llms-full.txt [skip ci]"
-          git push origin HEAD:${{ github.head_ref }}
+          git diff --cached --quiet || (
+            git commit -m "chore: regenerate llms-full.txt [skip ci]" &&
+            git push origin HEAD:${{ github.head_ref }} || echo "Branch no longer exists — skipping push."
+          )
 
   release:
     needs: [package, build-binary, sign-windows]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+    paths-ignore:
+      - 'llms-full.txt'
   pull_request:
     branches: [main]
 
@@ -253,7 +255,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add llms-full.txt
           git diff --cached --quiet || (
-            git commit -m "chore: regenerate llms-full.txt [skip ci]" &&
+            git commit -m "chore: regenerate llms-full.txt" &&
             git push origin HEAD:${{ github.head_ref }} || echo "Branch no longer exists — skipping push."
           )
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add llms-full.txt
+          if [[ "${{ github.head_ref }}" == "main" ]]; then
+            echo "Refusing to push auto-commit to main (protected branch)."
+            exit 0
+          fi
           git diff --cached --quiet || (
             git commit -m "chore: regenerate llms-full.txt" &&
             git push origin HEAD:${{ github.head_ref }} || echo "Branch no longer exists — skipping push."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Apra Fleet — Agent Context
+
+Read `README.md` in this repo for the full tool reference, installation, member registration, multi-provider setup, git authentication, PM skill commands, and troubleshooting.
+
+## Dev commands
+
+```bash
+npm install && npm run build   # Build from source
+npm test                       # Unit tests (vitest)
+npm run build:binary           # Build single-executable binary
+node dist/index.js install     # Dev-mode install
+```
+
+## Conventions
+
+- Branch naming: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`
+- Commit style: `<type>(<scope>): <description>` — e.g. `fix(ssh): handle key rotation timeout`
+- Never push to `main` directly; open a PR
+- See [Architecture](docs/architecture.md) for internal structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# Apra Fleet — Claude Code Context
+
+Read `README.md` in this repo for the full tool reference, installation, member registration, multi-provider setup, git authentication, PM skill commands, and troubleshooting.
+
+## Dev commands
+
+```bash
+npm install && npm run build   # Build from source
+npm test                       # Unit tests (vitest)
+npm run build:binary           # Build single-executable binary
+node dist/index.js install     # Dev-mode install
+```
+
+## Conventions
+
+- Branch naming: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`
+- Commit style: `<type>(<scope>): <description>` — e.g. `fix(ssh): handle key rotation timeout`
+- Never push to `main` directly; open a PR

--- a/skills/pm/cleanup.md
+++ b/skills/pm/cleanup.md
@@ -3,7 +3,9 @@
 Run at sprint completion, before raising the PR. Execute on both doer and reviewer via `execute_command`:
 
 ```
-git rm --cached .fleet-task*.md 2>/dev/null || true; rm -f .fleet-task*.md; git rm PLAN.md progress.json feedback.md requirements.md design.md 2>/dev/null; for file in CLAUDE.md GEMINI.md AGENTS.md COPILOT-INSTRUCTIONS.md; do git ls-files --error-unmatch "$file" 2>/dev/null || rm -f "$file"; done; git commit -m "cleanup: remove fleet control files" && git push
+git rm --cached .fleet-task*.md 2>/dev/null || true; rm -f .fleet-task*.md; git rm PLAN.md progress.json feedback.md requirements.md design.md 2>/dev/null; for file in CLAUDE.md GEMINI.md AGENTS.md COPILOT-INSTRUCTIONS.md; do if git show origin/main:"$file" > /dev/null 2>&1; then git checkout origin/main -- "$file"; else git rm -f "$file" 2>/dev/null || rm -f "$file"; fi; done; git commit -m "cleanup: remove fleet control files" && git push
 ```
+
+**Why:** If a file like `CLAUDE.md` or `AGENTS.md` exists in `main`, it is a project deliverable — the sprint replaced it with a context file of the same name. Restoring from `origin/main` ensures the deliverable is preserved. Only files absent from `main` (pure sprint context) are deleted.
 
 After cleanup on both members, raise the PR (`gh pr create`) and verify CI is green (`gh pr checks`). Do not merge — merge is the user's decision.


### PR DESCRIPTION
## Summary

Five CI and sprint-cleanup fixes bundled together:

1. **Checkout by SHA in `update-llms-full`** — was using `github.head_ref` (branch name) which fails if the branch is deleted before the job runs (race: Windows build takes 7+ min). SHA is always available.

2. **Soft-fail push if branch deleted** — `git push ... || echo "Branch no longer exists"` so a deleted branch does not fail the job.

3. **Restore `AGENTS.md` + `CLAUDE.md` deleted by sprint cleanup** — the cleanup command incorrectly deleted these project deliverables. Restored from pre-cleanup commit. Root fix: cleanup now checks `origin/main` first — if the file exists there it is a deliverable and is restored, not deleted.

4. **`paths-ignore: llms-full.txt` on main push** + **drop `[skip ci]` from auto-commit** — `[skip ci]` in any squash commit body suppresses the entire push trigger on main (GitHub platform-level, cannot be overridden per-branch). Replaced with `paths-ignore` so only-`llms-full.txt` pushes are skipped, but all real code pushes always run CI.

5. **Guard against auto-committing to `main`** — explicit check refuses the push if `github.head_ref == main`, protecting the branch.

## Test plan

- [ ] Push a real code change to a PR → CI runs on merge to main
- [ ] Merge a PR → `update-llms-full` job succeeds even if branch is deleted before it runs
- [ ] Sprint cleanup on a branch that has `CLAUDE.md`/`AGENTS.md` as deliverables in main → files restored, not deleted
- [ ] A commit that only changes `llms-full.txt` pushed to main → CI skipped (paths-ignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)