### PR TITLE
fix(#151): suppress fleet-mcp for Claude and Gemini members

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -117,7 +117,7 @@ export class ClaudeProvider implements ProviderAdapter {
   }
 
   composePermissionConfig(_role: 'doer' | 'reviewer', allow: string[] = []): Array<Record<string, unknown> | string> {
-    return [{ permissions: { allow } }];
+    return [{ permissions: { allow }, mcpServers: { 'apra-fleet': { disabled: true } } }];
   }
 
   supportsOAuthCopy(): boolean {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -125,7 +125,7 @@ export class GeminiProvider implements ProviderAdapter {
     //   so that oauth-personal and other user settings are preserved.
     const mode = role === 'doer' ? 'auto_edit' : 'default';
     // For now, carry only the mode field; caller is responsible for merging with existing content.
-    const settings: Record<string, unknown> = { mode };
+    const settings: Record<string, unknown> = { mode, mcp: { excluded: ['apra-fleet'] } };
 
     // fleet.toml: policy rules
     let toml = `[policy]\nmode = "${mode}"\ndescription = "Fleet ${role} permissions"\n`;

--- a/tests/compose-permissions.test.ts
+++ b/tests/compose-permissions.test.ts
@@ -73,6 +73,9 @@ describe('composePermissions — Claude proactive', () => {
     const writeCmd = writes.find(cmd => cmd.includes('.claude/settings.local.json'))!;
     expect(writeCmd).toContain('"permissions"');
     expect(writeCmd).toContain('"allow"');
+    // settings.local.json must suppress fleet-mcp (#151)
+    expect(writeCmd).toContain('apra-fleet');
+    expect(writeCmd).toContain('disabled');
   });
 
   it('delivers reviewer config with restricted allow list', async () => {
@@ -115,6 +118,9 @@ describe('composePermissions — Gemini proactive', () => {
     // settings.json should have auto_edit mode for doer
     const settingsWrite = writes.find(cmd => cmd.includes('.gemini/settings.json'))!;
     expect(settingsWrite).toContain('auto_edit');
+    // settings.json must suppress fleet-mcp via mcp.excluded (#151)
+    expect(settingsWrite).toContain('apra-fleet');
+    expect(settingsWrite).toContain('excluded');
 
     // fleet.toml should have [policy] section
     const tomlWrite = writes.find(cmd => cmd.includes('fleet.toml'))!;
@@ -134,6 +140,9 @@ describe('composePermissions — Gemini proactive', () => {
 
     const settingsWrite = writes.find(cmd => cmd.includes('.gemini/settings.json'))!;
     expect(settingsWrite).toContain('"default"');
+    // settings.json must suppress fleet-mcp via mcp.excluded (#151)
+    expect(settingsWrite).toContain('apra-fleet');
+    expect(settingsWrite).toContain('excluded');
   });
 });
 

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -177,6 +177,18 @@ describe('ClaudeProvider', () => {
     expect(p.supportsOAuthCopy()).toBe(true);
     expect(p.supportsApiKey()).toBe(true);
   });
+
+  it('composePermissionConfig disables fleet-mcp for doer (#151)', () => {
+    const [settings] = p.composePermissionConfig('doer') as [Record<string, unknown>];
+    const mcpServers = settings.mcpServers as Record<string, unknown>;
+    expect(mcpServers?.['apra-fleet']).toMatchObject({ disabled: true });
+  });
+
+  it('composePermissionConfig disables fleet-mcp for reviewer (#151)', () => {
+    const [settings] = p.composePermissionConfig('reviewer') as [Record<string, unknown>];
+    const mcpServers = settings.mcpServers as Record<string, unknown>;
+    expect(mcpServers?.['apra-fleet']).toMatchObject({ disabled: true });
+  });
 });
 
 // ─── GeminiProvider ───────────────────────────────────────────────────────────
@@ -299,6 +311,20 @@ describe('GeminiProvider', () => {
   it('does not support OAuth copy, supports API key', () => {
     expect(p.supportsOAuthCopy()).toBe(false);
     expect(p.supportsApiKey()).toBe(true);
+  });
+
+  it('composePermissionConfig suppresses fleet-mcp via mcp.excluded for doer (#151)', () => {
+    const [settings] = p.composePermissionConfig('doer') as [Record<string, unknown>];
+    const mcp = settings.mcp as Record<string, unknown>;
+    expect(Array.isArray(mcp?.excluded)).toBe(true);
+    expect((mcp.excluded as string[]).includes('apra-fleet')).toBe(true);
+  });
+
+  it('composePermissionConfig suppresses fleet-mcp via mcp.excluded for reviewer (#151)', () => {
+    const [settings] = p.composePermissionConfig('reviewer') as [Record<string, unknown>];
+    const mcp = settings.mcp as Record<string, unknown>;
+    expect(Array.isArray(mcp?.excluded)).toBe(true);
+    expect((mcp.excluded as string[]).includes('apra-fleet')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- `ClaudeProvider.composePermissionConfig()` adds `mcpServers['apra-fleet'].disabled=true` to `settings.local.json` delivered to every member — uses Claude Code's project-level settings layering to suppress fleet tools without touching the PM's global config
- `GeminiProvider.composePermissionConfig()` adds `mcp.excluded=['apra-fleet']` to `.gemini/settings.json` delivered to every member — experimentally verified: project-level `mcp.excluded` overrides the global `mcpServers` registration
- 4 new unit tests in `providers.test.ts` (2 per provider)
- 3 new integration assertions in `compose-permissions.test.ts` (Claude doer, Gemini doer, Gemini reviewer)

Closes #151

## Test plan

- [ ] CI green (795 tests passing locally, 3 skipped)
- [ ] Claude members: `settings.local.json` contains `mcpServers.apra-fleet.disabled=true` after `compose_permissions`
- [ ] Gemini members: `.gemini/settings.json` contains `mcp.excluded` with `apra-fleet` after `compose_permissions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)