### PR TITLE
fix: SSH username with spaces + improved SSH error messages

### DIFF
--- a/src/tools/register-member.ts
+++ b/src/tools/register-member.ts
@@ -22,7 +22,7 @@ export const registerMemberSchema = z.object({
   member_type: z.enum(['local', 'remote']).default('remote').describe('Member type: "local" for same machine, "remote" for SSH (default: "remote")'),
   host: z.string().regex(/^[^<>\n\r]+$/, 'host must not contain angle brackets or newlines').optional().describe('IP address or hostname of the remote machine (required for non-cloud remote members; optional for cloud members — auto-resolved from AWS when running)'),
   port: z.number().default(22).describe('SSH port (default: 22, remote members only)'),
-  username: z.string().optional().describe('SSH username (required for remote members)'),
+  username: z.string().optional().describe('SSH username (required for remote members). Spaces are allowed (e.g. "tester tester" on Windows) — passed directly to SSH, never shell-interpolated.'),
   auth_type: z.enum(['password', 'key']).optional().describe('Authentication method (required for non-cloud remote members; cloud members default to "key")'),
   password: z.string().optional().describe('SSH password. Omit for secure out-of-band entry — a password prompt will open in a separate terminal window. Supports {{secure.NAME}} token — value is resolved from the credential store before use.'),
   key_path: z.string().optional().describe('Path to SSH private key. Used for both regular SSH connections and cloud instance lifecycle.'),

--- a/src/tools/register-member.ts
+++ b/src/tools/register-member.ts
@@ -13,6 +13,7 @@ import { assignIcon } from '../services/icons.js';
 import { writeStatusline } from '../services/statusline.js';
 import { awsProvider } from '../services/cloud/aws.js';
 import { collectOobPassword } from '../services/auth-socket.js';
+import { classifySshError } from '../utils/ssh-error-messages.js';
 
 export const registerMemberSchema = z.object({
   friendly_name: z.string()
@@ -174,7 +175,7 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
       if (isCloud) {
         warnings.push(`SSH connectivity check failed: ${connResult.error}. Update host via update_member when the instance starts.`);
       } else {
-        return `❌ Failed to connect to ${target} — ${connResult.error}\nMember was NOT registered.`;
+        return `❌ Failed to connect to ${target} — ${classifySshError(connResult.error ?? '')}\nMember was NOT registered.`;
       }
     }
 

--- a/src/utils/ssh-error-messages.ts
+++ b/src/utils/ssh-error-messages.ts
@@ -1,0 +1,21 @@
+/**
+ * Maps raw ssh2 error strings to user-friendly guidance messages.
+ */
+export function classifySshError(error: string): string {
+  const msg = error ?? '';
+
+  if (/Authentication failed|All configured authentication methods failed/i.test(msg)) {
+    return 'Authentication failed — wrong password or key not accepted';
+  }
+  if (/ECONNREFUSED/i.test(msg)) {
+    return 'Connection refused — check host and port';
+  }
+  if (/ETIMEDOUT|ENOTFOUND|EHOSTUNREACH/i.test(msg)) {
+    return 'Host unreachable — check hostname and network';
+  }
+  if (/password prompt could not be opened|OOB|auth-socket/i.test(msg)) {
+    return "Password prompt could not be opened. Try passing the password directly via the 'password' field.";
+  }
+
+  return msg;
+}

--- a/tests/platform.test.ts
+++ b/tests/platform.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { detectOS } from '../src/utils/platform.js';
+import { detectOS, isContainedInWorkFolder } from '../src/utils/platform.js';
+import { getSSHConfig } from '../src/services/ssh.js';
 import { getOsCommands } from '../src/os/index.js';
 import type { OsCommands } from '../src/os/index.js';
 import { getProvider } from '../src/providers/index.js';
@@ -387,6 +388,77 @@ describe('OsCommands via getOsCommands', () => {
         delete process.env.__FLEET_TEST_MARKER__;
       }
     });
+  });
+});
+
+describe('isContainedInWorkFolder', () => {
+  it('accepts POSIX relative paths', () => {
+    expect(isContainedInWorkFolder('/remote/work', 'file.txt')).toBe(true);
+    expect(isContainedInWorkFolder('/remote/work', 'sub/file.txt')).toBe(true);
+  });
+
+  it('accepts POSIX absolute path inside workFolder', () => {
+    expect(isContainedInWorkFolder('/remote/work', '/remote/work/file.txt')).toBe(true);
+  });
+
+  it('rejects POSIX path escaping via ..', () => {
+    expect(isContainedInWorkFolder('/remote/work', '../escape.txt')).toBe(false);
+    expect(isContainedInWorkFolder('/remote/work', '/etc/passwd')).toBe(false);
+  });
+
+  describe('Windows remote workFolder (#146)', () => {
+    const winFolder = 'C:\\Users\\aUser\\ODM';
+
+    it('accepts backslash relative path', () => {
+      expect(isContainedInWorkFolder(winFolder, 'build\\logs\\net.log')).toBe(true);
+    });
+
+    it('accepts forward slash relative path', () => {
+      expect(isContainedInWorkFolder(winFolder, 'build/logs/net.log')).toBe(true);
+    });
+
+    it('accepts filename only', () => {
+      expect(isContainedInWorkFolder(winFolder, 'net.log')).toBe(true);
+    });
+
+    it('accepts absolute Windows path inside workFolder', () => {
+      expect(isContainedInWorkFolder(winFolder, 'C:\\Users\\aUser\\ODM\\net.log')).toBe(true);
+    });
+
+    it('rejects path escaping via ..', () => {
+      expect(isContainedInWorkFolder(winFolder, '..\\escape.txt')).toBe(false);
+    });
+
+    it('rejects absolute Windows path outside workFolder', () => {
+      expect(isContainedInWorkFolder(winFolder, 'C:\\Users\\other\\secret.txt')).toBe(false);
+    });
+  });
+});
+
+describe('SSH username with spaces (#144)', () => {
+  it('getSSHConfig passes username with spaces intact', () => {
+    const agent: any = {
+      host: '192.168.1.1',
+      port: 22,
+      username: 'tester tester',
+      authType: 'password',
+      encryptedPassword: undefined,
+    };
+    // Must not throw and must preserve the space-containing username
+    const config = getSSHConfig(agent);
+    expect(config.username).toBe('tester tester');
+  });
+
+  it('getSSHConfig passes username without spaces intact', () => {
+    const agent: any = {
+      host: '192.168.1.1',
+      port: 22,
+      username: 'normaluser',
+      authType: 'password',
+      encryptedPassword: undefined,
+    };
+    const config = getSSHConfig(agent);
+    expect(config.username).toBe('normaluser');
   });
 });
 

--- a/tests/ssh-error-messages.test.ts
+++ b/tests/ssh-error-messages.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { classifySshError } from '../src/utils/ssh-error-messages.js';
+
+describe('classifySshError (#150)', () => {
+  it('maps authentication failure to user-friendly message', () => {
+    expect(classifySshError('Authentication failed')).toContain('wrong password or key not accepted');
+    expect(classifySshError('All configured authentication methods failed')).toContain('wrong password or key not accepted');
+  });
+
+  it('maps ECONNREFUSED to connection refused message', () => {
+    expect(classifySshError('connect ECONNREFUSED 192.168.1.1:22')).toContain('Connection refused');
+    expect(classifySshError('connect ECONNREFUSED 192.168.1.1:22')).toContain('check host and port');
+  });
+
+  it('maps ETIMEDOUT to host unreachable message', () => {
+    expect(classifySshError('connect ETIMEDOUT')).toContain('Host unreachable');
+  });
+
+  it('maps ENOTFOUND to host unreachable message', () => {
+    expect(classifySshError('getaddrinfo ENOTFOUND mymachine')).toContain('Host unreachable');
+  });
+
+  it('maps EHOSTUNREACH to host unreachable message', () => {
+    expect(classifySshError('connect EHOSTUNREACH')).toContain('Host unreachable');
+  });
+
+  it('maps OOB/auth-socket error to password prompt message', () => {
+    const msg = classifySshError('OOB password prompt could not be opened');
+    expect(msg).toContain("password directly via the 'password' field");
+  });
+
+  it('returns original error for unknown errors', () => {
+    const raw = 'some unexpected ssh2 error message';
+    expect(classifySshError(raw)).toBe(raw);
+  });
+
+  it('handles empty string gracefully', () => {
+    expect(() => classifySshError('')).not.toThrow();
+  });
+});
+
+describe('onboarding hook gating (#150)', () => {
+  it('hook does not fire on SSH connection failure (❌ result)', async () => {
+    const { getOnboardingNudge } = await import('../src/services/onboarding.js');
+    const result = getOnboardingNudge(
+      'register_member',
+      { member_type: 'remote', friendly_name: 'testhost' },
+      '❌ Failed to connect to 192.168.1.1:22 — Authentication failed — wrong password or key not accepted\nMember was NOT registered.',
+    );
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- **#144** `fix(T1.3)`: Verify SSH username with spaces passes through intact — audit confirmed `agent.username` is never shell-interpolated in OS commands; it is passed directly to `ssh2 ConnectConfig.username`; added schema description noting spaces are allowed; adds unit tests for `getSSHConfig` and `isContainedInWorkFolder`
- **#150** `fix(T1.4)`: Improve SSH error messages in `register_member` — adds `classifySshError()` mapping ssh2 error codes to user-friendly guidance (auth failure, ECONNREFUSED, ETIMEDOUT/ENOTFOUND, OOB); applied in `registerMember()` at connection failure; verifies onboarding hook only fires on ✅ result; adds 9 unit tests

## Test plan

- [ ] CI green (821 tests passing locally)
- [ ] `register_member` with username containing spaces connects successfully
- [ ] SSH auth failure gives a clear "check credentials" message instead of raw error code
- [ ] ECONNREFUSED gives a "check host/port" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)