### PR TITLE
docs: add badges.md with security and build badges

### DIFF
--- a/badges.md
+++ b/badges.md
@@ -1,0 +1,18 @@
+# Apra Fleet — Badges
+
+## Security
+
+[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/apra-labs-apra-fleet-badge.png)](https://mseep.ai/app/apra-labs-apra-fleet)
+
+Third-party security and trust validation by [MseeP.ai](https://mseep.ai/app/apra-labs-apra-fleet).
+
+---
+
+## Build & Quality
+
+[![CI](https://github.com/Apra-Labs/apra-fleet/actions/workflows/ci.yml/badge.svg)](https://github.com/Apra-Labs/apra-fleet/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.5+-3178C6.svg?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-20+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](https://github.com/Apra-Labs/apra-fleet/releases)
+[![MCP](https://img.shields.io/badge/MCP-compatible-8A2BE2.svg)](https://modelcontextprotocol.io)


### PR DESCRIPTION
## Summary

- Adds `badges.md` to repo root as a dedicated home for project badges
- Includes MseeP.ai security assessment badge (refs #203) and existing build/quality badges
- Keeps README clean — badges live in one referenced file

## Badges included

- MseeP.ai security assessment
- CI build status
- License, TypeScript, Node.js, Platform, MCP compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)