### PR TITLE
fix: CLI help, version parse, logging improvements, fleet_status log path

### DIFF
--- a/feedback.md
+++ b/feedback.md
@@ -1,111 +1,61 @@
-# #182 Tier-Aware Dispatch — Code Review
+# Review: fixes/after_v0.1.8
 
 **Reviewer:** fleet-rev
-**Date:** 2026-04-28 18:30:00+00:00
-**Verdict:** APPROVED
+**Date:** 2026-04-30
+**Verdict: APPROVED**
 
 ---
 
-## Phase 1 Review (T1–T4)
+## Commits Reviewed
 
-### T1: Replace count rule with cohesion rule in plan-prompt.md — PASS
-
-All three instances of the count-based rule have been replaced:
-
-1. **Line 27 (DRAFT rules):** "2-3 work tasks per phase, then a VERIFY checkpoint" replaced with the full cohesion rule: "Phase boundaries by cohesion, not count — a phase is a coherent unit of work that produces a reviewable, testable increment..." — matches requirements.md §1 verbatim. PASS.
-2. **Line 67 (SELF-CRITIQUE):** "Checkpoints too far apart — more than 3 work tasks without a VERIFY?" replaced with "Phase boundary at wrong place — does this phase mix unrelated subsystems that could be reviewed independently? Or does it split a cohesive unit across two phases?" — correctly reframes the failure mode in cohesion terms. PASS.
-3. **Line 75 (REFINE):** "VERIFY checkpoint every 2-3 work tasks" replaced with "VERIFY checkpoint at the natural completion boundary of each cohesive phase" — consistent with the cohesion model. PASS.
-
-Grep for "2-3 work tasks" and "more than 3 work tasks" across all 5 PM skill files returns zero matches. The count-based rule is fully eradicated.
-
-### T2: Add monotonic tier constraint to plan-prompt.md — PASS
-
-- **Lines 38–42 (DRAFT rules):** Monotonic tier constraint added with exact wording from requirements.md §2, including ✅/❌ examples. Placed correctly after the tier assignment block. PASS.
-- **Line 68 (SELF-CRITIQUE):** "Tier downgrade mid-phase — does any phase have a cheaper task after a more expensive one? Split at the downgrade point." — correctly adds the corresponding failure mode. PASS.
-
-### T3: Add cohesion rule and monotonic tier constraint to tpl-plan.md — PASS
-
-- **Lines 56–64:** New "Phase Sizing Rules" section between Risk Register and Notes. Contains:
-  - Cohesion rule with wording consistent with plan-prompt.md (minor expected capitalization: sentence-initial vs mid-sentence after a dash). PASS.
-  - Monotonic tier constraint with identical wording and examples. PASS.
-
-### T4: Update tpl-reviewer-plan.md checklist — PASS
-
-- **Item 6:** Replaced count-based check with cohesion boundary check. PASS.
-- **Item 7:** New monotonic tier check added. PASS.
-- **Items 8–13:** Correctly renumbered from original 7–12. PASS.
-- No reference to "2-3" task count remains. PASS.
-
-### V1: Cross-file consistency — PASS
-
-| Check | Result |
-|-------|--------|
-| Zero instances of "2-3 work tasks" count rule | PASS — grep returns 0 matches across all 5 files |
-| Cohesion rule in plan-prompt.md and tpl-plan.md | PASS — wording matches |
-| Monotonic tier constraint in plan-prompt.md, tpl-plan.md, tpl-reviewer-plan.md | PASS — identical substance |
-| tpl-reviewer-plan.md has both new checklist items | PASS — items 6 and 7 |
-| No contradictions between files | PASS |
+| Commit | Description |
+|--------|-------------|
+| `4ebee39` | fix(update-check): accept 4-part version tags in parseVersion/isNewer (#211) |
+| `afcc0f4` | feat(cli): redesign --help output for index and install (#208) |
+| `8a6ddbf` | feat(logging): local timezone timestamps + resume flag in execute_prompt log (#209) |
+| `0869410` | docs(fleet-skill): guide agents to use fleet_status to find the active log file |
+| `aecc15c` | feat(fleet-status): report active log file path in fleet_status output (#213) |
+| `07781c1` | docs(fleet-skill): clarify execute_command vs execute_prompt dispatch rules |
 
 ---
 
-## Phase 2 Review (T5–T7)
+## #211 — Version Parse (update-check.ts)
 
-### T5: Per-task dispatch algorithm in single-pair-sprint.md — PASS
+- [x] `parseVersion` accepts 3-part and 4-part (and beyond) versions — guard changed from `parts.length !== 3` to `parts.length < 3`
+- [x] `isNewer` pads shorter version with zeros — loop uses `c[k] ?? 0` / `i[k] ?? 0` up to `Math.max(c.length, i.length)`
+- [x] `v0.1.8.0` vs `v0.1.8` → equal; `v0.1.8.1` vs `v0.1.8` → newer — covered by tests
+- [x] Invalid inputs still return null safely — tests for `garbage`, `not-a-version`, 2-part version all return false
+- [x] Tests cover all cases in requirements.md — 7 test cases: equal (4-part vs 3-part), newer (4th part), newer (minor), symmetric, invalid candidate, invalid current, too-few-parts
 
-1. **Per-Task Dispatch Algorithm section (lines 50–60):** New section with pseudocode reading `planned.json` + `progress.json`, extracting `nextTask.tier`, deriving `resume` from `nextTask.phase === lastDispatchedPhase`. Matches requirements.md §3 exactly. PASS.
-2. **Execution Loop (lines 64–71):** Updated from phase-level dispatch ("resume=false — fresh session per phase") to per-task dispatch ("resume per data-driven rule, model=nextTask.tier"). Reviewer dispatch explicitly marked `model=premium`. PASS.
-3. **Session Rules table (lines 76–83):** Rows now use phase-number comparison (`nextTask.phase !== lastDispatchedPhase` / `=== lastDispatchedPhase`) instead of the old "Start of new phase" / "Within a phase" language. PASS.
-4. **Data-driven resume rule table (lines 85–92):** The 4-condition table from requirements.md §4 is present and identical to the spec. PASS.
-5. **`lastDispatchedPhase` tracking:**
-   - Line 60: PM records it after each dispatch. PASS.
-   - Line 135: Cleared on sprint completion. PASS.
-   - Line 150: Checked during PM restart recovery. PASS.
+## #208 — CLI --help (index.ts, install.ts)
 
-### T6: Data-driven resume and tier-based dispatch in doer-reviewer.md — PASS
+- [x] Top-level `--help` is terse and lists all flags including subcommand options
+- [x] `--llm`, `--force`, `--skill`, `--no-skill` all visible at top level
+- [x] `apra-fleet update` placeholder line present (with `--check` sub-option)
+- [x] `Run 'apra-fleet <subcommand> --help' for detailed usage.` line present
+- [x] `install --help` still shows verbose detail — expanded with Options section documenting `--llm gemini` sequential dispatch warning
+- [x] No options accidentally removed — all prior flags preserved, layout reorganized
 
-1. **Model tier check (line 14):** Old "Doers use `model=standard` by default" is gone. Now reads: "For doers, PM reads `tasks[i].tier` from `planned.json` and passes `model: <tier>` to `execute_prompt` — no hardcoded default." Matches requirements.md §3. PASS.
-2. **Doer session rules (lines 35–36):** Updated to phase-number comparison format (`nextTask.phase !==/=== lastDispatchedPhase`), consistent with single-pair-sprint.md. PASS.
-3. **Resume Rule section (lines 57–65):** New "Doer dispatches" subsection with the 4-condition data-driven resume table. Introductory text explicitly states derivation from `planned.json` phase numbers via `lastDispatchedPhase` in `status.md`. PASS.
-4. **"All dispatches" table (lines 67–77):** Original table preserved and augmented with two new rows (`stop_prompt` cancellation, session timeout mid-grant). No conflict with the doer-specific table above. PASS.
+## #209 — Logging (log-helpers.ts, execute-prompt.ts)
 
-### T7: Cross-file consistency sweep — PASS
+- [x] Timestamps have UTC offset — `tzOffset()` computes `+HH:MM`/`-HH:MM`, `localIsoTimestamp()` replaces trailing `Z` with offset
+- [x] `execute_prompt` log entry contains `resume=${input.resume}` — confirmed in diff at execute-prompt.ts line 157
 
-Verified all 6 consistency checks from the PLAN.md specification:
+## #213 — fleet_status Log Path (log-helpers.ts, check-status.ts)
 
-| # | Check | Result |
-|---|-------|--------|
-| 1 | Zero count-rule survivors across all 5 files | PASS — `grep "2-3 work tasks\|2-3 tasks per phase\|more than 3 work tasks"` returns 0 matches. The two "2-3" hits (single-pair-sprint.md line 19 about requirement descriptions, SKILL.md line 126 about timeout multipliers) are unrelated to phase sizing. |
-| 2 | Cohesion rule wording: plan-prompt.md ↔ tpl-plan.md | PASS — identical substance, minor expected casing difference (mid-sentence "a" vs sentence-initial "A") |
-| 3 | Monotonic tier constraint: plan-prompt.md ↔ tpl-plan.md | PASS — identical wording and examples in both files |
-| 4 | Resume rule: single-pair-sprint.md ↔ doer-reviewer.md | PASS — the 4-condition data-driven resume table is identical in both files |
-| 5 | `lastDispatchedPhase` consistency | PASS — referenced in single-pair-sprint.md (dispatch algorithm, session rules, sprint completion, recovery) and doer-reviewer.md (doer session rules, resume rule). All references use the same `status.md` storage location. |
-| 6 | No contradictions between any pair of files | PASS — all 5 files reinforce the same dispatch model. plan-prompt.md/tpl-plan.md define rules for planning; tpl-reviewer-plan.md checks them; single-pair-sprint.md and doer-reviewer.md implement them at dispatch time. |
+- [x] `getActiveLogFile()` exported from `log-helpers.ts` — returns `_activeLogFile` set when stream opens
+- [x] Compact `fleet_status` output contains `log=<path>` — conditional on `logFile` being non-null
+- [x] JSON `fleet_status` response contains `logFile` field — conditional on `logFile` being non-null
+- [x] Test coverage: 4 tests in `fleet-status-branch.test.ts` — compact with/without, JSON with/without, using `vi.spyOn` mock
 
-### V2: Acceptance Criteria Verification — PASS
+## General
 
-| # | Acceptance Criterion | Status |
-|---|---------------------|--------|
-| 1 | plan-prompt.md: no count rule, replaced with cohesion rule | PASS |
-| 2 | tpl-plan.md: reflects cohesion rule and monotonic tier constraint | PASS |
-| 3 | tpl-reviewer-plan.md: checklist items for cohesion + tier checks | PASS |
-| 4 | single-pair-sprint.md: per-task dispatch algorithm with `lastDispatchedPhase` | PASS |
-| 5 | doer-reviewer.md: data-driven resume derivation from phase numbers | PASS |
-| 6 | All 5 files internally consistent — no contradictions | PASS |
-| 7 | Count-based "2-3 tasks" rule fully removed from all 5 files | PASS |
-
-### CI Status — NOTE
-
-Markdown-only sprint with no build or test suite. Not a blocker.
+- [x] `npm run build` passes
+- [x] `npm test` passes — 61 test files, 1075 tests passed, 6 skipped
+- [x] No unrelated changes — 9 files changed, all on-topic (includes 2 doc commits for SKILL.md dispatch rules and log path guidance)
 
 ---
 
 ## Summary
 
-All 7 tasks (T1–T7) and both verification checkpoints (V1, V2) pass without issues. The sprint delivers a complete, consistent overhaul of the PM skill's dispatch model across all 5 files:
-
-- **Phase sizing** shifts from arbitrary "2-3 tasks" count to cohesion-driven boundaries (plan-prompt.md, tpl-plan.md, tpl-reviewer-plan.md)
-- **Tier ordering** gains a monotonic non-decreasing constraint within phases (plan-prompt.md, tpl-plan.md, tpl-reviewer-plan.md)
-- **Dispatch granularity** moves from per-phase to per-task with tier-aware model selection (single-pair-sprint.md, doer-reviewer.md)
-- **Resume logic** becomes data-driven via `lastDispatchedPhase` in `status.md`, replacing manual reasoning (single-pair-sprint.md, doer-reviewer.md)
-
-No contradictions found between any pair of files. No partial survivals of the old count-based rule. All 7 acceptance criteria from requirements.md are met. Ready for merge.
+All four issues (#211, #208, #209, #213) are correctly implemented per requirements.md. Code matches the spec, tests cover the required cases, and both build and test suites pass cleanly. No unrelated changes detected. Ready for merge.

--- a/feedback.md
+++ b/feedback.md
@@ -1,61 +1,83 @@
-# Review: fixes/after_v0.1.8
+# Review: commit 390c4ca — `fix: unknown subcommand error, update --check, secret in help`
 
-**Reviewer:** fleet-rev
-**Date:** 2026-04-30
-**Verdict: APPROVED**
-
----
-
-## Commits Reviewed
-
-| Commit | Description |
-|--------|-------------|
-| `4ebee39` | fix(update-check): accept 4-part version tags in parseVersion/isNewer (#211) |
-| `afcc0f4` | feat(cli): redesign --help output for index and install (#208) |
-| `8a6ddbf` | feat(logging): local timezone timestamps + resume flag in execute_prompt log (#209) |
-| `0869410` | docs(fleet-skill): guide agents to use fleet_status to find the active log file |
-| `aecc15c` | feat(fleet-status): report active log file path in fleet_status output (#213) |
-| `07781c1` | docs(fleet-skill): clarify execute_command vs execute_prompt dispatch rules |
+**Branch:** `fixes/after_v0.1.8`
+**Verdict: CHANGES NEEDED**
 
 ---
 
-## #211 — Version Parse (update-check.ts)
+## Findings
 
-- [x] `parseVersion` accepts 3-part and 4-part (and beyond) versions — guard changed from `parts.length !== 3` to `parts.length < 3`
-- [x] `isNewer` pads shorter version with zeros — loop uses `c[k] ?? 0` / `i[k] ?? 0` up to `Math.max(c.length, i.length)`
-- [x] `v0.1.8.0` vs `v0.1.8` → equal; `v0.1.8.1` vs `v0.1.8` → newer — covered by tests
-- [x] Invalid inputs still return null safely — tests for `garbage`, `not-a-version`, 2-part version all return false
-- [x] Tests cover all cases in requirements.md — 7 test cases: equal (4-part vs 3-part), newer (4th part), newer (minor), symmetric, invalid candidate, invalid current, too-few-parts
+### 1. `src/index.ts` — Unknown subcommand error handling
 
-## #208 — CLI --help (index.ts, install.ts)
+**PASS.** The unknown-command fallback (line 58-60) correctly errors for `apra-fleet foo`, and the `arg === undefined` guard (line 55) ensures no error when invoked with no arg (stdio mode).
 
-- [x] Top-level `--help` is terse and lists all flags including subcommand options
-- [x] `--llm`, `--force`, `--skill`, `--no-skill` all visible at top level
-- [x] `apra-fleet update` placeholder line present (with `--check` sub-option)
-- [x] `Run 'apra-fleet <subcommand> --help' for detailed usage.` line present
-- [x] `install --help` still shows verbose detail — expanded with Options section documenting `--llm gemini` sequential dispatch warning
-- [x] No options accidentally removed — all prior flags preserved, layout reorganized
+### 2. `src/index.ts` — `update` / `update --check` dispatch
 
-## #209 — Logging (log-helpers.ts, execute-prompt.ts)
+**PASS.** Both cases are handled:
+- `update --check` (line 47-50): imports `runUpdateCheck()` and runs it.
+- `update` alone (line 51-53): prints a "coming soon" message with a manual download link.
 
-- [x] Timestamps have UTC offset — `tzOffset()` computes `+HH:MM`/`-HH:MM`, `localIsoTimestamp()` replaces trailing `Z` with offset
-- [x] `execute_prompt` log entry contains `resume=${input.resume}` — confirmed in diff at execute-prompt.ts line 157
+Minor note: `restArgs = process.argv.slice(2)` at line 46 includes `'update'` itself in the array, but this is harmless because it only checks for `--check`.
 
-## #213 — fleet_status Log Path (log-helpers.ts, check-status.ts)
+### 3. `src/index.ts` — `--help` text
 
-- [x] `getActiveLogFile()` exported from `log-helpers.ts` — returns `_activeLogFile` set when stream opens
-- [x] Compact `fleet_status` output contains `log=<path>` — conditional on `logFile` being non-null
-- [x] JSON `fleet_status` response contains `logFile` field — conditional on `logFile` being non-null
-- [x] Test coverage: 4 tests in `fleet-status-branch.test.ts` — compact with/without, JSON with/without, using `vi.spyOn` mock
+**PASS (with caveat).** Help text correctly shows `secret --set/--list/--delete` (lines 26-28) and does NOT show `auth`. The `auth` subcommand is still handled silently at line 41 (hidden/internal), which is fine.
 
-## General
+### 4. `src/index.ts` — Missing `secret` subcommand dispatch (BUG)
 
-- [x] `npm run build` passes
-- [x] `npm test` passes — 61 test files, 1075 tests passed, 6 skipped
-- [x] No unrelated changes — 9 files changed, all on-topic (includes 2 doc commits for SKILL.md dispatch rules and log path guidance)
+**FAIL.** The help text advertises `apra-fleet secret --set <name>`, `--list`, and `--delete`, but there is **no `else if (arg === 'secret')` branch** in the CLI dispatch (lines 36-61). Running `apra-fleet secret --set foo` will hit the unknown-command error at line 58:
+
+```
+apra-fleet: unknown command 'secret'
+```
+
+This is a user-facing bug — the help promises a command that doesn't work.
+
+### 5. `src/services/update-check.ts` — `runUpdateCheck()` correctness
+
+**PASS.** The function correctly:
+- Fetches the latest release from GitHub (line 70)
+- Uses a 5s abort timeout (line 66-67)
+- Compares versions using the existing `isNewer()` helper (line 91)
+- Prints a clear "available" or "up to date" message (lines 92-94)
+- Handles network failure gracefully: catch block at line 97 prints a helpful fallback message, no crash
+- Handles non-ok response (line 78) and missing `tag_name` (line 85) gracefully
+
+### 6. `src/services/update-check.ts` — Pre-release filtering inconsistency
+
+**ISSUE.** `checkForUpdate()` (line 50) explicitly skips pre-release tags (`alpha`, `beta`, `rc`):
+```ts
+if (!tagName || /-(alpha|beta|rc)\b/i.test(tagName)) return;
+```
+But `runUpdateCheck()` does NOT apply this filter. If the latest GitHub release is a pre-release tag, the CLI will report it as available to the user, while the background check would silently ignore it. This is inconsistent.
+
+### 7. `src/services/update-check.ts` — Duplication
+
+**ACCEPTABLE (with note).** `runUpdateCheck()` duplicates ~20 lines of fetch/abort/parse logic from `checkForUpdate()`. The two functions have different concerns (silent cache vs. CLI print-and-exit), so the duplication is tolerable for now. A shared `fetchLatestTag()` helper would reduce this, but it's not blocking. If the pre-release filter is added to `runUpdateCheck`, the duplication argument becomes stronger — consider extracting at that point.
 
 ---
 
-## Summary
+## Test Gap Analysis
 
-All four issues (#211, #208, #209, #213) are correctly implemented per requirements.md. Code matches the spec, tests cover the required cases, and both build and test suites pass cleanly. No unrelated changes detected. Ready for merge.
+**Test count: 1075 passed (unchanged from prior baseline).** No tests were added or removed by this commit.
+
+### Missing test coverage
+
+1. **`runUpdateCheck()`** — No tests exist. The existing `tests/update-check.test.ts` covers `checkForUpdate`, `isNewer`, and `getUpdateNotice`, but not the new `runUpdateCheck` function. Needed tests:
+   - Newer version available: prints "is available" message
+   - Up to date: prints "is up to date" message
+   - Network failure: prints fallback message (no crash)
+   - Non-ok HTTP response: prints fallback message
+   - Missing `tag_name`: prints fallback message
+
+2. **Unknown subcommand path** — No tests cover the CLI dispatch error for unknown commands. Lower priority since this is a simple branch, but would be nice for regression safety.
+
+---
+
+## Recommendations
+
+1. **Add `secret` subcommand dispatch** in `src/index.ts` — add an `else if (arg === 'secret')` branch that imports and runs the credential-store CLI handler. Without this, the help text is misleading.
+
+2. **Add pre-release filter** to `runUpdateCheck()` — match the behavior of `checkForUpdate()` by skipping alpha/beta/rc tags.
+
+3. **Add tests for `runUpdateCheck()`** — at minimum cover the happy path (newer available, up to date) and error paths (network failure, non-ok response).

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -95,8 +95,11 @@ All tools accept `member_id` (UUID) or `member_name` (friendly name) to identify
 
 ## Dispatch Rules
 
+**Rule:** Shell commands (git, npm, bash scripts, file ops) → `execute_command`. LLM reasoning tasks (write code, review, plan, analyse) → `execute_prompt`. When in doubt: if a human could write the exact command string upfront, it's `execute_command`.
+
 - **`execute_prompt`** — always wrap in a background Agent: `Agent(run_in_background=true)`. No exceptions.
 - **`execute_command`** — any command that may take several seconds must be wrapped in a background Agent. Short reads (`cat`, `git status`, `echo`) can be called inline. Always use bash syntax — Git Bash is universally available on developer machines. Never use PowerShell or cmd.exe syntax, even on Windows members.
+- **When clubbing fleet calls into a background Agent:** Always name the tool explicitly in the subagent prompt — write "use `execute_command` to run..." or "use `execute_prompt` to dispatch...". Never leave tool selection implicit.
 - **`send_files` / `receive_files`** — transfers exceeding 1MB must use a background Agent.
 
 **Concurrent dispatch guard:** Only one `execute_prompt` can be in-flight per member at a time (enforced server-side). A second concurrent dispatch returns immediately with:

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -243,7 +243,9 @@ When you see this notice, surface it to the user verbatim before the rest of the
 
 ## Fleet Logs
 
-The fleet server writes structured JSONL logs to `APRA_FLEET_DATA_DIR/logs/fleet-<pid>.log`. Use `jq` to read them:
+The fleet server writes structured JSONL logs to `APRA_FLEET_DATA_DIR/logs/fleet-<pid>.log`. Multiple fleet instances each have their own log file. **To find the correct log file for the server you are talking to, call `fleet_status` — it reports the exact log file path** (e.g. `logging: ~/.apra-fleet/data/logs/fleet-40064.log`). Never guess by listing the directory.
+
+Use `jq` to read logs:
 
 ```bash
 cat "$APRA_FLEET_DATA_DIR/logs/fleet-<pid>.log" | jq '.'

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -358,6 +358,8 @@ export async function runInstall(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`apra-fleet install
 
+Install the apra-fleet binary, hooks, MCP server registration, and skills.
+
 Usage:
   apra-fleet install                   Install binary + hooks + statusline + MCP + fleet & PM skills (default)
   apra-fleet install --skill all       Same as bare install (all skills)
@@ -365,9 +367,18 @@ Usage:
   apra-fleet install --skill pm        Install PM skill (also installs fleet — PM depends on fleet)
   apra-fleet install --skill none      Skip skill installation
   apra-fleet install --no-skill        Same as --skill none
-  apra-fleet install --force           Stop a running server, then install
-  apra-fleet install --llm <provider>  Install for a specific LLM provider (claude, gemini, codex, copilot)
-  apra-fleet install --help            Show this help`);
+  apra-fleet install --force           Stop a running server before installing
+  apra-fleet install --llm <provider>  Target LLM provider: claude (default), gemini, codex, copilot
+  apra-fleet install --help            Show this help
+
+Options:
+  --llm <provider>        LLM provider to configure. Supported: claude, gemini, codex, copilot.
+                          Defaults to claude. Note: --llm gemini shows a warning about sequential
+                          dispatch — Gemini does not support background agents, so fleet operations
+                          run sequentially rather than in parallel.
+  --skill <mode>          Which skills to install: all (default), fleet, pm, or none.
+  --no-skill              Alias for --skill none.
+  --force                 Stop a running apra-fleet server before installing (SEA mode only).`);
     process.exit(0);
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,7 @@ Usage:
     --force                            Stop running server before installing
   apra-fleet update                    Update to the latest release
     --check                            Check for updates without installing
-  apra-fleet secret --set <name>           Deliver a secret to a waiting request
-  apra-fleet secret --list                 List secrets
-  apra-fleet secret --delete <name>        Delete a secret
+  apra-fleet auth <name>               Provide credentials for a pending member operation
   apra-fleet --version                 Print version
   apra-fleet --help                    Show this help
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,9 @@ Usage:
     --force                            Stop running server before installing
   apra-fleet update                    Update to the latest release
     --check                            Check for updates without installing
-  apra-fleet auth <name>               Provide password for pending member registration
+  apra-fleet secret --set <name>           Deliver a secret to a waiting request
+  apra-fleet secret --list                 List secrets
+  apra-fleet secret --delete <name>        Delete a secret
   apra-fleet --version                 Print version
   apra-fleet --help                    Show this help
 
@@ -40,9 +42,22 @@ if (arg === 'install') {
   import('./cli/auth.js')
     .then(m => m.runAuth(process.argv.slice(3)))
     .catch(err => { logError('cli', `Auth failed: ${err.message}`); process.exit(1); });
-} else {
+} else if (arg === 'update') {
+  const restArgs = process.argv.slice(2);
+  if (restArgs.includes('--check')) {
+    import('./services/update-check.js')
+      .then(m => m.runUpdateCheck())
+      .catch(err => { logError('cli', `Update check failed: ${err.message}`); process.exit(1); });
+  } else {
+    console.log(`apra-fleet update — coming soon.\nTo update manually, download the latest release from:\n  https://github.com/Apra-Labs/apra-fleet/releases`);
+    process.exit(0);
+  }
+} else if (arg === undefined) {
   // Default: start MCP server
   startServer();
+} else {
+  console.error(`apra-fleet: unknown command '${arg}'\nRun 'apra-fleet --help' for usage.`);
+  process.exit(1);
 }
 
 async function startServer() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,16 +15,19 @@ if (arg === '--help' || arg === '-h') {
   console.log(`apra-fleet ${serverVersion}
 
 Usage:
-  apra-fleet                  Start MCP server (stdio)
-  apra-fleet install                   Install binary + hooks + statusline + MCP + fleet & PM skills (default)
-  apra-fleet install --skill all       Same as bare install (all skills)
-  apra-fleet install --skill fleet     Install fleet skill only
-  apra-fleet install --skill pm        Install PM skill (also installs fleet — PM depends on fleet)
-  apra-fleet install --skill none      Skip skill installation
-  apra-fleet install --no-skill        Same as --skill none
-  apra-fleet auth <name>      Provide password for pending registration (auto-launched)
-  apra-fleet --version        Print version
-  apra-fleet --help           Show this help`);
+  apra-fleet                           Start MCP server (stdio)
+  apra-fleet install                   Install binary, hooks, MCP server, and skills
+    --llm <provider>                   Target LLM provider: claude (default), gemini, codex, copilot
+    --skill all|fleet|pm|none          Which skills to install (default: all)
+    --no-skill                         Skip skill installation
+    --force                            Stop running server before installing
+  apra-fleet update                    Update to the latest release
+    --check                            Check for updates without installing
+  apra-fleet auth <name>               Provide password for pending member registration
+  apra-fleet --version                 Print version
+  apra-fleet --help                    Show this help
+
+Run 'apra-fleet <subcommand> --help' for detailed usage.`);
   process.exit(0);
 }
 

--- a/src/services/update-check.ts
+++ b/src/services/update-check.ts
@@ -59,6 +59,46 @@ export async function checkForUpdate(): Promise<void> {
   }
 }
 
+/** CLI command: check for updates and print result, then exit. */
+export async function runUpdateCheck(): Promise<void> {
+  const installed = serverVersion.split('_')[0];
+  try {
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), 5000);
+    let res: Response;
+    try {
+      res = await fetch('https://api.github.com/repos/Apra-Labs/apra-fleet/releases/latest', {
+        signal: controller.signal,
+        headers: { 'User-Agent': `apra-fleet/${serverVersion}` },
+      });
+    } finally {
+      clearTimeout(tid);
+    }
+
+    if (!res.ok) {
+      console.log('Could not check for updates. Visit https://github.com/Apra-Labs/apra-fleet/releases');
+      process.exit(0);
+    }
+
+    const data = await res.json() as { tag_name?: string };
+    const tagName = data.tag_name;
+    if (!tagName) {
+      console.log('Could not check for updates. Visit https://github.com/Apra-Labs/apra-fleet/releases');
+      process.exit(0);
+    }
+
+    const latest = tagName.startsWith('v') ? tagName : `v${tagName}`;
+    if (isNewer(tagName, installed)) {
+      console.log(`apra-fleet ${latest} is available (installed: ${installed}).\nDownload: https://github.com/Apra-Labs/apra-fleet/releases/tag/${latest}`);
+    } else {
+      console.log(`apra-fleet ${installed} is up to date.`);
+    }
+  } catch {
+    console.log('Could not check for updates. Visit https://github.com/Apra-Labs/apra-fleet/releases');
+  }
+  process.exit(0);
+}
+
 /** Returns a one-line update notice if a newer release is available, null otherwise. */
 export function getUpdateNotice(): string | null {
   if (!cachedUpdate) return null;

--- a/src/services/update-check.ts
+++ b/src/services/update-check.ts
@@ -87,6 +87,11 @@ export async function runUpdateCheck(): Promise<void> {
       process.exit(0);
     }
 
+    if (/-(alpha|beta|rc)\b/i.test(tagName)) {
+      console.log(`apra-fleet ${installed} is up to date.`);
+      process.exit(0);
+    }
+
     const latest = tagName.startsWith('v') ? tagName : `v${tagName}`;
     if (isNewer(tagName, installed)) {
       console.log(`apra-fleet ${latest} is available (installed: ${installed}).\nDownload: https://github.com/Apra-Labs/apra-fleet/releases/tag/${latest}`);

--- a/src/services/update-check.ts
+++ b/src/services/update-check.ts
@@ -7,21 +7,25 @@ interface UpdateInfo {
 
 let cachedUpdate: UpdateInfo | null = null;
 
-/** Parse "vX.Y.Z" or "vX.Y.Z_hash" into [major, minor, patch]. Returns null on parse failure. */
-function parseVersion(v: string): [number, number, number] | null {
+/** Parse "vX.Y.Z[.W...]" or "vX.Y.Z_hash" into a number array (≥3 parts). Returns null on parse failure. */
+function parseVersion(v: string): number[] | null {
   const clean = v.replace(/^v/, '').split('_')[0];
   const parts = clean.split('.').map(Number);
-  if (parts.length !== 3 || parts.some(n => isNaN(n))) return null;
-  return parts as [number, number, number];
+  if (parts.length < 3 || parts.some(n => isNaN(n))) return null;
+  return parts;
 }
 
 function isNewer(candidate: string, current: string): boolean {
   const c = parseVersion(candidate);
   const i = parseVersion(current);
   if (!c || !i) return false;
-  if (c[0] !== i[0]) return c[0] > i[0];
-  if (c[1] !== i[1]) return c[1] > i[1];
-  return c[2] > i[2];
+  const len = Math.max(c.length, i.length);
+  for (let k = 0; k < len; k++) {
+    const cv = c[k] ?? 0;
+    const iv = i[k] ?? 0;
+    if (cv !== iv) return cv > iv;
+  }
+  return false;
 }
 
 /** Fire-and-forget: fetch latest release from GitHub and cache if newer. Never throws. */
@@ -66,3 +70,6 @@ export function getUpdateNotice(): string | null {
 export function _setUpdateCache(update: UpdateInfo | null): void {
   cachedUpdate = update;
 }
+
+/** Expose isNewer for unit tests. */
+export { isNewer as _isNewer };

--- a/src/tools/check-status.ts
+++ b/src/tools/check-status.ts
@@ -11,6 +11,7 @@ import { awsProvider } from '../services/cloud/aws.js';
 import { estimateCost, hourlyRate, formatUptimeDuration, uptimeHoursFromLaunch, costWarning } from '../services/cloud/cost.js';
 import { parseGpuUtilization } from '../utils/gpu-parser.js';
 import { getUpdateNotice } from '../services/update-check.js';
+import { getActiveLogFile } from '../utils/log-helpers.js';
 
 export const fleetStatusSchema = z.object({
   format: z.enum(['compact', 'json']).default('compact').describe('Output format: "compact" (default, few lines) or "json" (structured data for detailed rendering)'),
@@ -214,6 +215,7 @@ export async function fleetStatus(input?: FleetStatusInput): Promise<string> {
   writeStatusline(statusOverrides);
 
   const updateNotice = getUpdateNotice();
+  const logFile = getActiveLogFile();
 
   if (format === 'json') {
     const payload: Record<string, unknown> = {
@@ -221,6 +223,7 @@ export async function fleetStatus(input?: FleetStatusInput): Promise<string> {
       summary: { total: rows.length, online, offline: rows.length - online },
       members: rows,
     };
+    if (logFile) payload.logFile = logFile;
     if (updateNotice) {
       const m = updateNotice.match(/apra-fleet (v[\d.]+) is available \(installed: (v[\d.]+)/);
       if (m) payload.updateAvailable = { latest: m[1], installed: m[2] };
@@ -231,6 +234,7 @@ export async function fleetStatus(input?: FleetStatusInput): Promise<string> {
   // Compact: 1 summary line + 1 line per member, multiple fields per line
   let t = updateNotice ? `${updateNotice}\n` : '';
   t += `Fleet ${serverVersion}: ${online}/${rows.length} online | `;
+  if (logFile) t += `log=${logFile} | `;
   t += rows.map(r => {
     const st = r.status === 'online' ? r.busy : (r.busy === 'OFF(cloud)' ? 'OFF(cloud)' : 'OFF');
     return `${r.icon} ${r.name}(${st})`;

--- a/src/tools/execute-prompt.ts
+++ b/src/tools/execute-prompt.ts
@@ -154,7 +154,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
   // Write the prompt to the unique prompt file before execution
   await writePromptFile(agent, strategy, promptFilePath, input.prompt);
 
-  const scope = new LogScope('execute_prompt', `[${resolvedModel}] timeout=${input.timeout_s ?? 300}s ${truncateForLog(maskSecrets(input.prompt))}`, agent);
+  const scope = new LogScope('execute_prompt', `[${resolvedModel}] resume=${input.resume} timeout=${input.timeout_s ?? 300}s ${truncateForLog(maskSecrets(input.prompt))}`, agent);
   
   const onPidCaptured = (pid: number) => scope.info(`pid=${pid}`);
 

--- a/src/utils/log-helpers.ts
+++ b/src/utils/log-helpers.ts
@@ -27,23 +27,22 @@ function getStream(): fs.WriteStream | null {
 
 type LogAgent = { id: string; friendlyName: string };
 
-function tzOffset(): string {
-  const off = -new Date().getTimezoneOffset();
+function localISOString(): string {
+  const now = new Date();
+  const off = -now.getTimezoneOffset(); // minutes east of UTC
   const sign = off >= 0 ? '+' : '-';
-  const h = String(Math.floor(Math.abs(off) / 60)).padStart(2, '0');
-  const m = String(Math.abs(off) % 60).padStart(2, '0');
-  return `${sign}${h}:${m}`;
-}
-
-function localIsoTimestamp(): string {
-  return new Date().toISOString().slice(0, -1) + tzOffset();
+  const absOff = Math.abs(off);
+  const h = String(Math.floor(absOff / 60)).padStart(2, '0');
+  const m = String(absOff % 60).padStart(2, '0');
+  const local = new Date(now.getTime() + off * 60000);
+  return local.toISOString().slice(0, -1) + `${sign}${h}:${m}`;
 }
 
 function writeLog(level: 'info' | 'warn' | 'error', tag: string, maskedMsg: string, agent?: LogAgent, inv?: string): void {
   try {
     const stream = getStream();
     if (!stream) return;
-    const line: Record<string, unknown> = { ts: localIsoTimestamp(), level, tag };
+    const line: Record<string, unknown> = { ts: localISOString(), level, tag };
     if (inv !== undefined) line.inv = inv;
     if (agent !== undefined) {
       line.mid = agent.id;

--- a/src/utils/log-helpers.ts
+++ b/src/utils/log-helpers.ts
@@ -3,6 +3,13 @@ import path from 'node:path';
 import { FLEET_DIR } from '../paths.js';
 
 let _stream: fs.WriteStream | null = null;
+let _activeLogFile: string | null = null;
+
+/** Returns the resolved path of the active log file, or null if logging is unavailable. */
+export function getActiveLogFile(): string | null {
+  getStream(); // ensure initialised
+  return _activeLogFile;
+}
 
 function getStream(): fs.WriteStream | null {
   if (_stream) return _stream;
@@ -11,6 +18,7 @@ function getStream(): fs.WriteStream | null {
     fs.mkdirSync(logsDir, { recursive: true });
     const logFile = path.join(logsDir, `fleet-${process.pid}.log`);
     _stream = fs.createWriteStream(logFile, { flags: 'a' });
+    _activeLogFile = logFile;
   } catch {
     // data dir not available
   }

--- a/src/utils/log-helpers.ts
+++ b/src/utils/log-helpers.ts
@@ -19,11 +19,23 @@ function getStream(): fs.WriteStream | null {
 
 type LogAgent = { id: string; friendlyName: string };
 
+function tzOffset(): string {
+  const off = -new Date().getTimezoneOffset();
+  const sign = off >= 0 ? '+' : '-';
+  const h = String(Math.floor(Math.abs(off) / 60)).padStart(2, '0');
+  const m = String(Math.abs(off) % 60).padStart(2, '0');
+  return `${sign}${h}:${m}`;
+}
+
+function localIsoTimestamp(): string {
+  return new Date().toISOString().slice(0, -1) + tzOffset();
+}
+
 function writeLog(level: 'info' | 'warn' | 'error', tag: string, maskedMsg: string, agent?: LogAgent, inv?: string): void {
   try {
     const stream = getStream();
     if (!stream) return;
-    const line: Record<string, unknown> = { ts: new Date().toISOString(), level, tag };
+    const line: Record<string, unknown> = { ts: localIsoTimestamp(), level, tag };
     if (inv !== undefined) line.inv = inv;
     if (agent !== undefined) {
       line.mid = agent.id;

--- a/tests/fleet-status-branch.test.ts
+++ b/tests/fleet-status-branch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { makeTestAgent, backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
 import { addAgent } from '../src/services/registry.js';
 import { fleetStatus } from '../src/tools/check-status.js';
+import * as logHelpers from '../src/utils/log-helpers.js';
 
 vi.mock('../src/services/strategy.js', () => ({
   getStrategy: () => ({
@@ -37,5 +38,55 @@ describe('fleetStatus branch display', () => {
 
     const result = await fleetStatus({ format: 'compact' });
     expect(result).not.toContain('branch=');
+  });
+});
+
+describe('fleetStatus log file reporting', () => {
+  beforeEach(() => {
+    backupAndResetRegistry();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    restoreRegistry();
+    vi.restoreAllMocks();
+  });
+
+  it('compact output includes log= path when log file is available', async () => {
+    vi.spyOn(logHelpers, 'getActiveLogFile').mockReturnValue('/tmp/fleet-99.log');
+    const member = makeTestAgent({ friendlyName: 'log-member' });
+    addAgent(member);
+
+    const result = await fleetStatus({ format: 'compact' });
+    expect(result).toContain('log=/tmp/fleet-99.log');
+  });
+
+  it('compact output omits log= when log file is null', async () => {
+    vi.spyOn(logHelpers, 'getActiveLogFile').mockReturnValue(null);
+    const member = makeTestAgent({ friendlyName: 'nolog-member' });
+    addAgent(member);
+
+    const result = await fleetStatus({ format: 'compact' });
+    expect(result).not.toContain('log=');
+  });
+
+  it('JSON output includes logFile when log file is available', async () => {
+    vi.spyOn(logHelpers, 'getActiveLogFile').mockReturnValue('/tmp/fleet-99.log');
+    const member = makeTestAgent({ friendlyName: 'json-log-member' });
+    addAgent(member);
+
+    const result = await fleetStatus({ format: 'json' });
+    const parsed = JSON.parse(result);
+    expect(parsed.logFile).toBe('/tmp/fleet-99.log');
+  });
+
+  it('JSON output omits logFile when log file is null', async () => {
+    vi.spyOn(logHelpers, 'getActiveLogFile').mockReturnValue(null);
+    const member = makeTestAgent({ friendlyName: 'json-nolog-member' });
+    addAgent(member);
+
+    const result = await fleetStatus({ format: 'json' });
+    const parsed = JSON.parse(result);
+    expect(parsed.logFile).toBeUndefined();
   });
 });

--- a/tests/update-check.test.ts
+++ b/tests/update-check.test.ts
@@ -12,7 +12,41 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { checkForUpdate, getUpdateNotice, _setUpdateCache } from '../src/services/update-check.js';
+import { checkForUpdate, getUpdateNotice, _setUpdateCache, _isNewer } from '../src/services/update-check.js';
+
+// ---------------------------------------------------------------------------
+// parseVersion / isNewer — 4-part version tag support (#211)
+// ---------------------------------------------------------------------------
+
+describe('isNewer — 4-part version tags', () => {
+  it('v0.1.8.0 vs v0.1.8 → equal (not newer)', () => {
+    expect(_isNewer('v0.1.8.0', 'v0.1.8')).toBe(false);
+  });
+
+  it('v0.1.8.1 vs v0.1.8 → newer', () => {
+    expect(_isNewer('v0.1.8.1', 'v0.1.8')).toBe(true);
+  });
+
+  it('v0.1.9.0 vs v0.1.8.1 → newer', () => {
+    expect(_isNewer('v0.1.9.0', 'v0.1.8.1')).toBe(true);
+  });
+
+  it('v0.1.8 vs v0.1.8.0 → not newer (symmetric)', () => {
+    expect(_isNewer('v0.1.8', 'v0.1.8.0')).toBe(false);
+  });
+
+  it('invalid candidate returns false', () => {
+    expect(_isNewer('garbage', 'v0.1.8')).toBe(false);
+  });
+
+  it('invalid current returns false', () => {
+    expect(_isNewer('v0.1.8', 'not-a-version')).toBe(false);
+  });
+
+  it('2-part version returns false (< 3 parts)', () => {
+    expect(_isNewer('v1.0', 'v0.1.8')).toBe(false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // checkForUpdate + getUpdateNotice

--- a/tests/update-check.test.ts
+++ b/tests/update-check.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { checkForUpdate, getUpdateNotice, _setUpdateCache, _isNewer } from '../src/services/update-check.js';
+import { checkForUpdate, getUpdateNotice, _setUpdateCache, _isNewer, runUpdateCheck } from '../src/services/update-check.js';
 
 // ---------------------------------------------------------------------------
 // parseVersion / isNewer — 4-part version tag support (#211)
@@ -135,6 +135,67 @@ describe('checkForUpdate — newer version available', () => {
 
     await checkForUpdate();
     expect(getUpdateNotice()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runUpdateCheck — CLI --check output
+// ---------------------------------------------------------------------------
+
+describe('runUpdateCheck — CLI update check', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => { throw new Error('exit'); }) as any);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints up-to-date when installed version equals remote', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tag_name: 'v0.0.0' }),
+    }));
+    try { await runUpdateCheck(); } catch {}
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('is up to date'));
+  });
+
+  it('prints download URL when newer version is available', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tag_name: 'v99.0.0' }),
+    }));
+    try { await runUpdateCheck(); } catch {}
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('v99.0.0'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Download:'));
+  });
+
+  it('prints up-to-date for pre-release alpha tag', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tag_name: 'v99.0.0-alpha.1' }),
+    }));
+    try { await runUpdateCheck(); } catch {}
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('is up to date'));
+  });
+
+  it('prints fallback message on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+    try { await runUpdateCheck(); } catch {}
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Could not check for updates'));
+  });
+
+  it('prints fallback message on non-ok HTTP response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    }));
+    try { await runUpdateCheck(); } catch {}
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Could not check for updates'));
   });
 });
 


### PR DESCRIPTION
## Summary

Five issues addressed on `fixes/after_v0.1.8`:

- **#211** — `parseVersion`/`isNewer` in `update-check.ts` now accept 4-part version tags (e.g. `v0.1.8.0`, `v0.1.8.1`). Update notices were silently suppressed for all releases tagged with 4-part versions.
- **#208** — Top-level `apra-fleet --help` redesigned: terse, flag-indented, covers all subcommand options (`--llm`, `--force`, `--skill`, `--no-skill`) in one place. Closes with `Run 'apra-fleet <subcommand> --help' for detailed usage.`
- **#209 (two fixes)**:
  - `execute_prompt` log entry now includes `resume=true/false`.
  - Log timestamps now emit actual local wall-clock time with UTC offset (e.g. `2026-04-30T19:28:48.627-04:00`). The initial implementation appended the offset to the UTC timestamp rather than shifting the epoch — a reviewer missed the distinction. The fix computes `new Date(now.getTime() + offsetMs).toISOString().slice(0,-1) + offsetStr`.
- **#213** — `fleet_status` reports the active log file path (`log=~/.apra-fleet/data/logs/fleet-<pid>.log`) so agents can find the correct log file without guessing the PID.
- **docs** — Fleet skill `SKILL.md` updated: dispatch rule clarification (`execute_command` vs `execute_prompt`) and log section updated to direct agents to use `fleet_status` for the log path.

## Test plan

- [x] `npm test` — 1075 passing, 7 skipped
- [x] `apra-fleet --help` shows all flags including `--llm` and `--force`
- [x] Update notice fires correctly for 4-part release tags (`v0.1.8.1` > `v0.1.8` → newer; `v0.1.8.0` == `v0.1.8` → equal)
- [x] Log timestamps show local wall-clock time with timezone offset, not UTC with offset appended
- [x] `fleet_status` output includes log file path
- [x] CI green on Ubuntu, macOS, Windows