### PR TITLE
feat(install): add Beads (bd) CLI as install step 8 (#232)

### DIFF
--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -37,10 +37,3 @@ compose-permissions integration levels.
 ### Test suite health
 
 All 1113 tests pass across 63 test files. No regressions introduced.
-
-## PR #232: Beads Install Step Bug Fix
-
-### Issue
-When `bd --version` call fails during Beads post-install validation, the banner section left `beadsVersion` as `'installed'` instead of showing the actual failure state.
-
-**Doer:** fixed in commit f4e2a99 — catch block now sets beadsVersion to 'not available'

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -37,3 +37,10 @@ compose-permissions integration levels.
 ### Test suite health
 
 All 1113 tests pass across 63 test files. No regressions introduced.
+
+## PR #232: Beads Install Step Bug Fix
+
+### Issue
+When `bd --version` call fails during Beads post-install validation, the banner section left `beadsVersion` as `'installed'` instead of showing the actual failure state.
+
+**Doer:** fixed in commit f4e2a99 — catch block now sets beadsVersion to 'not available'

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { parse, stringify } from 'smol-toml';
 import { serverVersion } from '../version.js';
 import type { LlmProvider } from '../types.js';
@@ -449,7 +449,7 @@ Options:
 
   const installFleet = skillMode === 'fleet' || skillMode === 'pm' || skillMode === 'all';
   const installPm = skillMode === 'pm' || skillMode === 'all';
-  const totalSteps = (installFleet && installPm) ? 7 : installFleet ? 6 : installPm ? 7 : 5;
+  const totalSteps = (installFleet && installPm) ? 8 : installFleet ? 7 : installPm ? 8 : 6;
 
   if (llm === 'gemini' && (installFleet || installPm)) {
     console.warn(`\n⚠ Note: Gemini does not support background agents. If you plan to use Gemini as the\n  PM/orchestrator, fleet operations will run sequentially (no parallel dispatch).\n  For best orchestration performance, consider using Claude. See docs for details.\n`);
@@ -597,6 +597,22 @@ ${killHint}
     console.log(`  Skipping skills (use --skill all to install, or omit --skill for default)`);
   }
 
+  // --- Step 8: Install Beads task tracker ---
+  console.log(`  [${totalSteps}/${totalSteps}] Installing Beads task tracker...`);
+  try {
+    // Check if already installed
+    try {
+      execFileSync('bd', ['--version'], { stdio: 'pipe' });
+      // already installed — skip
+    } catch {
+      // not installed — install it
+      execFileSync('npm', ['install', '-g', '@beads/bd'], { stdio: 'inherit' });
+    }
+  } catch (err) {
+    // non-fatal: warn but don't fail the install
+    console.warn('  ⚠ Beads install skipped — npm not available or install failed');
+  }
+
   // Finalize permissions
   mergePermissions(paths);
 
@@ -607,6 +623,14 @@ ${killHint}
   fs.writeFileSync(path.join(configDir, 'install-config.json'), JSON.stringify(installConfig, null, 2), { mode: 0o600 });
 
   // --- Done ---
+  let beadsVersion = 'installed';
+  try {
+    const versionOut = execFileSync('bd', ['--version'], { stdio: 'pipe', encoding: 'utf-8' });
+    beadsVersion = (versionOut as string).trim() || 'installed';
+  } catch {
+    // not installed or unavailable
+  }
+
   const instructions = llm === 'claude' ? 'Run /mcp in Claude Code to load the server.' : `Restart ${paths.name} to load the server.`;
   const forceNote = force ? '\nRestart Claude Code to reload the MCP server.' : '';
   console.log(`
@@ -615,6 +639,7 @@ Apra Fleet ${serverVersion} installed successfully for ${paths.name}.
   Hooks:       ${HOOKS_DIR}
   Scripts:     ${SCRIPTS_DIR}
   Settings:    ${paths.settingsFile}${installFleet ? `\n  Fleet Skill: ${paths.fleetSkillsDir}` : ''}${installPm ? `\n  PM Skill:    ${paths.skillsDir}` : ''}
+  Beads:       ${beadsVersion}
 
 ${instructions}${forceNote}
 `);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -628,7 +628,7 @@ ${killHint}
     const versionOut = execFileSync('bd', ['--version'], { stdio: 'pipe', encoding: 'utf-8' });
     beadsVersion = (versionOut as string).trim() || 'installed';
   } catch {
-    // not installed or unavailable
+    beadsVersion = 'not available';
   }
 
   const instructions = llm === 'claude' ? 'Run /mcp in Claude Code to load the server.' : `Restart ${paths.name} to load the server.`;

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { runInstall, _setSeaOverride, _setManifestOverride } from '../src/cli/install.js';
 
 vi.mock('node:os', () => ({
@@ -91,5 +92,91 @@ describe('install config persistence (T5)', () => {
       JSON.stringify({ llm: 'claude', skill: 'fleet' }, null, 2),
       { mode: 0o600 }
     );
+  });
+});
+
+describe('install step 8 — Beads task tracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home');
+    vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+      const ps = p.toString();
+      if (ps.includes('version.json')) return true;
+      if (ps.includes('hooks-config.json')) return true;
+      return false;
+    });
+    vi.mocked(fs.readFileSync).mockImplementation((p: any) => {
+      const ps = p.toString();
+      if (ps.includes('version.json')) return JSON.stringify({ version: '0.1.0' });
+      if (ps.includes('hooks-config.json')) return JSON.stringify({ hooks: { PostToolUse: [] } });
+      return '';
+    });
+    vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as any);
+    vi.mocked(fs.chmodSync).mockImplementation(() => {});
+    vi.mocked(fs.copyFileSync).mockImplementation(() => {});
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    _setSeaOverride(false);
+    _setManifestOverride({ version: '0.1.0', hooks: {}, scripts: {}, skills: {}, fleetSkills: {} });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    _setSeaOverride(null);
+    _setManifestOverride(null);
+  });
+
+  it('installs Beads when bd not found — step [8/8] appears in output', async () => {
+    // First call: bd --version throws (not installed); second call: npm install succeeds
+    vi.mocked(execFileSync)
+      .mockImplementationOnce(() => { throw new Error('bd: command not found'); })
+      .mockImplementation(() => undefined as any);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runInstall([]);
+
+    const logs = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(logs).toContain('[8/8] Installing Beads task tracker...');
+
+    logSpy.mockRestore();
+  });
+
+  it('skips npm install when bd is already installed', async () => {
+    // bd --version succeeds — already installed
+    vi.mocked(execFileSync).mockReturnValue('bd 1.2.3\n' as any);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runInstall([]);
+
+    const logs = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(logs).toContain('[8/8] Installing Beads task tracker...');
+
+    // npm install -g @beads/bd should NOT have been called
+    const npmCall = vi.mocked(execFileSync).mock.calls.find(
+      c => c[0] === 'npm' && Array.isArray(c[1]) && c[1].includes('@beads/bd')
+    );
+    expect(npmCall).toBeUndefined();
+
+    logSpy.mockRestore();
+  });
+
+  it('warns non-fatally when npm install fails', async () => {
+    // bd --version throws, then npm install also throws
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('npm: not found'); });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Should not throw
+    await expect(runInstall([])).resolves.toBeUndefined();
+
+    const warns = warnSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(warns).toContain('Beads install skipped');
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `[8/8] Installing Beads task tracker...` as the final step of `apra-fleet install`
- Skips install if `bd` is already present (idempotent)
- Non-fatal: if npm install fails, warns and continues — doesn't block the rest of install
- Adds `Beads: <version>` line to the install success banner (shows `'not available'` if install failed)
- 3 new tests covering all paths: fresh install, skip-if-present, fail-gracefully

## Why

Beads (`bd`) is being integrated into the PM skill as a persistent cross-session task tracker. Installing it automatically means every orchestrator machine gets `bd` without a separate manual step.

## Test plan

- [ ] `apra-fleet install` on a machine without `bd` — step 8 runs, `bd` installed, banner shows version
- [ ] `apra-fleet install` on a machine with `bd` already — step 8 skips npm install
- [ ] `apra-fleet install` when npm unavailable — step 8 warns, rest of install completes normally
- [ ] All 1066 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)