### PR TITLE
fix(update-check): support N-part version tags (e.g. v0.1.8.1)

### DIFF
--- a/src/services/update-check.ts
+++ b/src/services/update-check.ts
@@ -7,21 +7,25 @@ interface UpdateInfo {
 
 let cachedUpdate: UpdateInfo | null = null;
 
-/** Parse "vX.Y.Z" or "vX.Y.Z_hash" into [major, minor, patch]. Returns null on parse failure. */
-export function parseVersion(v: string): [number, number, number] | null {
+/** Parse "vX.Y.Z[.W]" or "vX.Y.Z_hash" into numeric parts. Returns null on parse failure. */
+export function parseVersion(v: string): number[] | null {
   const clean = v.replace(/^v/, '').split('_')[0];
   const parts = clean.split('.').map(Number);
-  if (parts.length !== 3 || parts.some(n => isNaN(n))) return null;
-  return parts as [number, number, number];
+  if (parts.length < 3 || parts.some(n => isNaN(n))) return null;
+  return parts;
 }
 
 export function isNewer(candidate: string, current: string): boolean {
   const c = parseVersion(candidate);
   const i = parseVersion(current);
   if (!c || !i) return false;
-  if (c[0] !== i[0]) return c[0] > i[0];
-  if (c[1] !== i[1]) return c[1] > i[1];
-  return c[2] > i[2];
+  const len = Math.max(c.length, i.length);
+  for (let idx = 0; idx < len; idx++) {
+    const cv = c[idx] ?? 0;
+    const iv = i[idx] ?? 0;
+    if (cv !== iv) return cv > iv;
+  }
+  return false;
 }
 
 /** Fire-and-forget: fetch latest release from GitHub and cache if newer. Never throws. */

--- a/tests/update-check.test.ts
+++ b/tests/update-check.test.ts
@@ -31,8 +31,12 @@ describe('isNewer — version comparison', () => {
     expect(isNewer('v0.1.7', 'v0.1.8')).toBe(false);
   });
 
-  it('4-part version string returns false (not supported)', () => {
-    expect(isNewer('v0.1.8.1', 'v0.1.8')).toBe(false);
+  it('4-part version: v0.1.8.1 > v0.1.8', () => {
+    expect(isNewer('v0.1.8.1', 'v0.1.8')).toBe(true);
+  });
+
+  it('4-part version: v0.1.8.0 not newer than v0.1.8', () => {
+    expect(isNewer('v0.1.8.0', 'v0.1.8')).toBe(false);
   });
 
   it('invalid candidate returns false', () => {


### PR DESCRIPTION
## Summary
- `parseVersion` now accepts any number of parts (≥3) instead of rejecting non-3-part versions
- `isNewer` compares all parts pairwise, treating missing parts as 0
- Previously 4-part tags like `v0.1.8.1` were silently rejected, causing `apra-fleet update --check` to report "up to date" even when a newer release was available

## Test plan
- [ ] `isNewer('v0.1.8.1', 'v0.1.8')` → `true`
- [ ] `isNewer('v0.1.8.0', 'v0.1.8')` → `false`
- [ ] All 65 existing test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)