### PR TITLE
fix(gemini): exclude apra-fleet from child process MCP via allowlist

### DIFF
--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,8 +1,27 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import type { ProviderAdapter, PromptOptions, ParsedResponse } from './provider.js';
 import { buildResumeFlag } from './provider.js';
 import type { LlmProvider, SSHExecResult } from '../types.js';
 import type { PromptErrorCategory } from '../utils/prompt-errors.js';
 import { escapeDoubleQuoted } from '../os/os-commands.js';
+
+export function getAllowedMcpServers(): string {
+  const settingsPath = path.join(os.homedir(), '.gemini', 'settings.json');
+  try {
+    const raw = fs.readFileSync(settingsPath, 'utf-8');
+    const settings = JSON.parse(raw) as Record<string, unknown>;
+    const mcpServers = settings['mcpServers'];
+    if (!mcpServers || typeof mcpServers !== 'object' || Array.isArray(mcpServers)) {
+      return 'none';
+    }
+    const allowed = Object.keys(mcpServers).filter(k => k !== 'apra-fleet');
+    return allowed.length > 0 ? allowed.join(',') : 'none';
+  } catch {
+    return 'none';
+  }
+}
 
 export class GeminiProvider implements ProviderAdapter {
   readonly name: LlmProvider = 'gemini';
@@ -31,7 +50,7 @@ export class GeminiProvider implements ProviderAdapter {
     const { folder, promptFile, sessionId, unattended, model } = opts;
     const escapedFolder = escapeDoubleQuoted(folder);
     const instruction = `Your task is described in ${promptFile} in the current directory. Read that file first, then execute the task.`;
-    let cmd = `cd "${escapedFolder}" && gemini -p "${instruction}" --output-format json --allowed-mcp-server-names ""`;
+    let cmd = `cd "${escapedFolder}" && gemini -p "${instruction}" --output-format json --allowed-mcp-server-names "${getAllowedMcpServers()}"`;
     const rf = buildResumeFlag(sessionId);
     if (rf) {
       cmd += ` ${rf}`;

--- a/tests/gemini-mcp-exclude.test.ts
+++ b/tests/gemini-mcp-exclude.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs');
+vi.mock('os');
+vi.mock('path');
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getAllowedMcpServers } from '../src/providers/gemini.js';
+
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+const mockHomedir = vi.mocked(os.homedir);
+const mockJoin = vi.mocked(path.join);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockHomedir.mockReturnValue('/home/user');
+  mockJoin.mockImplementation((...parts: string[]) => parts.join('/'));
+});
+
+describe('getAllowedMcpServers', () => {
+  it('returns "none" when settings file does not exist', () => {
+    mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    expect(getAllowedMcpServers()).toBe('none');
+  });
+
+  it('returns "none" when settings file has no mcpServers key', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ mode: 'auto' }) as unknown as Buffer);
+    expect(getAllowedMcpServers()).toBe('none');
+  });
+
+  it('returns "none" when mcpServers contains only apra-fleet', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ mcpServers: { 'apra-fleet': {} } }) as unknown as Buffer);
+    expect(getAllowedMcpServers()).toBe('none');
+  });
+
+  it('returns other servers when apra-fleet is present alongside them', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      mcpServers: { 'apra-fleet': {}, 'my-server': {}, 'another': {} },
+    }) as unknown as Buffer);
+    const result = getAllowedMcpServers();
+    expect(result.split(',').sort()).toEqual(['another', 'my-server']);
+  });
+
+  it('returns all servers when apra-fleet is not present', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      mcpServers: { 'server-a': {}, 'server-b': {} },
+    }) as unknown as Buffer);
+    const result = getAllowedMcpServers();
+    expect(result.split(',').sort()).toEqual(['server-a', 'server-b']);
+  });
+
+  it('returns "none" when mcpServers is empty', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ mcpServers: {} }) as unknown as Buffer);
+    expect(getAllowedMcpServers()).toBe('none');
+  });
+
+  it('returns "none" when settings file contains invalid JSON', () => {
+    mockReadFileSync.mockReturnValue('not-valid-json' as unknown as Buffer);
+    expect(getAllowedMcpServers()).toBe('none');
+  });
+});


### PR DESCRIPTION
## Problem

When apra-fleet launches a Gemini member's CLI process, the child process was loading the `apra-fleet` MCP server recursively. The previous fix passed `--allowed-mcp-server-names ""` (empty string) which had no effect — verified by live experiment.

## Root cause

`apra-fleet` is registered in the **user-level** `~/.gemini/settings.json`, not project-level. Project-level `mcp.excluded` / `mcp.excludedServers` keys have no effect on user-level registrations.

## Fix

- `getAllowedMcpServers()` reads `~/.gemini/settings.json`, extracts `mcpServers` keys, removes `"apra-fleet"`, returns the remainder comma-joined
- If remainder is empty (or file missing/malformed) → returns `"none"` (verified to suppress all MCP in child process)
- `buildPromptCommand` uses `--allowed-mcp-server-names "${getAllowedMcpServers()}"` 
- Future-proof: if the user adds other MCP servers they want in child processes, they load automatically

## Test plan

- [x] 7 new unit tests in `tests/gemini-mcp-exclude.test.ts` (file missing, no key, only apra-fleet, apra-fleet + others, others only, empty object, invalid JSON)
- [x] npm run build — clean
- [x] npm test — 1071/1071 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)