### PR TITLE
fix(cli): reject unknown arguments with error and help text

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,13 @@ Usage:
       .then(m => m.runUpdate())
       .catch(err => { logError('cli', `Update failed: ${err.message}`); process.exit(1); });
   }
-} else {
+} else if (arg === undefined || arg === '--stdio') {
   // Default: start MCP server
   startServer();
+} else {
+  console.error(`Error: unknown option '${arg}'`);
+  console.error(`\nRun 'apra-fleet --help' for usage.`);
+  process.exit(1);
 }
 
 async function startServer() {


### PR DESCRIPTION
## Problem

Passing any unknown argument to the binary silently started the fleet server instead of reporting an error:

```
C:\> apra-fleet.exe garbage
[fleet] startup apra-fleet v0.1.8_11c7d7 started — FLEET_DIR=...
[idle-manager] started (idle timeout: 30min)
```

## Fix

Changed the catch-all `else` branch (which unconditionally started the server) into an explicit check for known modes (`undefined` = no args, `--stdio` = MCP mode). Any other value now prints an error and exits 1:

```
Error: unknown option 'garbage'

Run 'apra-fleet --help' for usage.
```

## Test plan

- [x] `apra-fleet garbage` → prints error, exits 1
- [x] `apra-fleet --version` → still works
- [x] `apra-fleet --help` → still works
- [x] npm run build — clean
- [x] npm test — 1071/1071 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)