### PR TITLE
feat(e2e+oob): LLM-driven e2e suite, credential_store_set Windows fix

### DIFF
--- a/.github/e2e/mcp.json
+++ b/.github/e2e/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "apra-fleet": {
       "type": "stdio",
-      "command": "apra-fleet",
+      "command": "C:\\Users\\akhil\\.apra-fleet\\bin\\apra-fleet.exe",
       "args": []
     }
   }

--- a/.github/e2e/mcp.json
+++ b/.github/e2e/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "apra-fleet": {
+      "type": "stdio",
+      "command": "apra-fleet",
+      "args": []
+    }
+  }
+}

--- a/.github/e2e/members.json
+++ b/.github/e2e/members.json
@@ -1,0 +1,22 @@
+{
+  "windows": {
+    "host": "192.168.1.25",
+    "username": "akhil",
+    "work_folder": "C:\\Users\\akhil\\git\\apra-fleet-e2e"
+  },
+  "linux": {
+    "host": "192.168.1.102",
+    "username": "akhil",
+    "work_folder": "~/git/apra-fleet-e2e"
+  },
+  "macos": {
+    "host": "192.168.1.13",
+    "username": "akhil",
+    "work_folder": "~/git/apra-fleet-e2e"
+  },
+  "toy_projects": {
+    "github":    "https://github.com/Apra-Labs/fleet-e2e-toy",
+    "bitbucket": "https://bitbucket.org/kumaakh/fleet-e2e-toy",
+    "azdevops":  "https://dev.azure.com/apralabs/e2e-fleet-testing/_git/fleet-e2e-toy"
+  }
+}

--- a/.github/e2e/suites.json
+++ b/.github/e2e/suites.json
@@ -1,0 +1,40 @@
+{
+  "suites": {
+    "s1": {
+      "pm":       { "os": "windows", "provider": "claude",  "runner": "fleet-windows" },
+      "doer":     { "os": "linux",   "provider": "claude" },
+      "reviewer": { "os": "macos",   "provider": "claude" },
+      "vcs": "github"
+    },
+    "s2": {
+      "pm":       { "os": "linux",   "provider": "claude",  "runner": "fleet-linux" },
+      "doer":     { "os": "windows", "provider": "gemini" },
+      "reviewer": { "os": "macos",   "provider": "gemini" },
+      "vcs": "github"
+    },
+    "s3": {
+      "pm":       { "os": "macos",   "provider": "claude",  "runner": "fleet-macos" },
+      "doer":     { "os": "linux",   "provider": "gemini" },
+      "reviewer": { "os": "windows", "provider": "claude" },
+      "vcs": "bitbucket"
+    },
+    "s4": {
+      "pm":       { "os": "windows", "provider": "gemini",  "runner": "fleet-windows" },
+      "doer":     { "os": "macos",   "provider": "claude" },
+      "reviewer": { "os": "linux",   "provider": "gemini" },
+      "vcs": "bitbucket"
+    },
+    "s5": {
+      "pm":       { "os": "linux",   "provider": "gemini",  "runner": "fleet-linux" },
+      "doer":     { "os": "windows", "provider": "claude" },
+      "reviewer": { "os": "macos",   "provider": "claude" },
+      "vcs": "azdevops"
+    },
+    "s6": {
+      "pm":       { "os": "macos",   "provider": "gemini",  "runner": "fleet-macos" },
+      "doer":     { "os": "windows", "provider": "gemini" },
+      "reviewer": { "os": "linux",   "provider": "claude" },
+      "vcs": "azdevops"
+    }
+  }
+}

--- a/.github/e2e/test-script.md
+++ b/.github/e2e/test-script.md
@@ -1,0 +1,134 @@
+# Fleet E2E Test Run
+
+You are a Fleet PM running an automated end-to-end test of apra-fleet.
+
+**Your environment:**
+- PM machine: {{PM_OS}} (this machine)
+- PM provider: {{PM_PROVIDER}}
+- Doer member: {{DOER_HOST}} ({{DOER_OS}}) — provider: {{DOER_PROVIDER}}
+- Reviewer member: {{REVIEWER_HOST}} ({{REVIEWER_OS}}) — provider: {{REVIEWER_PROVIDER}}
+- Toy project: {{TOY_PROJECT_URL}} ({{VCS}})
+- Fleet version: call the `version` tool to get this
+
+All SSH credentials and LLM API keys are pre-stored in the fleet credential store.
+Use `{{secure.NAME}}` references as needed. Do NOT ask for any passwords or tokens.
+
+For each test section below:
+1. Execute the steps using fleet tools
+2. Record your observation as either ✅ PASS or ❌ FAIL with a brief note
+3. Continue to the next test even if a test fails — do not stop early
+
+---
+
+## T1: Member Registration
+
+Register both members (doer and reviewer) as remote SSH members.
+- Use `auth_type=key` — SSH keys are pre-configured on each machine.
+- Work folder for each: `~/git/apra-fleet-e2e` (Linux/macOS) or `C:\Users\<user>\git\apra-fleet-e2e` (Windows)
+
+After registering, provision LLM auth on each member:
+- Provision Claude on both
+- Provision Gemini on both
+
+Verify both members appear online in `fleet_status`.
+
+**Record:** Did both members register? Did all 4 auth provisions succeed? Are both online?
+
+---
+
+## T2: Basic Execution
+
+Run `echo "e2e-ok-$(hostname)"` on each member via `execute_command`.
+Verify each response contains the string `e2e-ok-`.
+
+Send a small text file (create it with content `fleet-e2e-roundtrip`) to each member.
+Receive it back. Verify the content is identical.
+
+**Record:** Did commands execute on both members? Did file round-trip correctly for both?
+
+---
+
+## T3: Credential Store
+
+Create a credential named `e2e_test_cred` with a dummy value via `credential_store_set`.
+Verify it appears in `credential_store_list`.
+Update its network policy to `confirm` via `credential_store_update`.
+Verify the policy changed.
+Delete it via `credential_store_delete`.
+Verify it no longer appears in `credential_store_list`.
+
+**Record:** Did all 4 CRUD operations succeed?
+
+---
+
+## T4: LLM Execution
+
+Run `execute_prompt` on each member with this prompt:
+> "What operating system are you running on? Reply in exactly one sentence."
+
+Verify each response names the correct OS ({{DOER_OS}} and {{REVIEWER_OS}}).
+
+**Record:** Did both prompts execute? Did each response name the correct OS?
+
+---
+
+## T5: Full Sprint
+
+The toy project is at {{TOY_PROJECT_URL}}.
+
+Branch prefix for this run: `{{BRANCH_PREFIX}}` — the doer **must** name the feature branch
+`{{BRANCH_PREFIX}}/<short-slug>` (e.g. `{{BRANCH_PREFIX}}/fix-login`). This prevents
+branch name collisions when multiple suites run concurrently.
+
+1. On the doer: clone the repo (or verify it is already cloned) in the work folder
+2. Provision VCS auth ({{VCS}}) on the doer so it can push branches and raise PRs.
+   If VCS is `bitbucket`: also run `git config user.email {{secure.e2e_bb_user}}` in the
+   repo via `execute_command` — the repository access token requires this bot email on commits.
+3. Pick the oldest open issue: run `bd ready` in the toy repo (Beads task backlog is committed in `.beads/` — no VCS issues API needed)
+4. Assign the doer to implement it and the reviewer to review it
+5. Run a complete doer → reviewer sprint:
+   - Doer implements on a branch named `{{BRANCH_PREFIX}}/<short-slug>`, runs tests, commits, pushes
+   - Reviewer reviews the code
+   - If approved: raise a PR targeting `main`
+6. Verify CI is green on the PR
+
+**Record:** Was the sprint completed? Was a PR raised? What is the PR URL? Is CI green?
+
+---
+
+## T6: Cleanup
+
+Remove both members from fleet.
+Verify `fleet_status` shows no registered members (or only the PM itself).
+
+**Record:** Were both members removed cleanly?
+
+---
+
+## Final Report
+
+Output ONLY the following JSON — no other text before or after it:
+
+```json
+{
+  "run": {
+    "suite": "{{SUITE_ID}}",
+    "pm_os": "{{PM_OS}}",
+    "pm_provider": "{{PM_PROVIDER}}",
+    "fleet_version": "<from version tool>",
+    "timestamp": "<ISO timestamp>"
+  },
+  "results": [
+    { "test": "T1", "status": "PASS", "notes": "" },
+    { "test": "T2", "status": "PASS", "notes": "" },
+    { "test": "T3", "status": "PASS", "notes": "" },
+    { "test": "T4", "status": "PASS", "notes": "" },
+    { "test": "T5", "status": "PASS", "notes": "", "pr_url": "" },
+    { "test": "T6", "status": "PASS", "notes": "" }
+  ],
+  "overall": "PASS"
+}
+```
+
+Set each `status` to `"PASS"` or `"FAIL"` and fill in `notes` with a brief observation.
+Set `overall` to `"FAIL"` if any test failed.

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -1,0 +1,161 @@
+name: Fleet E2E Test Suite
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Test suite to run (s1-s6). Start with s1 to validate setup.'
+        required: true
+        type: choice
+        options: [s1, s2, s3, s4, s5, s6]
+
+jobs:
+  e2e:
+    name: 'Fleet E2E – ${{ inputs.suite }}'
+    # Runner label is derived from suites.json pm.runner field.
+    # Each self-hosted runner must be registered with label fleet-windows / fleet-linux / fleet-macos.
+    runs-on:
+      - self-hosted
+      - ${{ inputs.suite == 's1' && 'fleet-windows' || inputs.suite == 's2' && 'fleet-linux' || inputs.suite == 's3' && 'fleet-macos' || inputs.suite == 's4' && 'fleet-windows' || inputs.suite == 's5' && 'fleet-linux' || 'fleet-macos' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ── Step 1: Load suite config ──────────────────────────────────────────
+      - name: Load suite config
+        id: suite
+        shell: bash
+        run: |
+          SUITE='${{ inputs.suite }}'
+          CONFIG=$(cat .github/e2e/suites.json)
+          MEMBERS=$(cat .github/e2e/members.json)
+
+          PM_PROVIDER=$(echo $CONFIG | jq -r ".suites.$SUITE.pm.provider")
+          PM_OS=$(echo $CONFIG      | jq -r ".suites.$SUITE.pm.os")
+          DOER_OS=$(echo $CONFIG    | jq -r ".suites.$SUITE.doer.os")
+          DOER_PROV=$(echo $CONFIG  | jq -r ".suites.$SUITE.doer.provider")
+          REV_OS=$(echo $CONFIG     | jq -r ".suites.$SUITE.reviewer.os")
+          REV_PROV=$(echo $CONFIG   | jq -r ".suites.$SUITE.reviewer.provider")
+          VCS=$(echo $CONFIG        | jq -r ".suites.$SUITE.vcs")
+
+          DOER_HOST=$(echo $MEMBERS   | jq -r ".$DOER_OS.host")
+          DOER_USER=$(echo $MEMBERS   | jq -r ".$DOER_OS.username")
+          DOER_FOLDER=$(echo $MEMBERS | jq -r ".$DOER_OS.work_folder")
+          REV_HOST=$(echo $MEMBERS    | jq -r ".$REV_OS.host")
+          REV_USER=$(echo $MEMBERS    | jq -r ".$REV_OS.username")
+          REV_FOLDER=$(echo $MEMBERS  | jq -r ".$REV_OS.work_folder")
+          TOY_URL=$(echo $MEMBERS     | jq -r ".toy_projects.$VCS")
+
+          echo "pm_provider=$PM_PROVIDER"   >> $GITHUB_OUTPUT
+          echo "pm_os=$PM_OS"               >> $GITHUB_OUTPUT
+          echo "doer_os=$DOER_OS"           >> $GITHUB_OUTPUT
+          echo "doer_provider=$DOER_PROV"   >> $GITHUB_OUTPUT
+          echo "doer_host=$DOER_HOST"       >> $GITHUB_OUTPUT
+          echo "doer_user=$DOER_USER"       >> $GITHUB_OUTPUT
+          echo "doer_folder=$DOER_FOLDER"   >> $GITHUB_OUTPUT
+          echo "reviewer_os=$REV_OS"        >> $GITHUB_OUTPUT
+          echo "reviewer_provider=$REV_PROV" >> $GITHUB_OUTPUT
+          echo "reviewer_host=$REV_HOST"    >> $GITHUB_OUTPUT
+          echo "reviewer_user=$REV_USER"    >> $GITHUB_OUTPUT
+          echo "reviewer_folder=$REV_FOLDER" >> $GITHUB_OUTPUT
+          echo "vcs=$VCS"                   >> $GITHUB_OUTPUT
+          echo "toy_url=$TOY_URL"           >> $GITHUB_OUTPUT
+
+      # ── Step 2: Seed fleet credential store ───────────────────────────────
+      - name: Seed fleet credential store
+        shell: bash
+        run: |
+          echo "$E2E_BB_TOKEN"    | apra-fleet secret --set e2e_bb_token    --persist -y
+          echo "$E2E_BB_USER"     | apra-fleet secret --set e2e_bb_user     --persist -y
+          echo "$E2E_GH_TOKEN"    | apra-fleet secret --set e2e_gh_token    --persist -y
+          echo "$E2E_ADO_TOKEN"   | apra-fleet secret --set e2e_ado_token   --persist -y
+        env:
+          E2E_BB_TOKEN:   ${{ secrets.E2E_BB_TOKEN }}
+          E2E_BB_USER:    ${{ secrets.E2E_BB_USER }}
+          E2E_GH_TOKEN:   ${{ secrets.E2E_GH_TOKEN }}
+          E2E_ADO_TOKEN:  ${{ secrets.E2E_ADO_TOKEN }}
+
+      # ── Step 3: Build and install fleet binary on PM runner ───────────────
+      # Repo is already checked out — build the SEA binary from source so all
+      # three platforms (Windows/Linux/macOS x86_64) work without any artifact
+      # download. The binary name encodes platform+arch via package-sea.mjs.
+      - name: Build fleet binary on PM
+        shell: bash
+        run: |
+          npm ci
+          npm run build:binary
+          BIN=$(ls dist/apra-fleet-installer-* | grep -v '\.exe$\|\.blob$\|\.cjs$\|\.json$' | head -1)
+          [ -z "$BIN" ] && BIN=$(ls dist/apra-fleet-installer-*.exe 2>/dev/null | head -1)
+          chmod +x "$BIN" 2>/dev/null || true
+          sudo cp "$BIN" /usr/local/bin/apra-fleet 2>/dev/null || \
+            cp "$BIN" ~/bin/apra-fleet
+          apra-fleet --version
+
+
+      # ── Step 4: Render test script with suite context ─────────────────────
+      - name: Render test script
+        shell: bash
+        run: |
+          sed \
+            -e 's|{{SUITE_ID}}|${{ inputs.suite }}|g' \
+            -e 's|{{PM_OS}}|${{ steps.suite.outputs.pm_os }}|g' \
+            -e 's|{{PM_PROVIDER}}|${{ steps.suite.outputs.pm_provider }}|g' \
+            -e 's|{{DOER_HOST}}|${{ steps.suite.outputs.doer_host }}|g' \
+            -e 's|{{DOER_OS}}|${{ steps.suite.outputs.doer_os }}|g' \
+            -e 's|{{DOER_PROVIDER}}|${{ steps.suite.outputs.doer_provider }}|g' \
+            -e 's|{{REVIEWER_HOST}}|${{ steps.suite.outputs.reviewer_host }}|g' \
+            -e 's|{{REVIEWER_OS}}|${{ steps.suite.outputs.reviewer_os }}|g' \
+            -e 's|{{REVIEWER_PROVIDER}}|${{ steps.suite.outputs.reviewer_provider }}|g' \
+            -e 's|{{TOY_PROJECT_URL}}|${{ steps.suite.outputs.toy_url }}|g' \
+            -e 's|{{VCS}}|${{ steps.suite.outputs.vcs }}|g' \
+            -e 's|{{BRANCH_PREFIX}}|e2e-${{ inputs.suite }}-${{ github.run_id }}|g' \
+            .github/e2e/test-script.md > rendered-test-script.md
+
+      # ── Step 5: Run the LLM-driven test ───────────────────────────────────
+      - name: Run fleet e2e (${{ steps.suite.outputs.pm_provider }})
+        shell: bash
+        run: |
+          PROVIDER='${{ steps.suite.outputs.pm_provider }}'
+          if [ "$PROVIDER" = "claude" ]; then
+            claude \
+              -p "$(cat rendered-test-script.md)" \
+              --mcp-config .github/e2e/mcp.json \
+              --output-format json \
+              --max-turns 80 \
+              > raw-output.txt 2>&1
+          else
+            gemini \
+              --output-format stream-json \
+              --mcp-config .github/e2e/mcp.json \
+              -p "$(cat rendered-test-script.md)" \
+              > raw-output.txt 2>&1
+          fi
+
+          # Extract the JSON report from the output (last JSON block)
+          grep -o '{.*}' raw-output.txt | tail -1 > results.json || echo '{"overall":"FAIL","error":"no JSON in output"}' > results.json
+
+      # ── Step 6: Post summary ───────────────────────────────────────────────
+      - name: Post job summary
+        if: always()
+        shell: bash
+        run: |
+          echo "## Fleet E2E – Suite ${{ inputs.suite }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Test | Status | Notes |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          cat results.json | jq -r '.results[] | "| \(.test) | \(.status) | \(.notes) |"' >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo "| error | FAIL | could not parse results |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          OVERALL=$(cat results.json | jq -r '.overall' 2>/dev/null || echo "FAIL")
+          echo "**Overall: $OVERALL**" >> $GITHUB_STEP_SUMMARY
+
+      # ── Step 7: Upload artifacts ───────────────────────────────────────────
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-${{ inputs.suite }}-${{ github.run_id }}
+          path: |
+            results.json
+            raw-output.txt
+            rendered-test-script.md

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -62,7 +62,22 @@ jobs:
           echo "vcs=$VCS"                   >> $GITHUB_OUTPUT
           echo "toy_url=$TOY_URL"           >> $GITHUB_OUTPUT
 
-      # ── Step 2: Seed fleet credential store ───────────────────────────────
+      # ── Step 2: Build and install fleet binary on PM runner ───────────────
+      # Must come before credential seeding — seed step needs fleet on PATH.
+      # Build from source so all three platforms (Windows/Linux/macOS x86_64)
+      # work without any artifact download.
+      - name: Build and install fleet binary on PM
+        shell: bash
+        run: |
+          npm ci
+          npm run build:binary
+          BIN=$(ls dist/apra-fleet-installer-* | grep -v '\.blob$\|\.cjs$\|\.json$' | grep -v '^.*\.exe$' | head -1)
+          [ -z "$BIN" ] && BIN=$(ls dist/apra-fleet-installer-*.exe 2>/dev/null | head -1)
+          chmod +x "$BIN" 2>/dev/null || true
+          "$BIN" install --force
+          apra-fleet --version
+
+      # ── Step 3: Seed fleet credential store ───────────────────────────────
       - name: Seed fleet credential store
         shell: bash
         run: |
@@ -75,22 +90,6 @@ jobs:
           E2E_BB_USER:    ${{ secrets.E2E_BB_USER }}
           E2E_GH_TOKEN:   ${{ secrets.E2E_GH_TOKEN }}
           E2E_ADO_TOKEN:  ${{ secrets.E2E_ADO_TOKEN }}
-
-      # ── Step 3: Build and install fleet binary on PM runner ───────────────
-      # Repo is already checked out — build the SEA binary from source so all
-      # three platforms (Windows/Linux/macOS x86_64) work without any artifact
-      # download. The binary name encodes platform+arch via package-sea.mjs.
-      - name: Build fleet binary on PM
-        shell: bash
-        run: |
-          npm ci
-          npm run build:binary
-          BIN=$(ls dist/apra-fleet-installer-* | grep -v '\.exe$\|\.blob$\|\.cjs$\|\.json$' | head -1)
-          [ -z "$BIN" ] && BIN=$(ls dist/apra-fleet-installer-*.exe 2>/dev/null | head -1)
-          chmod +x "$BIN" 2>/dev/null || true
-          sudo cp "$BIN" /usr/local/bin/apra-fleet 2>/dev/null || \
-            cp "$BIN" ~/bin/apra-fleet
-          apra-fleet --version
 
 
       # ── Step 4: Render test script with suite context ─────────────────────
@@ -116,18 +115,23 @@ jobs:
       - name: Run fleet e2e (${{ steps.suite.outputs.pm_provider }})
         shell: bash
         run: |
+          # Resolve fleet binary path and write a runtime mcp config with the
+          # full path — avoids PATH lookup failures in claude's subprocess env.
+          FLEET_BIN=$(which apra-fleet 2>/dev/null || echo "$HOME/.apra-fleet/bin/apra-fleet")
+          printf '{"mcpServers":{"apra-fleet":{"type":"stdio","command":"%s","args":[]}}}\n' "$FLEET_BIN" > mcp-runtime.json
+
           PROVIDER='${{ steps.suite.outputs.pm_provider }}'
           if [ "$PROVIDER" = "claude" ]; then
             claude \
               -p "$(cat rendered-test-script.md)" \
-              --mcp-config .github/e2e/mcp.json \
+              --mcp-config mcp-runtime.json \
               --output-format json \
               --max-turns 80 \
               > raw-output.txt 2>&1
           else
             gemini \
               --output-format stream-json \
-              --mcp-config .github/e2e/mcp.json \
+              --mcp-config mcp-runtime.json \
               -p "$(cat rendered-test-script.md)" \
               > raw-output.txt 2>&1
           fi

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ echo "$TOKEN" | apra-fleet secret --set github_pat --persist -y
 - `provision_vcs_auth` — VCS token fields (GitHub PAT, Bitbucket token, Azure DevOps PAT)
 - `provision_auth` — LLM API key fields
 
-`execute_prompt` does **not** support `{{secure.NAME}}` — secrets must never be passed to LLM prompts. In `execute_prompt`, reference credentials by name only (e.g. `"authenticate using credential github_pat"`); the member resolves the token in its own `execute_command` calls.
+`execute_prompt` does **not** support `{{secure.NAME}}` — secrets must never be passed to LLM prompts. When a task requires a secret, the PM uses `execute_command` with `{{secure.NAME}}` to run the authenticated command directly; members have no access to the credential store or fleet tools.
 
 **Credential store tools:**
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Apra Fleet is an MCP server that agentic coding systems connect to. It manages a
 | `setup_git_app` | One-time setup: register a GitHub App for scoped git token minting |
 | `provision_vcs_auth` | Deploy VCS credentials to a member (GitHub App, Bitbucket, Azure DevOps) |
 | `revoke_vcs_auth` | Remove deployed VCS credentials from a member |
-| `credential_store_set` | Store a secret credential for use in commands (entered OOB — never in chat) |
+| `credential_store_set` | Store a secret credential for use in commands — opens an OOB terminal and blocks until entered (never in chat). Use `apra-fleet secret --set NAME -y` for CI/non-interactive input from stdin. |
 | `credential_store_list` | List stored credential names (values are never returned) |
 | `credential_store_delete` | Delete a stored credential |
 
@@ -328,14 +328,22 @@ Secrets never enter the LLM conversation or logs. Fleet's credential store keeps
 **Three-step workflow:**
 
 ```
-# 1. Store once — Fleet opens an OOB terminal prompt, never asks in chat
-credential_store_set  name=github_pat
+# 1. Store once — Fleet opens an OOB terminal and BLOCKS until you enter the secret.
+#    No "Waiting..." intermediate response. Returns only after you've entered the value:
+#    ✓ github_pat stored [persistent]. Use {{secure.github_pat}} in commands.
+credential_store_set  name=github_pat  persist=true
 
 # 2. Use in execute_command — {{secure.NAME}} is resolved only in commands, never in prompts
 execute_command  command="curl -H 'Authorization: Bearer {{secure.github_pat}}' https://api.github.com/user"
 
 # 3. Output is automatically redacted before it reaches the LLM
 # Output: Authorization: Bearer [REDACTED:github_pat]
+```
+
+**CI / non-interactive usage:** Use the `-y` flag with the CLI to read the secret from stdin instead of opening an OOB terminal window:
+
+```bash
+echo "$TOKEN" | apra-fleet secret --set github_pat --persist -y
 ```
 
 **Tools that support `{{secure.NAME}}` token substitution:**
@@ -352,7 +360,7 @@ execute_command  command="curl -H 'Authorization: Bearer {{secure.github_pat}}' 
 
 | Tool | What it does |
 |------|-------------|
-| `credential_store_set` | Prompt for a secret OOB and store it encrypted under a name |
+| `credential_store_set` | Open an OOB terminal, block until the secret is entered, then store it encrypted under a name. Returns `✓ NAME stored [session/persistent]. Use {{secure.NAME}} in commands.` |
 | `credential_store_list` | List stored credential names — values are never returned |
 | `credential_store_delete` | Remove a stored credential by name |
 
@@ -497,6 +505,7 @@ When registering a remote member with password authentication, you don't need to
 - Works on macOS (Terminal.app), Windows (cmd), and Linux (gnome-terminal/xterm)
 - Headless or unsupported environments get a manual command fallback
 - Supports password rotation via `update_member`
+- On Windows, closing the OOB window returns immediately with a cancellation message — no longer hangs
 
 See [`docs/adr-oob-password.md`](docs/adr-oob-password.md) for the design rationale.
 

--- a/docs/adr-oob-password.md
+++ b/docs/adr-oob-password.md
@@ -36,10 +36,10 @@ Add a **Unix domain socket side-channel** with an **auto-launched terminal promp
 1. Starts a UDS listener at `~/.apra-fleet/data/auth.sock`
 2. Creates a pending auth request keyed by member name
 3. Auto-launches a new terminal window running `apra-fleet auth <member-name>`
-4. **Blocks** — the tool handler awaits a Promise that resolves when the password arrives
+4. **Blocks** — the tool handler awaits a Promise that resolves only when the credential arrives over the socket (or a cancellation fires). It does **not** return a "Waiting..." intermediate result and does not require a second call from the LLM.
 5. The user sees a password prompt in the new window, types the password (hidden input)
 6. The password flows over the socket to the MCP server, resolving the waiting Promise
-7. Registration continues and completes — all in a single tool call
+7. Registration continues and completes — all in a single tool call. On success the tool returns `✓ NAME stored [session/persistent]. Use {{secure.NAME}} in commands.`
 
 The key insight: the MCP server itself launches the terminal and blocks until the password arrives over the socket, so Claude only sees the final registration result — never the password. No retry needed.
 
@@ -240,6 +240,7 @@ unnecessarily.
 | User provides password param AND runs CLI | Password param wins, pending request ignored |
 | No display / headless server | `launchAuthTerminal` catches failure, returns manual instructions |
 | Terminal emulator not found (Linux) | Falls through gnome-terminal → xterm → x-terminal-emulator → manual fallback |
+| User closes OOB window (Windows) | Close-signal handler resolves the pending Promise with a cancellation error immediately — no 5-minute hang |
 
 ## Test Coverage
 

--- a/docs/features/oob-auth.md
+++ b/docs/features/oob-auth.md
@@ -20,8 +20,8 @@ The fleet server creates a socket at `~/.apra-fleet/data/auth.sock` (Linux/macOS
 2. `collectOobInput` registers a pending auth request with a 10-minute TTL via `createPendingAuth()`.
 3. It calls `launchAuthTerminal()` to open a terminal window running `apra-fleet auth <memberName>`.
 4. The launched process prompts the user, reads input with masked display (LLM cannot see it), and sends the value over the UDS as a JSON message.
-5. `waitForPassword()` races the socket delivery against a cancellation signal.
-6. On receipt, the credential is consumed from the pending store and returned to the caller.
+5. `collectOobInput` **blocks** — `waitForPassword()` awaits a Promise that resolves only when the credential arrives over the socket (or a cancellation/timeout fires). The call does not return early with a "Waiting..." status.
+6. On receipt, the credential is consumed from the pending store and returned to the caller. The tool call then completes with a success message of the form `✓ NAME stored [session/persistent]. Use {{secure.NAME}} in commands.`
 
 **Key property:** The UDS socket is a filesystem object — no GUI or display server is required to write to it. Any process on the machine, including one launched in a second SSH terminal, can deliver credentials.
 
@@ -67,6 +67,8 @@ export function hasInteractiveDesktop(): boolean {
 Probing (attempting a spawn and checking exit code) is what caused the misleading error in the first place. Env var checks are fast, zero-side-effect, and accurate for the cases that matter: X11/Wayland forwarding sets `$DISPLAY`, and Windows service contexts have a distinct `SESSIONNAME`.
 
 Edge case accepted: X11 forwarding where `$DISPLAY` is set but the forwarded display is unreachable. This is acceptable — if the terminal fails to launch, existing fallback logic catches it, and a user with X11 forwarding active almost certainly has a working display.
+
+**Windows OOB window close:** Closing the OOB terminal window on Windows now returns immediately with a cancellation message. Previously, closing the window caused the tool call to hang for up to 5 minutes waiting for a password that would never arrive. The fix attaches a close-signal handler so that window dismissal resolves the pending Promise with a cancellation error immediately.
 
 ---
 

--- a/docs/requirements/oob-credential-collection.md
+++ b/docs/requirements/oob-credential-collection.md
@@ -1,142 +1,69 @@
-# Requirements: OOB Credential Collection Unification
+# OOB Credential Collection
 
-## Context
-
-Secret/password collection from the user currently has two divergent code paths:
-
-1. `src/cli/secret.ts` — `apra-fleet secret --set NAME` — has the full reveal UX (already implemented)
-2. `src/cli/auth.ts` — `apra-fleet auth <name>` — bare `secureInput()`, no reveal UX
-
-Both are spawned as OOB terminal subprocesses by `auth-socket.ts`. The split is arbitrary:
-- The fleet server blocks in both cases (via socket wait)
-- API keys already route through `secret --set`; SSH passwords route through `auth` — inconsistent
-- The reveal UX lives inline in `handleSet()` in `secret.ts` rather than as a shared utility
-
-**Goal:** One shared `collectSecret()` function used by all credential collection paths. The `auth` subcommand handles `--confirm` (network egress yes/no) only — it is NOT a credential collection path.
+Out-of-band (OOB) credential collection is how fleet gathers secrets from the user without ever exposing them to the LLM, chat history, or logs. When a tool needs a secret it doesn't have, fleet opens a separate terminal window on the user's desktop, waits for input, and receives the value over a local socket — the secret never passes through the server's main process or any log file.
 
 ---
 
-## Credential Cases
+## When OOB Is Triggered
 
-### Named / Persistent
-User explicitly sets or updates a stored credential.
-- Entry: `apra-fleet secret --set <NAME>`
-- After collection: stored in credential vault
+OOB collection is triggered in two situations:
 
-### Anonymous / Transient
-A tool call needs a credential inline (SSH password, API key, token). Collected OOB, delivered over socket, discarded.
-- Entry: OOB terminal spawned automatically → `apra-fleet secret --set <NAME> --prompt "<context>"`
-- `--prompt` overrides the display text so the user sees human-readable context:
-  - SSH: `"SSH password for akhil@192.168.1.102"`
-  - GitHub PAT: `"Enter your GitHub PAT"`
-  - API key: `"Enter API key for claude"`
+**Explicit storage** — the user directly asks fleet to store a credential:
+```
+apra-fleet secret --set MyPass
+```
+
+**Implicit / on-demand** — a tool call needs a credential it doesn't have:
+- `register_member` with SSH password auth and no password provided → OOB opens with the SSH context as the prompt
+- Any `{{secure.NAME}}` reference where `NAME` is not yet in the store → OOB opens, user is asked whether to persist the value after entry
+- `credential_store_set` tool call → OOB always opens
+
+In all cases the UX is identical — only the prompt text changes to give the user context about what they're entering.
 
 ---
 
-## UX — Already Implemented in `secret.ts`
+## The Collection UX
 
-The reveal loop (v/Esc/Enter, in-place ANSI, dim hints) is already built and working in `handleSet()`. This is the reference implementation to extract into `collectSecret()` — do not change the behaviour.
+A terminal window opens with a masked input field. The prompt describes what is being collected (e.g. `SSH password for akhil@192.168.1.102` or `Enter value for MyPass`).
 
----
+To avoid typing errors, users can press **v** to reveal the entered value in place before confirming. Pressing **Esc** clears the field and re-enters from scratch. Pressing **Enter** confirms.
 
-## What Needs to Be Built
-
-### 1. `src/utils/oob-timeout.ts` — new
-```typescript
-export const OOB_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-```
-Single source of truth. Imported by both `auth-socket.ts` and `collect-secret.ts`. No other timeout values for OOB credential collection may be hardcoded.
-
-### 2. `src/utils/collect-secret.ts` — new
-Extract the reveal loop out of `handleSet()` verbatim into:
-```typescript
-export async function collectSecret(prompt: string): Promise<string>
-```
-Add one thing not currently in `handleSet()`: an inactivity timeout using `OOB_TIMEOUT_MS`:
-```typescript
-const timeout = setTimeout(() => {
-  process.stderr.write('\n  ⏱ Timed out. Closing.\n');
-  process.exit(1); // treated identically to Ctrl+C by the server
-}, OOB_TIMEOUT_MS);
-// ... collect ...
-clearTimeout(timeout); // clear on successful entry
-```
-
-### 3. `src/cli/secret.ts` — two changes
-- Add `--prompt <text>` flag: when present, use it as the display prompt instead of `"Enter value for <NAME>: "`
-- Replace the inline reveal loop in `handleSet()` with `collectSecret(prompt)`
-- Everything else (persist logic, socket delivery) unchanged
-
-### 4. `src/cli/auth.ts` — strip to `--confirm` only
-Remove the password/API key collection branches entirely. Only the `--confirm` (network egress yes/no) handler remains.
-
-### 5. `src/services/auth-socket.ts` — three changes
-
-**a) `getAuthCommand()` — unify routing**
-Currently routes SSH passwords to `auth <name>` and API keys to `secret --set <name>`. Route ALL credential collection to:
-```
-secret --set <name> [--prompt "<context>"] [--ask-persist]
-```
-Remove the `auth` routing for password/API key modes.
-
-**b) `waitForPassword()` — kill PID on timeout**
-When the timeout fires, kill the spawned terminal before rejecting:
-```typescript
-const pending = pendingRequests.get(memberName);
-if (pending?.spawned_pid) killProcess(pending.spawned_pid);
-```
-Also fix existing bug: `spawned_pid` is currently only stored for API key mode (lines 584, 600). Store it for ALL credential collection modes.
-
-**c) Add `cancelPendingAuth(memberName)` — new export**
-```typescript
-export function cancelPendingAuth(memberName: string): void {
-  const pending = pendingRequests.get(memberName);
-  if (pending?.spawned_pid) killProcess(pending.spawned_pid);
-  const waiter = passwordWaiters.get(memberName);
-  if (waiter) { clearTimeout(waiter.timer); waiter.reject(new Error('cancelled')); }
-  passwordWaiters.delete(memberName);
-  pendingRequests.delete(memberName);
-}
-```
-
-### 6. `src/tools/stop-prompt.ts`
-Call `cancelPendingAuth(memberName)` when stopping a member's prompt session, so any waiting OOB terminal is also killed.
+If the terminal is left idle for 5 minutes without input it closes automatically — the waiting tool call fails cleanly, the same as if the user had pressed Ctrl+C.
 
 ---
 
-## OOB Wait Exit Conditions
+## How the Secret Is Delivered
 
-All conditions reduce to: **kill spawned PID → waiter resolved/rejected → pending request cleared**.
+Once confirmed, the value is sent over a local socket directly to the waiting fleet server process. It is never written to disk unencrypted, never appears in any log, and is zeroed from memory immediately after delivery. The terminal closes.
 
-| # | Condition | Who handles it |
-|---|-----------|----------------|
-| 1 | User enters value | Subprocess delivers via socket → waiter resolved |
-| 2 | User Ctrl+C | Subprocess exits code 1 → cancellationPromise rejects |
-| 3 | `secret --set` from another terminal | Any process delivers via socket → waiter resolved |
-| 4 | Server-side timeout | `waitForPassword` timer → `killProcess(spawned_pid)` → waiter rejected |
-| 5 | LLM StopTask / MCP disconnect | `cancelPendingAuth()` → `killProcess(spawned_pid)` → waiter rejected |
-| 6 | Subprocess inactivity | `setTimeout(process.exit(1), OOB_TIMEOUT_MS)` in `collectSecret()` → same as case 2 |
+If the user opts to persist the value (either via `--persist` flag or when prompted), it is encrypted and stored in the local credential vault. Persisted credentials are referenced as `{{secure.NAME}}` in subsequent tool calls.
 
 ---
 
-## Files to Change
+## Persistence and Network Policy
 
-| File | Change |
-|------|--------|
-| `src/utils/oob-timeout.ts` | **new** — `OOB_TIMEOUT_MS` constant |
-| `src/utils/collect-secret.ts` | **new** — extract reveal loop + add inactivity timeout |
-| `src/cli/secret.ts` | add `--prompt` flag; call `collectSecret()` |
-| `src/cli/auth.ts` | strip to `--confirm` only |
-| `src/services/auth-socket.ts` | unify routing; store `spawned_pid` always; kill PID on timeout; add `cancelPendingAuth` |
-| `src/tools/stop-prompt.ts` | call `cancelPendingAuth` on stop |
-| `tests/secret-cli.test.ts` | mock `collectSecret` instead of inline stdin stubs |
-| `tests/auth-socket.test.ts` | update command assertions; add tests for `cancelPendingAuth`, PID kill on timeout |
+A credential can be **session-only** (discarded after delivery) or **persistent** (survives server restarts). When stored persistently, a **network policy** controls how it may be used:
+
+| Policy | Effect |
+|--------|--------|
+| `allow` (default) | No restriction — credential can be used in any command |
+| `confirm` | Fleet prompts before allowing a command that uses this credential to make network calls |
+| `deny` | Commands that would make network calls while using this credential are blocked |
+
+The policy can be updated at any time without re-entering the secret:
+```
+apra-fleet secret --update MyPass --deny
+```
 
 ---
 
-## What Does NOT Change
+## Exit Conditions
 
-- The reveal UX behaviour (already correct in `secret.ts`)
-- The socket protocol (IPC between subprocess and server)
-- The `--confirm` (network egress) flow
-- The `--persist` and `--ask-persist` flags on `secret --set`
+The OOB wait resolves in any of these ways — all are handled identically by the server:
+
+1. **User enters value** — delivered via socket, waiter resolved, terminal closes
+2. **User presses Ctrl+C** — terminal exits, tool call fails with a clear error
+3. **Value delivered from another terminal** — another `apra-fleet secret --set NAME` call delivers the value; the auto-spawned terminal is closed automatically
+4. **Server-side timeout** — server gives up after 5 minutes, closes the terminal, tool call fails
+5. **LLM session stopped** — if the session that triggered OOB is cancelled, the terminal is killed immediately
+6. **Subprocess inactivity** — terminal auto-closes after 5 minutes of no input (same outcome as Ctrl+C)

--- a/docs/secure-variable-usecases.md
+++ b/docs/secure-variable-usecases.md
@@ -185,5 +185,19 @@
 ## Observations
 
 - Delivery vs. persistence: Running `apra-fleet secret --set NAME` without `--persist` delivers to a waiting OOB request but does NOT store in the vault. `{{secure.NAME}}` requires vault storage — use `--persist`.
-- `credential_store_set` with `persist=true` stores immediately and returns a handle (`sec://NAME`) without waiting for OOB entry if the value was already delivered.
+- `credential_store_set` **blocks** — when called, the tool opens an OOB terminal and waits synchronously for the user to enter the secret. It does not return a "Waiting..." intermediate status or require a second call. On success it returns `✓ NAME stored [session/persistent]. Use {{secure.NAME}} in commands.`
 - Failed resolution is always explicit — the tool returns an error and aborts. No silent pass-through of the token string.
+
+## CI / Non-Interactive Usage
+
+For CI pipelines or scripts where interactive input is unavailable, use the `-y` flag with `apra-fleet secret --set` to read the value from stdin instead of opening an OOB terminal:
+
+```bash
+# Store a secret non-interactively (value from stdin)
+echo "$TOKEN" | apra-fleet secret --set github_pat --persist -y
+
+# Pipe from a file or command substitution
+cat ~/.token | apra-fleet secret --set deploy_key --persist -y
+```
+
+The `-y` flag bypasses OOB terminal launch entirely — the value is read from stdin and stored directly. This is safe in CI because stdin is already a controlled, non-LLM channel. The same success message is returned: `✓ github_pat stored [persistent]. Use {{secure.github_pat}} in commands.`

--- a/docs/test-audit-report.md
+++ b/docs/test-audit-report.md
@@ -1,0 +1,369 @@
+# Test Suite Audit Report
+Generated: 2026-05-09
+
+## Summary
+- Files audited: 76
+- Dead tests: 26
+- Duplicate tests: 28
+- Implementation-detail tests: 98
+- Tests to add (coverage gaps): 12
+
+## Findings by File
+
+### tests/cost.test.ts
+#### Implementation Details
+- Line 35: "high-cost warning references dollar amount (consistent with COST_WARNING_THRESHOLD)" — asserts `COST_WARNING_THRESHOLD === 10` (literal constant value); regex assertion duplicates line 32
+- Line 42: "returns rate warning for expensive instance types" — embeds `expect(RATE_WARNING_THRESHOLD).toBe(5)` (constant value assertion)
+- Line 68: "returns anomaly warning for long sessions" — embeds `expect(UPTIME_WARNING_THRESHOLD_HRS).toBe(12)` (constant value assertion)
+
+### tests/credential-validation.test.ts
+#### Implementation Details
+- Line 35: "returns near-expiry with 1 minute left" — tests internal `Math.ceil` rounding (`30s → minutesLeft: 1`), not a distinct behavioral case from the "at 59 minutes" test
+
+### tests/crypto.test.ts
+#### Implementation Details
+- Line 41: "creates and reuses a per-installation key file" — reads internal `salt` file path directly, checks hex format — tests private key-storage internals, not observable encrypt/decrypt contract
+
+### tests/git-config.test.ts
+#### Dead
+- Line 50: "saves with restrictive file permissions" — `if (process.platform !== 'win32') return;` makes the 0o600 assertion a no-op on Windows
+
+### tests/github-app.test.ts
+#### Implementation Details
+- Line 56: "produces a verifiable RS256 signature" — generates two RSA key pairs that are never used; verifies signature using the signing key as its own verifier (internal mechanism, not API contract)
+
+### tests/install-force.test.ts
+#### Implementation Details
+- Line 247: "killApraFleet calls pkill -x apra-fleet on Linux" — verifies exact `pkill -x apra-fleet` shell string rather than observable effect
+- Line 255: "killApraFleet calls taskkill on Windows" — verifies exact `taskkill /F /IM apra-fleet.exe` shell string
+
+### tests/install-multi-provider.test.ts
+#### Implementation Details
+- Line 337: "writes defaultModel for Claude (claude-sonnet-4-6) to settings.json" — tests the literal value of a config constant; breaks on intentional model renames
+- Line 352: "writes defaultModel for Gemini (gemini-3-flash-preview) to settings.json" — same
+- Line 366: "writes defaultModel for Codex (gpt-5.4) to config.toml" — same
+- Line 402: "writes defaultModel for Copilot (claude-sonnet-4-5) to settings.json" — same
+#### Duplicates
+- Lines 418 + 441 + 549: "--skill alone" / "--skill all" / "bare install" — all three assert identical `mkdirSync` calls for both skill dirs
+- Lines 572 + 587: "--skill none" / "--skill=none (equals form)" — identical assertions (no skill dirs created)
+- Lines 464 + 503: "--skill fleet" / "--skill=fleet (equals form)" — identical assertions
+- Lines 480 + 518: "--skill pm" / "--skill=pm (equals form)" — identical assertions
+- Lines 619 + 633: "--help" / "-h" — `-h` test is a strict subset of `--help` test
+- Lines 152 + 160: "errors on unsupported provider" / "errors on unsupported provider via space form" — identical exit-1 assertion
+
+### tests/known-hosts.test.ts
+#### Dead
+- Line 109: "writes known_hosts file with mode 0o600" — `if (process.platform === 'win32') return;` makes the assertion a no-op on Windows
+
+### tests/onboarding-text.test.ts
+#### Implementation Details
+- Line 13: "contains the ASCII art header line" — tests a literal substring of a UI string constant; breaks on copy/design changes
+- Line 17: "contains the tagline" — same
+- Line 21: "contains the separator lines" — same
+- Line 27: "covers adding a member" — tests literal copy in a UI string constant
+- Line 30: "covers giving it work with natural language examples" — same
+- Line 34: "covers checking status" — same
+- Line 37: "does not include the /pm step" — tests absence of specific text in a UI string constant
+
+### tests/ssh-error-messages.test.ts
+#### Implementation Details
+- Line 43: "hook does not fire on SSH connection failure (❌ result)" — tests internal `❌` string-based gating in `getOnboardingNudge`; also placed in the wrong test file
+
+### tests/task-wrapper.test.ts
+#### Implementation Details
+- Line 11: "output contains no python3 reference" — regression guard for internal command choice
+- Line 17: "uses grep + cut to extract started timestamp" — verifies internal shell parsing technique, not observable outcome
+- Line 23: "has fallback to date if started is empty" — verifies internal `[ -z ]` fallback string, not observable behavior
+- Line 33: "MAIN_CMD and RESTART_CMD are same base64 when restartCommand is omitted" — checks internal base64-variable naming
+- Line 41: "MAIN_CMD and RESTART_CMD are different when restartCommand is provided" — same
+- Line 54: "first run uses MAIN_CMD" — checks internal bash variable name
+- Line 60: "retry loop uses RESTART_CMD" — checks internal bash variable name
+
+### tests/windows-credential-helper.test.ts
+#### Implementation Details
+- Line 7: "produces valid PowerShell without here-string delimiters" — regression guard for absent internal syntax (`@'...'@`)
+- Line 43: "uses -join to build multi-line bat content" — checks internal PowerShell `-join` operator usage
+
+### tests/unit/pid-wrapper.test.ts
+#### Dead
+- Line 72: "emits FLEET_PID as first stdout line before command output" (unixTest) — `it.skip` on Windows
+- Line 81: "emitted PID is a positive integer" (unixTest) — `it.skip` on Windows
+- Line 90: "propagates exit code 0 from successful inner command" (unixTest) — `it.skip` on Windows
+- Line 95: "propagates non-zero exit code from inner command" (unixTest) — `it.skip` on Windows
+#### Implementation Details
+- Line 16: "uses a captured variable for the PID" — tests internal variable name `_fleet_pid`
+- Line 20: "backgrounds the inner command in a subshell" — tests internal subshell-backgrounding mechanism
+- Line 24: "waits for the background process" — tests `wait` string in script
+- Line 28: "propagates exit code with exit $?" — tests `exit $?` string
+- Line 31: "emits PID before wait in command order" — tests internal script ordering via `indexOf`
+- Line 56: "places setup commands before ProcessStartInfo" — tests internal .NET class name ordering
+#### Duplicates
+- Lines 108 + 113: "returns kill -9 command with the given PID" / "works for PID 1" — same structural assertion, only integer differs
+- Lines 120 + 124: "returns taskkill command with force and tree flags" / "includes /T to terminate child processes" — `/T` check is a strict subset
+
+### tests/cloud-integration.test.ts
+#### Implementation Details
+- Line 232: "uses restart_command: wrapper script contains both base64-encoded commands" — calls `generateTaskWrapper` directly and asserts base64 string contents (internal encoding detail)
+
+### tests/cloud-lifecycle.test.ts
+#### Implementation Details
+- Line 84: "calls ensureCloudReady even for non-cloud members (returns unchanged)" — asserts internal call pattern, not observable behavior
+
+### tests/cloud-provider.test.ts
+#### Implementation Details
+- Lines 48–51, 76–83, 87–91, 99–110, 118–127: Multiple tests asserting `exec.mock.calls[1][0]` contains specific CLI substrings (`describe-instances`, `start-instances`, `stop-instances`, `--output text`, `--profile`) — pins exact shell command strings; breaks if implementation switches from CLI to SDK
+- Line 173: "caches CLI check — only calls aws --version once across multiple operations" — counts internal raw exec calls to verify an optimization detail
+
+### tests/credential-cleanup.test.ts
+#### Implementation Details
+- Line 75: "schedules a timer with default 55-minute TTL when no expiresAt" — peeks at internal `_getCleanupTimers()` Map
+- Line 80: "schedules timer based on expiresAt" — identical internal map assertion
+- Line 118: "cancels previous timer when re-provisioning same member" — compares internal `NodeJS.Timeout` object references
+- Line 129: "multiple agents have independent timers" — asserts internal map size and membership
+- Line 150: "cancels the timer and removes from map" — asserts internal map state instead of behavioral outcome
+#### Duplicates
+- Lines 75 + 80: Both assert only `_getCleanupTimers().has('member-1') === true` — identical observable assertion
+
+### tests/credential-store-and-execute.test.ts
+#### Duplicates
+- Line 80: "credentialDelete removes from both session and persistent tiers (M1)" — the set/resolve/delete/verify-gone pattern is identical to "set, list, delete a session credential" (line 46); cannot test the claimed two-tier deletion because `credentialSet(name, ..., false, ...)` only writes to session tier
+
+### tests/idle-manager.test.ts
+#### Implementation Details
+- Line 130: "is wired into touchAgent via setIdleTouchHook" — extracts internal mock call to verify hook registration; final assertion `typeof hookFn === 'function'` is trivially true
+- Line 90: "R-9: preloads lastActivity from registry so recently-active members are not stopped" — test name references private field `lastActivity`; assertions are behavioral but design is oriented around internal mechanism
+
+### tests/integration.test.ts
+#### Dead
+- Entire file: No vitest `describe`/`it` blocks; excluded from vitest config via `exclude: ['tests/integration.test.ts']`; requires live SSH infrastructure. This is a script-style e2e harness, not a vitest test file.
+
+### tests/integration/session-lifecycle.test.ts
+#### Dead
+- Line 141: "returns fallback with actual member name when DISPLAY is unset on Linux" — bare `if (process.platform !== 'linux') return;` — never fires on Windows
+- Line 170: "does not return the headless-display fallback when DISPLAY is set on Linux" — same
+- Line 192: "returns fallback on macOS when SSH_TTY is set" — bare `if (process.platform !== 'darwin') return;` — never fires on Windows
+
+### tests/log-helpers.test.ts
+#### Implementation Details
+- Line 60: "field order: ts, level, tag, msg (no mid/mem/pid when omitted)" — asserts exact JSON key insertion order (`Object.keys(lines[0]).toEqual([...])`) which is an internal formatting detail
+
+### tests/onboarding.test.ts
+#### Dead
+- Line 128: "writes onboarding.json with 0o600 permissions (owner-only, non-Windows)" — bare `if (process.platform === 'win32') return;` makes it a no-op on Windows
+#### Duplicates
+- Lines 177 + 183: "returns true for unset milestones" / "returns false for set milestones" — already fully covered by `advanceMilestone` describe block (lines 146–152)
+
+### tests/provision-auth.test.ts
+#### Implementation Details
+- Line 172: "prompts OOB when api_key is absent for non-OAuth provider" — `expect(mockCollectOobApiKey).toHaveBeenCalledWith(...)` verifies internal OOB dispatch mechanism rather than observable outcome
+
+### tests/provision-vcs-auth.test.ts
+#### Implementation Details
+- Line 288: "github: pat mode prompts OOB when token is absent" — asserts `expect(mockCollectOobApiKey).toHaveBeenCalledWith(...)` (internal OOB dispatch)
+- Line 305: "bitbucket: prompts OOB when api_token is absent" — same
+- Line 323: "azure-devops: prompts OOB when pat is absent" — same
+
+### tests/remove-member-decomm.test.ts
+#### Implementation Details
+- Line 93: "calls cancelCredentialCleanup before removing" — verifies a specific private service function was invoked
+- Line 102: "revokes VCS auth for remote member with vcsProvider" — asserts internal `revoke()` method was called rather than observable `✅` result
+- Line 128: "attempts authorized_keys cleanup for remote member with keyPath" — verifies internal command list sent to `mockExecCommand`
+
+### tests/revoke-vcs-auth.test.ts
+#### Implementation Details
+- Lines 44–58: "github/bitbucket/azure-devops: revokes credentials successfully" — assert exact internal shell command content (`fleet-git-credential`, `credential.https://`)
+- Line 61: "revoke with label targets only that label credential file" — asserts internal file-naming conventions in shell commands
+- Line 75: "revoke without label defaults to provider-named label" — verifies internal default label naming in generated command
+
+### tests/security-hardening.test.ts
+#### Dead
+- Line 18: "writes registry with mode 0o600 (non-Windows)" — bare `if (process.platform === 'win32') return;` makes it a no-op on Windows
+#### Implementation Details
+- Line 295: "Linux: generates proper commands with escapeShellArg" — verifies internal shell command string formats
+- Line 309: "Linux: escapes single quotes in key comments" — same
+- Line 319: "Windows: generates proper commands" — same
+- Line 335: "Windows: escapes single quotes in key" — same
+
+### tests/strategy.test.ts
+#### Implementation Details
+- Line 132: "execCommand() passes windowsHide:true to spawn to suppress cmd.exe flashes on Windows" — reads the TypeScript source file and checks that string `windowsHide: true` appears in source text (source-code inspection test, not behavioral)
+
+### tests/tool-provider.test.ts
+#### Implementation Details
+- Lines 171–186: "provisions claude/gemini/codex/copilot API key using correct env var" — verifies internal shell command strings contain provider's auth env var name
+- Line 219: "uses gemini version command when member is gemini provider" — asserts `gemini` appears in internal command strings
+
+### tests/unattended-mode.test.ts
+#### Implementation Details
+- Line 205: "does NOT pass --dangerously-skip-permissions when dangerously_skip_permissions=true but member.unattended=false" — asserts internal CLI command string content
+- Line 228: "passes --dangerously-skip-permissions when member.unattended='dangerous'" — same
+- Line 250: "passes --permission-mode auto when member.unattended='auto'" — same
+
+### tests/vcs-auth.test.ts
+#### Implementation Details
+- Line 42: "deploy: github-app mode mints token and writes credential helper" — verifies exact internal shell command strings (`github.com`, `x-access-token`)
+- Line 63: "deploy: pat mode deploys token directly without minting" — verifies token in internal command and asserts `mockMint` not called
+- Lines 179–259: Multiple tests in "Multi-label credential isolation" — all assert `execCalls[N].toContain(...)` checking internal shell command strings for file naming patterns
+
+### tests/execute-command.test.ts
+#### Implementation Details
+- Line 39: "wraps command with work folder" — asserts exact call signature of `mockExecCommand` including positional `undefined` (for `maxTotalMs`)
+- Line 53: "uses custom run_from when provided" — same; any argument reordering breaks these tests
+
+### tests/receive-files.test.ts
+#### Dead
+- Lines 6 + 11: `vi.mock('../src/services/registry.js')` and `registry` import — dead mock; `receive-files.ts` doesn't import `registry` directly
+#### Implementation Details
+- Line 58: "Remote member: downloads via SFTP" — verifies internal SFTP function is invoked with exact arguments through two layers of private delegation
+
+### tests/windows-pid-wrap.test.ts
+#### Implementation Details
+- Line 34: "contains ProcessStartInfo" — checks internal .NET API class name in generated script
+- Line 38: "contains UseShellExecute = $false" — checks internal PowerShell flag
+- Line 42: "does not contain Start-Process" — checks absence of internal cmdlet
+- Line 46: "launches via [System.Diagnostics.Process]::Start" — checks internal .NET method call
+- Line 50: "contains WaitForExit" — checks internal .NET method
+- Line 54: "contains exit $_fleet_proc.ExitCode" — checks internal variable and property
+- Line 58: "uses $_fleet_proc as the process variable" — checks internal variable name
+- Line 147: "uses direct shell execution to launch the claude executable" — checks internal `FLEET_PID:$pid` format
+#### Duplicates
+- Lines 72 + 77 + 82: "does not contain FLEET_PID:$PID in buildAgentPromptCommand" for unattended=false/auto/dangerous — all three make the same assertion; PID format doesn't vary with unattended flag
+
+### tests/compose-permissions.test.ts
+#### Implementation Details
+- All tests in "Claude proactive", "Gemini proactive", "Codex proactive", "Copilot proactive", "Claude reactive grant", "Gemini reactive grant" describe blocks — assertions check `allCmds.filter(cmd => cmd.includes('cat >'))` and inspect shell command string content. Pins exact format of shell commands sent to `mockExecCommand`.
+- Line 446: "does not crash when permissions.json exists but contains only {}" — uses `vi.spyOn(fs, 'existsSync')` with complex conditional mock tightly coupled to internal `findProfilesDir()` candidate paths
+
+### tests/sftp-path-resolution.test.ts
+#### Dead
+- Lines 15–96: Entire file (6 tests) — imports nothing from `src/`. Tests `path.posix.resolve` from Node.js stdlib to document an old bug. The bug is already fixed in `src/utils/platform.ts` (`resolveRemotePath`). Does not exercise the fix.
+
+### tests/update-check.test.ts
+#### Dead
+- Line 159: "compact output includes update notice when update available" — imports `fleetStatus` but never calls it; only calls `getUpdateNotice()` which is already fully covered by other tests in the same file
+
+### tests/read-log-tail.test.ts
+#### Implementation Details
+- Line 58: "calls logLine before issuing execCommand" — asserts internal log tag string `'stall_log_read'`
+- Line 67: "calls execCommand with tail command and 5000ms timeout" — asserts exact shell string `tail -c 512`
+
+### tests/stall-detector.test.ts
+#### Implementation Details
+- Line 115: "start sets interval" — spies on `global.setInterval` and asserts it was called; pins internal scheduling mechanism
+
+### tests/stall-poller.test.ts
+#### Implementation Details
+- Line 127: "uses tail -c 500 on Unix" — asserts exact shell command `tail -c 500`
+- Line 136: "uses PowerShell Get-Content -Tail on Windows" — asserts exact PowerShell command string
+
+### tests/auth-socket.test.ts
+#### Dead
+- Line 26: "returns a path under FLEET_DIR on non-Windows" — body gated `if (process.platform !== 'win32')`, zero assertions on Windows
+- Line 210: "cleans up socket file on close" — all meaningful assertions inside `if (process.platform !== 'win32')`, zero assertions on Windows
+- Line 557: "returns fallback with member name on Linux when DISPLAY is unset" — `if (process.platform !== 'linux') return;`, zero assertions on Windows
+- Line 568: "returns fallback with member name on Windows when SESSIONNAME is not Console" — `if (process.platform !== 'win32') return;`, zero assertions on non-Windows
+- Line 578: "returns fallback with actual member name substituted (not a placeholder)" — `if (process.platform !== 'linux') return;`, zero assertions on Windows
+
+### tests/providers.test.ts
+#### Implementation Details
+- Line 26: "has correct metadata" (ClaudeProvider) — asserts literal constant values of `name`, `processName`, `authEnvVar`, `credentialPath`, `instructionFileName`
+- Line 204: "has correct metadata" (GeminiProvider) — same
+- Line 389: "has correct metadata" (CodexProvider) — same
+- Line 500: "has correct metadata" (CopilotProvider) — same
+- Line 700: "member without llmProvider uses ClaudeProvider" — tests `undefined ?? 'claude'` written inside the test body, not any src function; already covered by `getProvider factory` tests
+#### Duplicates
+- Lines 149 + 154: "maps model tiers" / "modelTiers() returns cheap/standard/premium mapping" (ClaudeProvider) — `modelForTier(tier)` and `modelTiers()[tier]` must return the same string by definition
+- Lines 323 + 326: Same pair for GeminiProvider
+- Lines 441 + 444: Same pair for CodexProvider
+- Lines 592 + 595: Same pair for CopilotProvider
+
+### tests/secret-cli.test.ts
+#### Dead
+- Line 355: "exits 1 for invalid name" (under `--update`) — passes `'bad-name'` expecting rejection, but `NAME_REGEX = /^[a-zA-Z0-9_-]{1,64}$/` accepts hyphens. Test expectation contradicts actual src regex.
+
+## Coverage Gaps
+
+### src/tools/credential-store-set.ts — no test file exists
+The entire file was rewritten. No `tests/credential-store-set.test.ts` exists. Key paths to cover:
+- `collectOobApiKey` call and fallback handling (line 25–28)
+- `decryptPassword` on the received password (line 30)
+- `members` parsing: `'*'` stays as `'*'`, otherwise comma-split with trim/filter (lines 31–33)
+- `credentialSet` call with all parameters including `ttl_seconds` (line 34)
+- `logLine` called after successful store (line 35)
+- Success message format with `meta.name`, `meta.scope`, `{{secure.NAME}}` hint (line 36)
+- Error path when no password received (line 28)
+
+### src/cli/secret.ts — -y flag (nonInteractive mode)
+- Line 175: `-y` flag sets `nonInteractive = true`
+- Lines 191–210: When `-y` is set, reads from `process.stdin` directly (data chunks, trims, exits 1 if empty)
+- No test covers the `-y` / `nonInteractive` stdin-reading path
+
+### src/services/auth-socket.ts — 500ms grace period
+- Lines 354–368: When the cancellation promise resolves `null` (terminal exited code 0), a 500ms `Promise.race` determines if the password arrived in time
+- The 500ms timeout → fallback path is not covered by any test
+- The detached cleanup logic (lines 364–366) in the catch block is not tested
+
+### src/tools/provision-auth.ts — logLine post-success placement
+- Lines 258, 265, 275: `logLine` is only called when `!result.startsWith('❌')`
+- No test verifies that `logLine` is NOT called on failure, or that it IS called on success with the correct arguments
+
+## Recommended Additions
+
+### 1. tests/credential-store-set.test.ts (new file)
+- **"returns fallback message when OOB terminal is unavailable"** — mock `collectOobApiKey` to return `{ fallback: 'no terminal' }`, verify the fallback string is returned
+- **"returns error when no password received"** — mock `collectOobApiKey` to return `{}` (no password, no fallback), verify error message
+- **"decrypts password and stores credential with correct parameters"** — mock `collectOobApiKey` to return `{ password: encryptedValue }`, verify `decryptPassword` called, `credentialSet` called with `(name, plaintext, persist, network_policy, allowedMembers, ttl_seconds)`
+- **"parses members='*' as wildcard"** — pass `members: '*'`, verify `credentialSet` called with `'*'`
+- **"parses comma-separated members list"** — pass `members: 'alice, bob, ,charlie'`, verify `credentialSet` called with `['alice', 'bob', 'charlie']`
+- **"returns success message with name, scope, and secure template hint"** — verify returned string contains `name`, scope indicator, and `{{secure.NAME}}`
+- **"calls logLine after successful store"** — verify `logLine('credential_store_set', ...)` called after `credentialSet`
+- **"schema validates name regex"** — pass names with invalid characters, verify zod parse fails
+- **"schema enforces positive ttl_seconds"** — pass `ttl_seconds: 0` and `ttl_seconds: -1`, verify zod parse fails
+
+### 2. tests/secret-cli.test.ts — -y flag coverage
+- **"reads secret from stdin when -y is passed"** — mock `process.stdin` with a readable stream that emits data, verify `credentialSet` or socket delivery receives the value
+- **"exits 1 when -y is passed but stdin is empty"** — mock `process.stdin` that emits empty string, verify `process.exit(1)` called
+- **"does not call collectSecret() when -y is passed"** — verify the interactive prompt is bypassed
+
+### 3. tests/auth-socket.test.ts — 500ms grace period
+- **"returns password when it arrives within 500ms of terminal exit"** — simulate terminal close (code 0), deliver password within 500ms, verify password returned
+- **"returns fallback when no password arrives within 500ms of terminal exit"** — simulate terminal close (code 0), do not deliver password, verify fallback returned after 500ms
+- **"cleans up waiter and pendingRequests on 500ms timeout"** — after timeout, verify `passwordWaiters` and `pendingRequests` are cleaned up
+
+## Clean Files (no findings)
+
+The following 26 files had no issues:
+
+- tests/credential-store-update.test.ts
+- tests/gpu-parser.test.ts
+- tests/setup-git-app.test.ts
+- tests/shell-escape.test.ts
+- tests/task-cleanup.test.ts
+- tests/activity.test.ts
+- tests/agent-detail.test.ts
+- tests/agent-helpers.test.ts
+- tests/auth-env.test.ts
+- tests/cloud-lifecycle-unit.test.ts
+- tests/credential-scoping-ttl.test.ts
+- tests/defensive-ux.test.ts
+- tests/integration/pid-lifecycle.test.ts
+- tests/platform.test.ts
+- tests/prompt-errors.test.ts
+- tests/registry.test.ts
+- tests/send-files-collision.test.ts
+- tests/statusline.test.ts
+- tests/update-member.test.ts
+- tests/file-transfer-matrix.test.ts
+- tests/fleet-status-branch.test.ts
+- tests/stop-prompt.test.ts
+- tests/execute-prompt.test.ts
+- tests/find-log-file.test.ts
+- tests/gemini-mcp-exclude.test.ts
+- tests/install.test.ts
+- tests/log-path-resolver.test.ts
+- tests/stall-detector-integration.test.ts
+- tests/time-utils.test.ts
+- tests/uninstall.test.ts
+- tests/update.test.ts
+- tests/credential-store-path.test.ts
+- tests/register-member-oob.test.ts

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -311,7 +311,7 @@ Apra Fleet is an MCP server that agentic coding systems connect to. It manages a
 | `setup_git_app` | One-time setup: register a GitHub App for scoped git token minting |
 | `provision_vcs_auth` | Deploy VCS credentials to a member (GitHub App, Bitbucket, Azure DevOps) |
 | `revoke_vcs_auth` | Remove deployed VCS credentials from a member |
-| `credential_store_set` | Store a secret credential for use in commands (entered OOB — never in chat) |
+| `credential_store_set` | Store a secret credential for use in commands — opens an OOB terminal and blocks until entered (never in chat). Use `apra-fleet secret --set NAME -y` for CI/non-interactive input from stdin. |
 | `credential_store_list` | List stored credential names (values are never returned) |
 | `credential_store_delete` | Delete a stored credential |
 
@@ -331,14 +331,22 @@ Secrets never enter the LLM conversation or logs. Fleet's credential store keeps
 **Three-step workflow:**
 
 ```
-# 1. Store once — Fleet opens an OOB terminal prompt, never asks in chat
-credential_store_set  name=github_pat
+# 1. Store once — Fleet opens an OOB terminal and BLOCKS until you enter the secret.
+#    No "Waiting..." intermediate response. Returns only after you've entered the value:
+#    ✓ github_pat stored [persistent]. Use {{secure.github_pat}} in commands.
+credential_store_set  name=github_pat  persist=true
 
 # 2. Use in execute_command — {{secure.NAME}} is resolved only in commands, never in prompts
 execute_command  command="curl -H 'Authorization: Bearer {{secure.github_pat}}' https://api.github.com/user"
 
 # 3. Output is automatically redacted before it reaches the LLM
 # Output: Authorization: Bearer [REDACTED:github_pat]
+```
+
+**CI / non-interactive usage:** Use the `-y` flag with the CLI to read the secret from stdin instead of opening an OOB terminal window:
+
+```bash
+echo "$TOKEN" | apra-fleet secret --set github_pat --persist -y
 ```
 
 **Tools that support `{{secure.NAME}}` token substitution:**
@@ -349,13 +357,13 @@ execute_command  command="curl -H 'Authorization: Bearer {{secure.github_pat}}' 
 - `provision_vcs_auth` — VCS token fields (GitHub PAT, Bitbucket token, Azure DevOps PAT)
 - `provision_auth` — LLM API key fields
 
-`execute_prompt` does **not** support `{{secure.NAME}}` — secrets must never be passed to LLM prompts. In `execute_prompt`, reference credentials by name only (e.g. `"authenticate using credential github_pat"`); the member resolves the token in its own `execute_command` calls.
+`execute_prompt` does **not** support `{{secure.NAME}}` — secrets must never be passed to LLM prompts. When a task requires a secret, the PM uses `execute_command` with `{{secure.NAME}}` to run the authenticated command directly; members have no access to the credential store or fleet tools.
 
 **Credential store tools:**
 
 | Tool | What it does |
 |------|-------------|
-| `credential_store_set` | Prompt for a secret OOB and store it encrypted under a name |
+| `credential_store_set` | Open an OOB terminal, block until the secret is entered, then store it encrypted under a name. Returns `✓ NAME stored [session/persistent]. Use {{secure.NAME}} in commands.` |
 | `credential_store_list` | List stored credential names — values are never returned |
 | `credential_store_delete` | Remove a stored credential by name |
 
@@ -500,6 +508,7 @@ When registering a remote member with password authentication, you don't need to
 - Works on macOS (Terminal.app), Windows (cmd), and Linux (gnome-terminal/xterm)
 - Headless or unsupported environments get a manual command fallback
 - Supports password rotation via `update_member`
+- On Windows, closing the OOB window returns immediately with a cancellation message — no longer hangs
 
 See [`docs/adr-oob-password.md`](docs/adr-oob-password.md) for the design rationale.
 

--- a/src/cli/secret.ts
+++ b/src/cli/secret.ts
@@ -9,7 +9,7 @@ const NAME_REGEX = /^[a-zA-Z0-9_-]{1,64}$/;
 export async function runSecret(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h') || args.length === 0) {
     console.error('Usage:');
-    console.error('  apra-fleet secret --set <name> [--persist]');
+    console.error('  apra-fleet secret --set <name> [--persist] [-y]');
     console.error('  apra-fleet secret --list');
     console.error('  apra-fleet secret --update <name> [--members <list>] [--ttl <seconds>] [--allow|--deny]');
     console.error('  apra-fleet secret --delete <name>');
@@ -172,11 +172,12 @@ async function handleSet(args: string[]): Promise<void> {
   const name = args[0];
   const persist = args.includes('--persist');
   const askPersist = args.includes('--ask-persist');
+  const nonInteractive = args.includes('-y');
   const promptIdx = args.indexOf('--prompt');
   const customPrompt = promptIdx !== -1 ? args[promptIdx + 1] : undefined;
 
   if (!name) {
-    console.error('Usage: apra-fleet secret --set <name> [--persist]');
+    console.error('Usage: apra-fleet secret --set <name> [--persist] [-y]');
     process.exit(1);
   }
 
@@ -186,8 +187,27 @@ async function handleSet(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const displayPrompt = customPrompt ?? `Enter value for ${name}`;
-  let secretValue = await collectSecret(displayPrompt);
+  let secretValue: string;
+  if (nonInteractive) {
+    secretValue = await new Promise<string>((resolve, reject) => {
+      let data = '';
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', chunk => { data += chunk; });
+      process.stdin.on('end', () => {
+        const trimmed = data.trim();
+        if (!trimmed) {
+          console.error('✗ Empty value on stdin. Aborting.');
+          process.exit(1);
+        }
+        resolve(trimmed);
+      });
+      process.stdin.on('error', reject);
+      process.stdin.resume();
+    });
+  } else {
+    const displayPrompt = customPrompt ?? `Enter value for ${name}`;
+    secretValue = await collectSecret(displayPrompt);
+  }
 
   let finalPersist = persist;
   if (askPersist && !persist) {

--- a/src/services/auth-socket.ts
+++ b/src/services/auth-socket.ts
@@ -348,12 +348,24 @@ async function collectOobInput(
     const raceResult = await Promise.race([passwordPromise, cancellationPromise]);
 
     if (raceResult === null) {
-      // This case should not be hit if passwordPromise always wins on success,
-      // but as a safeguard, we wait for the password again.
-      const pw = await passwordPromise;
-      const persist = pendingRequests.get(memberName)?.persist;
-      pendingRequests.delete(memberName);
-      return { password: pw, persist };
+      // The terminal exited with code 0 (Windows `start /wait` always exits 0, even
+      // on user-close). Wait briefly for any in-flight socket message — if the user
+      // genuinely submitted, the password arrives within milliseconds of process exit.
+      // If nothing arrives in 500 ms, treat it as a user cancellation.
+      try {
+        const pw = await Promise.race([
+          passwordPromise,
+          new Promise<never>((_, reject) => setTimeout(() => reject(new Error('cancelled')), 500)),
+        ]);
+        const persist = pendingRequests.get(memberName)?.persist;
+        pendingRequests.delete(memberName);
+        return { password: pw, persist };
+      } catch {
+        const waiter = passwordWaiters.get(memberName);
+        if (waiter) { clearTimeout(waiter.timer); passwordWaiters.delete(memberName); }
+        pendingRequests.delete(memberName);
+        return { fallback: cancelledMessage };
+      }
     }
 
     // Handle the fallback case from the cancellation promise
@@ -596,7 +608,7 @@ export function launchAuthTerminal(
       // terminal window to be closed. This allows us to capture the exit event.
       // The title argument to start is required.
       const spawnArgs = ['/c', 'start', 'Fleet Password Entry', '/wait', ...fullArgs];
-      child = spawn('cmd', spawnArgs, { detached: true, stdio: 'ignore' });
+      child = spawn('cmd', spawnArgs, { stdio: 'ignore' });
       if (child.pid) {
         const pending = pendingRequests.get(memberName);
         if (pending) pending.spawned_pid = child.pid;

--- a/src/tools/credential-store-set.ts
+++ b/src/tools/credential-store-set.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { collectOobApiKey, hasPendingAuth, getPendingPassword, createPendingAuth, ensureAuthSocket, getSocketPath, launchAuthTerminal } from '../services/auth-socket.js';
+import { collectOobApiKey } from '../services/auth-socket.js';
 import { decryptPassword } from '../utils/crypto.js';
 import { credentialSet } from '../services/credential-store.js';
 import { logLine } from '../utils/log-helpers.js';
@@ -22,32 +22,16 @@ export const credentialStoreSetSchema = z.object({
 export type CredentialStoreSetInput = z.infer<typeof credentialStoreSetSchema>;
 
 export async function credentialStoreSet(input: CredentialStoreSetInput): Promise<string> {
-  // Check if password has already arrived from a previous call
-  if (hasPendingAuth(input.name)) {
-    const encPw = getPendingPassword(input.name);
-    if (encPw) {
-      const plaintext = decryptPassword(encPw);
-      const allowedMembers: string[] | '*' = input.members === '*'
-        ? '*'
-        : input.members.split(',').map(s => s.trim()).filter(Boolean);
-      const meta = credentialSet(input.name, plaintext, input.persist, input.network_policy, allowedMembers, input.ttl_seconds);
-      logLine('credential_store_set', `name=${input.name} persist=${input.persist}`);
-      return JSON.stringify({ handle: `sec://${meta.name}`, scope: meta.scope });
-    }
-  }
+  const result = await collectOobApiKey(input.name, 'credential_store_set', { prompt: input.prompt });
 
-  // No password arrived yet, so check if we should set up a fresh pending request
-  if (!hasPendingAuth(input.name)) {
-    await ensureAuthSocket();
-    createPendingAuth(input.name);
-    const waitingMsg = `Waiting for secret ${input.name}. Run: apra-fleet secret --set ${input.name}`;
-    logLine('credential_store_set', waitingMsg);
-    launchAuthTerminal(input.name, ['--api-key'], (_exitCode) => {
-      // On terminal exit, no action needed — password will be collected via socket or not
-    });
-    return waitingMsg;
-  }
+  if (result.fallback) return result.fallback;
+  if (!result.password) return `❌ No secret received for ${input.name}. Please try again.`;
 
-  // Pending auth exists but no password yet — return waiting message
-  return `Waiting for secret ${input.name}. Run: apra-fleet secret --set ${input.name}`;
+  const plaintext = decryptPassword(result.password);
+  const allowedMembers: string[] | '*' = input.members === '*'
+    ? '*'
+    : input.members.split(',').map(s => s.trim()).filter(Boolean);
+  const meta = credentialSet(input.name, plaintext, input.persist, input.network_policy, allowedMembers, input.ttl_seconds);
+  logLine('credential_store_set', `name=${input.name} persist=${input.persist}`);
+  return `✓ ${meta.name} stored [${meta.scope}]. Use {{secure.${meta.name}}} in commands.`;
 }


### PR DESCRIPTION
## Summary
- Add LLM-driven e2e test suite infrastructure (`.github/e2e/`): GitHub Actions workflow, test script, suite config, member config, and MCP server config covering 6 suites across OS/provider combinations
- Fix `credential_store_set` blocking issue: OOB input now awaits `collectOobApiKey` correctly — old two-call design returned `Waiting...` and never stored the secret
- Fix Windows hang in credential store: remove `detached: true` from `cmd` spawn so the `close` event fires; add 500ms grace period for `cmd /c start /wait` edge case
- Add `-y` flag to `secret --set` to read the value from stdin for CI/non-interactive use
- Add test suite audit report (76 files, 164 findings) and correct README claim that members use `execute_command` for credentials

## Test plan
- [ ] CI passes on the new branch
- [ ] Run e2e suite locally (`node .github/e2e/run-e2e.js` or via the workflow)
- [ ] Verify `credential_store_set` no longer hangs on Windows after entering a secret
- [ ] Verify `fleet secret --set -y` reads value from stdin in a CI pipeline