### PR TITLE
ci(llms-full): regenerate on push:main via apra-fleet-git app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,17 +229,28 @@ jobs:
           overwrite: true
 
   update-llms-full:
+    # Runs only on push to main (i.e. after a PR has merged). Bypasses the
+    # main-protection ruleset via the apra-fleet-git GitHub App, which is
+    # configured as a bypass actor. No-op when llms-full.txt is already current.
+    # Requires: secret APRA_FLEET_GIT_APP_PRIVATE_KEY (PEM) and variable
+    # APRA_FLEET_GIT_APP_ID.
     needs: build-and-test
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - name: Checkout PR branch
+      - name: Mint app token for apra-fleet-git
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APRA_FLEET_GIT_APP_ID }}
+          private-key: ${{ secrets.APRA_FLEET_GIT_APP_PRIVATE_KEY }}
+
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: main
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
@@ -253,19 +264,18 @@ jobs:
       - name: Regenerate llms-full.txt
         run: node scripts/gen-llms-full.mjs
 
-      - name: Commit if changed
+      - name: Commit + push if changed
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "apra-fleet-git[bot]"
+          git config user.email "apra-fleet-git[bot]@users.noreply.github.com"
           git add llms-full.txt
-          if [[ "${{ github.head_ref }}" == "main" ]]; then
-            echo "Refusing to push auto-commit to main (protected branch)."
-            exit 0
+          if git diff --cached --quiet; then
+            echo "llms-full.txt unchanged - nothing to commit."
+          else
+            git commit -m "chore: regenerate llms-full.txt"
+            git push origin main
+            echo "Pushed regenerated llms-full.txt to main."
           fi
-          git diff --cached --quiet || (
-            git commit -m "chore: regenerate llms-full.txt" &&
-            git push origin HEAD:${{ github.head_ref }} || echo "Branch no longer exists — skipping push."
-          )
 
   release:
     needs: [package, build-binary, sign-windows]
@@ -328,4 +338,3 @@ jobs:
             release-binaries/apra-fleet-installer-darwin-arm64
             release-binaries/apra-fleet-installer-win-x64.exe
           generate_release_notes: true
-


### PR DESCRIPTION
## Summary

Moves the llms-full.txt auto-regen from the PR path to a post-merge push:main path. Authenticates via the apra-fleet-git GitHub App which is configured as an Integration bypass actor in the new main-protection ruleset, so the regen commit can push directly to main without needing required status checks.

## Why

The previous implementation auto-committed regenerated llms-full.txt back to PR branches as github-actions[bot]. That:
- Advanced the PR head past the original commit
- The new commit only touched llms-full.txt (in paths-ignore) so CI did not re-run
- Required status checks never registered on the PR head, blocking merge

Result: every PR with a non-trivial change ended up requiring an empty-commit workaround or admin override to merge. Confirmed during the recent feat/agy-support merge.

## What changed

- update-llms-full job now triggers only on push:main (not pull_request)
- Authenticates with the apra-fleet-git GitHub App (id 3001109) via actions/create-github-app-token
- Pushes the regenerated file directly to main; bypass is granted by the new ruleset

## One-time setup (needed before this PR is useful after merge)

1. Repo variable: APRA_FLEET_GIT_APP_ID = 3001109
2. Repo secret: APRA_FLEET_GIT_APP_PRIVATE_KEY = PEM private key downloaded from https://github.com/organizations/Apra-Labs/settings/apps/apra-fleet-git

The first push:main after merging this PR will exercise the new path. If the secret/var are missing the workflow fails visibly at the Mint app token step.

## Test plan
- [x] CI build-and-test passes on this branch (will be a required check before merge)
- [ ] After merge: confirm update-llms-full job runs and either no-ops (if llms-full.txt already current) or commits + pushes successfully