### PR TITLE
feat(config): user-level model tier mapping override (02o)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -175,6 +175,51 @@ apra-fleet uninstall --llm claude --skill fleet
 If the fleet server is running, uninstall aborts and tells you to re-run with
 `--force`. Full detail: [docs/features/uninstall.md](features/uninstall.md).
 
+## Customizing model tier mapping
+
+By default, each provider maps the three tiers (`cheap`, `standard`, `premium`)
+to hardcoded model names. You can override any of these per-provider by creating
+a `config.json` file in the Fleet data directory:
+
+```
+~/.apra-fleet/data/config.json
+```
+
+If you set `APRA_FLEET_DATA_DIR`, the file lives at
+`$APRA_FLEET_DATA_DIR/config.json` instead.
+
+**Schema example:**
+
+```json
+{
+  "providers": {
+    "agy": {
+      "modelMapping": {
+        "cheap":    "GPT-OSS 120B (Medium)",
+        "standard": "Gemini 3.1 Pro (High)",
+        "premium":  "Claude Opus 4.6 (Thinking)"
+      }
+    },
+    "claude": {
+      "modelMapping": {
+        "cheap": "claude-haiku-4-5",
+        "premium": "claude-opus-4-7"
+      }
+    }
+  }
+}
+```
+
+Provider keys: `claude`, `gemini`, `codex`, `copilot`, `agy`. Tier keys:
+`cheap`, `standard`, `premium`. All fields are optional -- omitted tiers fall
+back to the provider's built-in default.
+
+**Precedence:** per-member override (`update_member --model-cheap/standard/premium`)
+> user config > hardcoded provider default.
+
+If the file is missing, Fleet proceeds with built-in defaults. If the JSON is
+malformed, Fleet logs a warning to stderr and ignores the file.
+
 ## Self-update
 
 Update the fleet binary to the latest release:

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -29,4 +29,9 @@ Fleet supports Claude, Antigravity (agy), Codex, Copilot, and Gemini. Members ca
 
 ---
 
+To override which model each tier resolves to on a per-provider basis, see
+[Customizing model tier mapping](install.md#customizing-model-tier-mapping).
+
+---
+
 Extending Fleet's provider support, or need the full CLI / integration detail? See [docs/provider-matrix.md](provider-matrix.md).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -737,6 +737,51 @@ apra-fleet uninstall --llm claude --skill fleet
 If the fleet server is running, uninstall aborts and tells you to re-run with
 `--force`. Full detail: [docs/features/uninstall.md](features/uninstall.md).
 
+## Customizing model tier mapping
+
+By default, each provider maps the three tiers (`cheap`, `standard`, `premium`)
+to hardcoded model names. You can override any of these per-provider by creating
+a `config.json` file in the Fleet data directory:
+
+```
+~/.apra-fleet/data/config.json
+```
+
+If you set `APRA_FLEET_DATA_DIR`, the file lives at
+`$APRA_FLEET_DATA_DIR/config.json` instead.
+
+**Schema example:**
+
+```json
+{
+  "providers": {
+    "agy": {
+      "modelMapping": {
+        "cheap":    "GPT-OSS 120B (Medium)",
+        "standard": "Gemini 3.1 Pro (High)",
+        "premium":  "Claude Opus 4.6 (Thinking)"
+      }
+    },
+    "claude": {
+      "modelMapping": {
+        "cheap": "claude-haiku-4-5",
+        "premium": "claude-opus-4-7"
+      }
+    }
+  }
+}
+```
+
+Provider keys: `claude`, `gemini`, `codex`, `copilot`, `agy`. Tier keys:
+`cheap`, `standard`, `premium`. All fields are optional -- omitted tiers fall
+back to the provider's built-in default.
+
+**Precedence:** per-member override (`update_member --model-cheap/standard/premium`)
+> user config > hardcoded provider default.
+
+If the file is missing, Fleet proceeds with built-in defaults. If the JSON is
+malformed, Fleet logs a warning to stderr and ignores the file.
+
 ## Self-update
 
 Update the fleet binary to the latest release:
@@ -1384,6 +1429,11 @@ Fleet supports Claude, Antigravity (agy), Codex, Copilot, and Gemini. Members ca
 
 - **`max_turns` is Claude-only.** On Gemini, Codex, Copilot, and Antigravity, use `timeout_s` instead to bound execution time.
 - **Copilot needs a paid GitHub Copilot subscription** (Pro, Business, or Enterprise) and has the smallest context window (64K). It is best suited for smaller, focused tasks.
+
+---
+
+To override which model each tier resolves to on a per-provider basis, see
+[Customizing model tier mapping](install.md#customizing-model-tier-mapping).
 
 ---
 

--- a/src/os/windows.ts
+++ b/src/os/windows.ts
@@ -130,7 +130,7 @@ export class WindowsCommands implements OsCommands {
       argList += ` ${provider.modelFlag(escapeWindowsArg(model))}`;
     }
 
-    return provider.wrapWindowsPrompt(setupCmd, filePath, argList, sessionId, model);
+    return provider.wrapWindowsPrompt(setupCmd, filePath, argList, sessionId, model, opts.tier);
   }
 
   // --- Filesystem ---

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -4,6 +4,7 @@ import type { PromptErrorCategory } from '../utils/prompt-errors.js';
 import { classifyPromptError } from '../utils/prompt-errors.js';
 import { escapeDoubleQuoted } from '../os/os-commands.js';
 import { stripAnsi } from '../utils/ansi.js';
+import { getModelOverride } from '../services/user-config.js';
 
 const AGY_MODEL_FOR_TIER: Record<'cheap'|'standard'|'premium', string> = {
   cheap:    'Gemini 3.5 Flash (Medium)',
@@ -47,7 +48,7 @@ export class AgyProvider implements ProviderAdapter {
   }
 
   buildPromptCommand(opts: PromptOptions): string {
-    const { folder, promptFile, sessionId, resuming, unattended, inv, model } = opts;
+    const { folder, promptFile, sessionId, resuming, unattended, inv, model, tier: inputTier } = opts;
     const escapedFolder = escapeDoubleQuoted(folder);
     let instruction = `Your task is described in ${promptFile} in the current directory. Read that file first, then execute the task.`;
     if (inv) {
@@ -55,8 +56,8 @@ export class AgyProvider implements ProviderAdapter {
     }
 
     // Write per-workspace model override before launching agy.
-    const tier = this.resolveTierFromModel(model);
-    const displayModel = AGY_MODEL_FOR_TIER[tier];
+    const tier = inputTier ?? this.resolveTierFromModel(model);
+    const displayModel = getModelOverride('agy', tier) ?? AGY_MODEL_FOR_TIER[tier];
     const settingsScript = `${SCRIPTS_UNIX}/agy-settings-merge.js`;
 
     let cmd = `cd "${escapedFolder}" && node "${settingsScript}" "${escapeDoubleQuoted(displayModel)}" && agy -p "${instruction}"`;
@@ -216,10 +217,10 @@ export class AgyProvider implements ProviderAdapter {
     return 'ANTIGRAVITY_API_KEY';
   }
 
-  wrapWindowsPrompt(setupCmd: string, filePath: string, argList: string, sessionId?: string, model?: string): string {
+  wrapWindowsPrompt(setupCmd: string, filePath: string, argList: string, sessionId?: string, model?: string, tier?: 'cheap' | 'standard' | 'premium'): string {
     // Write per-workspace model override before launching agy (mirrors buildPromptCommand).
-    const tier = this.resolveTierFromModel(model);
-    const displayModel = AGY_MODEL_FOR_TIER[tier];
+    const resolvedTier = tier ?? this.resolveTierFromModel(model);
+    const displayModel = getModelOverride('agy', resolvedTier) ?? AGY_MODEL_FOR_TIER[resolvedTier];
     const settingsScript = `${SCRIPTS_WIN}\\agy-settings-merge.js`;
 
     let cmd = `${setupCmd}node "${settingsScript}" "${escapeDoubleQuoted(displayModel)}"; Write-Output "FLEET_PID:$pid"; ${filePath} ${argList}`;

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -33,6 +33,7 @@ export interface PromptOptions {
   resuming?: boolean;
   unattended?: false | 'auto' | 'dangerous';
   model?: string;
+  tier?: 'cheap' | 'standard' | 'premium';
   maxTurns?: number;
   inv?: string;
 }
@@ -104,7 +105,7 @@ export interface ProviderAdapter {
 
   // Windows / PowerShell prompt building helpers
   /** On Windows, wrap the command for execution (e.g. via .NET ProcessStartInfo or direct shell). */
-  wrapWindowsPrompt(setupCmd: string, filePath: string, argList: string, sessionId?: string, model?: string): string;
+  wrapWindowsPrompt(setupCmd: string, filePath: string, argList: string, sessionId?: string, model?: string, tier?: 'cheap' | 'standard' | 'premium'): string;
 
   /** JSON output flag for the CLI (e.g. --output-format json, --json, --format json) */
   jsonOutputFlag(): string;

--- a/src/services/user-config.ts
+++ b/src/services/user-config.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { FLEET_DIR } from '../paths.js';
+import type { LlmProvider } from '../types.js';
+
+export type ModelTier = 'cheap' | 'standard' | 'premium';
+
+export interface UserConfig {
+  providers?: Partial<Record<LlmProvider, {
+    modelMapping?: Partial<Record<ModelTier, string>>;
+  }>>;
+}
+
+const VALID_PROVIDERS = new Set<string>(['claude', 'gemini', 'codex', 'copilot', 'agy']);
+const VALID_TIERS = new Set<string>(['cheap', 'standard', 'premium']);
+
+let cached: UserConfig | undefined;
+
+export function loadUserConfig(): UserConfig {
+  if (cached !== undefined) return cached;
+
+  const configPath = path.join(FLEET_DIR, 'config.json');
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf-8');
+  } catch {
+    cached = {};
+    return cached;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.error('[fleet] user config malformed, ignoring');
+    cached = {};
+    return cached;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    console.error('[fleet] user config malformed, ignoring');
+    cached = {};
+    return cached;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const result: UserConfig = {};
+
+  if (obj.providers && typeof obj.providers === 'object' && !Array.isArray(obj.providers)) {
+    const providers = obj.providers as Record<string, unknown>;
+    result.providers = {};
+
+    for (const [provKey, provVal] of Object.entries(providers)) {
+      if (!VALID_PROVIDERS.has(provKey)) {
+        console.error(`[fleet] user config: unknown provider "${provKey}", skipping`);
+        continue;
+      }
+      if (typeof provVal !== 'object' || provVal === null || Array.isArray(provVal)) continue;
+
+      const provObj = provVal as Record<string, unknown>;
+      if (provObj.modelMapping && typeof provObj.modelMapping === 'object' && !Array.isArray(provObj.modelMapping)) {
+        const mapping = provObj.modelMapping as Record<string, unknown>;
+        const validMapping: Partial<Record<ModelTier, string>> = {};
+
+        for (const [tierKey, tierVal] of Object.entries(mapping)) {
+          if (!VALID_TIERS.has(tierKey)) {
+            console.error(`[fleet] user config: unknown tier "${tierKey}" in provider "${provKey}", skipping`);
+            continue;
+          }
+          if (typeof tierVal === 'string') {
+            validMapping[tierKey as ModelTier] = tierVal;
+          }
+        }
+
+        (result.providers as Record<string, { modelMapping?: Partial<Record<ModelTier, string>> }>)[provKey] = { modelMapping: validMapping };
+      }
+    }
+  }
+
+  cached = result;
+  return cached;
+}
+
+export function getModelOverride(provider: LlmProvider, tier: ModelTier): string | undefined {
+  const config = loadUserConfig();
+  return config.providers?.[provider]?.modelMapping?.[tier];
+}
+
+/** Reset the cached config -- for testing only. */
+export function _resetCache(): void {
+  cached = undefined;
+}

--- a/src/tools/execute-prompt.ts
+++ b/src/tools/execute-prompt.ts
@@ -12,6 +12,7 @@ import { memberIdentifier, resolveMember } from '../utils/resolve-member.js';
 import { isRetryable, authErrorAdvice } from '../utils/prompt-errors.js';
 import { buildAuthEnvPrefix } from '../utils/auth-env.js';
 import { writeStatusline } from '../services/statusline.js';
+import { getModelOverride } from '../services/user-config.js';
 import { ensureCloudReady } from '../services/cloud/lifecycle.js';
 import { getStallDetector, resolveSessionLogPath } from '../services/stall/index.js';
 import { escapeWindowsArg, escapeDoubleQuoted } from '../os/os-commands.js';
@@ -157,12 +158,16 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
 
   const tiers = provider.modelTiers();
   let resolvedModel = input.model || 'standard';
+  let resolvedTier: 'cheap' | 'standard' | 'premium' | undefined;
   if (resolvedModel === 'cheap') {
-    resolvedModel = agent.modelCheap || tiers.cheap;
+    resolvedTier = 'cheap';
+    resolvedModel = agent.modelCheap || getModelOverride(provider.name, 'cheap') || tiers.cheap;
   } else if (resolvedModel === 'standard') {
-    resolvedModel = agent.modelStandard || tiers.standard;
+    resolvedTier = 'standard';
+    resolvedModel = agent.modelStandard || getModelOverride(provider.name, 'standard') || tiers.standard;
   } else if (resolvedModel === 'premium') {
-    resolvedModel = agent.modelPremium || tiers.premium;
+    resolvedTier = 'premium';
+    resolvedModel = agent.modelPremium || getModelOverride(provider.name, 'premium') || tiers.premium;
   } else {
     resolvedModel = tiers[resolvedModel as keyof typeof tiers] ?? resolvedModel;
   }
@@ -185,6 +190,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
     resuming,
     unattended: agent.unattended,
     model: resolvedModel,
+    tier: resolvedTier,
     maxTurns: input.max_turns,
     inv: scope.getInv(),
   };

--- a/tests/user-config.test.ts
+++ b/tests/user-config.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { FLEET_DIR } from './test-helpers.js';
+import { loadUserConfig, getModelOverride, _resetCache } from '../src/services/user-config.js';
+
+const CONFIG_PATH = path.join(FLEET_DIR, 'config.json');
+
+describe('user-config loader', () => {
+  beforeEach(() => {
+    _resetCache();
+    if (!fs.existsSync(FLEET_DIR)) {
+      fs.mkdirSync(FLEET_DIR, { recursive: true });
+    }
+    // Clean up any existing config
+    try { fs.unlinkSync(CONFIG_PATH); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    _resetCache();
+    try { fs.unlinkSync(CONFIG_PATH); } catch { /* ignore */ }
+  });
+
+  it('returns empty config when file is missing', () => {
+    const config = loadUserConfig();
+    expect(config).toEqual({});
+  });
+
+  it('loads well-formed config with valid providers and tiers', () => {
+    const data = {
+      providers: {
+        agy: {
+          modelMapping: {
+            cheap: 'GPT-OSS 120B (Medium)',
+            standard: 'Gemini 3.1 Pro (High)',
+            premium: 'Claude Opus 4.6 (Thinking)',
+          },
+        },
+        claude: {
+          modelMapping: {
+            cheap: 'claude-haiku-4-5',
+          },
+        },
+      },
+    };
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(data), 'utf-8');
+
+    const config = loadUserConfig();
+    expect(config.providers?.agy?.modelMapping?.cheap).toBe('GPT-OSS 120B (Medium)');
+    expect(config.providers?.agy?.modelMapping?.standard).toBe('Gemini 3.1 Pro (High)');
+    expect(config.providers?.agy?.modelMapping?.premium).toBe('Claude Opus 4.6 (Thinking)');
+    expect(config.providers?.claude?.modelMapping?.cheap).toBe('claude-haiku-4-5');
+  });
+
+  it('returns empty config for malformed JSON and logs warning', () => {
+    fs.writeFileSync(CONFIG_PATH, '{ bad json !!!', 'utf-8');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const config = loadUserConfig();
+    expect(config).toEqual({});
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('user config malformed'));
+    spy.mockRestore();
+  });
+
+  it('returns empty config for non-object JSON (array)', () => {
+    fs.writeFileSync(CONFIG_PATH, '[1,2,3]', 'utf-8');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const config = loadUserConfig();
+    expect(config).toEqual({});
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('user config malformed'));
+    spy.mockRestore();
+  });
+
+  it('warns on unknown provider keys but accepts valid ones', () => {
+    const data = {
+      providers: {
+        agy: { modelMapping: { cheap: 'Model A' } },
+        bogus: { modelMapping: { cheap: 'Model B' } },
+      },
+    };
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(data), 'utf-8');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const config = loadUserConfig();
+    expect(config.providers?.agy?.modelMapping?.cheap).toBe('Model A');
+    expect((config.providers as any)?.bogus).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('unknown provider "bogus"'));
+    spy.mockRestore();
+  });
+
+  it('warns on unknown tier keys but accepts valid ones', () => {
+    const data = {
+      providers: {
+        claude: { modelMapping: { cheap: 'haiku', ultra: 'opus' } },
+      },
+    };
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(data), 'utf-8');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const config = loadUserConfig();
+    expect(config.providers?.claude?.modelMapping?.cheap).toBe('haiku');
+    expect((config.providers?.claude?.modelMapping as any)?.ultra).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('unknown tier "ultra"'));
+    spy.mockRestore();
+  });
+
+  it('caches the result across calls', () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({ providers: { agy: { modelMapping: { cheap: 'X' } } } }), 'utf-8');
+
+    const first = loadUserConfig();
+    // Overwrite file -- cache should still return old value
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({ providers: { agy: { modelMapping: { cheap: 'Y' } } } }), 'utf-8');
+    const second = loadUserConfig();
+
+    expect(first).toBe(second); // same object reference
+    expect(second.providers?.agy?.modelMapping?.cheap).toBe('X');
+  });
+});
+
+describe('getModelOverride', () => {
+  beforeEach(() => {
+    _resetCache();
+    if (!fs.existsSync(FLEET_DIR)) {
+      fs.mkdirSync(FLEET_DIR, { recursive: true });
+    }
+    try { fs.unlinkSync(CONFIG_PATH); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    _resetCache();
+    try { fs.unlinkSync(CONFIG_PATH); } catch { /* ignore */ }
+  });
+
+  it('returns undefined when no config file exists', () => {
+    expect(getModelOverride('agy', 'cheap')).toBeUndefined();
+  });
+
+  it('returns override when config has a mapping for the provider/tier', () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      providers: { agy: { modelMapping: { premium: 'Custom Premium' } } },
+    }), 'utf-8');
+
+    expect(getModelOverride('agy', 'premium')).toBe('Custom Premium');
+    expect(getModelOverride('agy', 'cheap')).toBeUndefined();
+    expect(getModelOverride('claude', 'premium')).toBeUndefined();
+  });
+});
+
+describe('agy provider uses user-config for display name', () => {
+  beforeEach(() => {
+    _resetCache();
+    if (!fs.existsSync(FLEET_DIR)) {
+      fs.mkdirSync(FLEET_DIR, { recursive: true });
+    }
+    try { fs.unlinkSync(CONFIG_PATH); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    _resetCache();
+    try { fs.unlinkSync(CONFIG_PATH); } catch { /* ignore */ }
+  });
+
+  it('uses hardcoded default when no user config exists', async () => {
+    const { AgyProvider } = await import('../src/providers/agy.js');
+    const p = new AgyProvider();
+    const cmd = p.buildPromptCommand({
+      folder: '/home/user/project',
+      promptFile: '.fleet-task.md',
+      tier: 'cheap',
+    });
+    // Default cheap display name
+    expect(cmd).toContain('Gemini 3.5 Flash (Medium)');
+  });
+
+  it('uses user-config override when config is present', async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      providers: { agy: { modelMapping: { cheap: 'Custom Cheap Model' } } },
+    }), 'utf-8');
+
+    const { AgyProvider } = await import('../src/providers/agy.js');
+    const p = new AgyProvider();
+    const cmd = p.buildPromptCommand({
+      folder: '/home/user/project',
+      promptFile: '.fleet-task.md',
+      tier: 'cheap',
+    });
+    expect(cmd).toContain('Custom Cheap Model');
+    expect(cmd).not.toContain('Gemini 3.5 Flash (Medium)');
+  });
+
+  it('falls back to hardcoded default for tiers not in user config', async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      providers: { agy: { modelMapping: { premium: 'Custom Premium' } } },
+    }), 'utf-8');
+
+    const { AgyProvider } = await import('../src/providers/agy.js');
+    const p = new AgyProvider();
+    const cmd = p.buildPromptCommand({
+      folder: '/home/user/project',
+      promptFile: '.fleet-task.md',
+      tier: 'standard',
+    });
+    // standard not overridden -- should use hardcoded default
+    expect(cmd).toContain('Gemini 3.1 Pro (Low)');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `~/.apra-fleet/data/config.json` as user-level config for overriding per-provider tier-to-model mappings
- Precedence chain: per-member override (`update_member --model-*`) > user config > hardcoded provider default
- Fixes agy display-name resolution by threading the original tier through `PromptOptions` instead of reverse-looking-up the resolved model ID
- Applies user-config overrides for all five providers (claude, gemini, codex, copilot, agy) in `execute-prompt.ts`

## Changes

- **New:** `src/services/user-config.ts` -- `loadUserConfig()` reads and caches config; `getModelOverride(provider, tier)` returns the override or undefined
- **Modified:** `src/providers/provider.ts` -- added `tier` field to `PromptOptions` and `wrapWindowsPrompt` signature
- **Modified:** `src/tools/execute-prompt.ts` -- resolves tier, applies user-config in precedence chain, passes tier to prompt opts
- **Modified:** `src/providers/agy.ts` -- uses `opts.tier` and `getModelOverride()` instead of reverse-lookup + hardcoded map
- **Modified:** `src/os/windows.ts` -- passes `opts.tier` through to `wrapWindowsPrompt`
- **Docs:** `docs/install.md` new section, `docs/provider-guide.md` cross-link
- **Tests:** 12 new tests in `tests/user-config.test.ts`

Closes apra-fleet-projects-02o.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` passes (1310 tests, 79 files)
- [ ] Manual smoke: write config.json with agy override, dispatch, verify settings.json gets overridden display name