### PR TITLE
fix(agy): use official Google standalone installers for agy CLI

### DIFF
--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -33,7 +33,10 @@ export class AgyProvider implements ProviderAdapter {
   }
 
   installCommand(os: 'linux' | 'macos' | 'windows'): string {
-    return 'npm install -g @google/antigravity-cli';
+    if (os === 'windows') {
+      return 'powershell -Command "irm https://antigravity.google/cli/install.ps1 | iex"';
+    }
+    return 'curl -fsSL https://antigravity.google/cli/install.sh | bash';
   }
 
   updateCommand(): string {

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -883,7 +883,9 @@ describe('AgyProvider', () => {
   });
 
   it('builds installCommand', () => {
-    expect(p.installCommand('linux')).toBe('npm install -g @google/antigravity-cli');
+    expect(p.installCommand('linux')).toBe('curl -fsSL https://antigravity.google/cli/install.sh | bash');
+    expect(p.installCommand('macos')).toBe('curl -fsSL https://antigravity.google/cli/install.sh | bash');
+    expect(p.installCommand('windows')).toBe('powershell -Command "irm https://antigravity.google/cli/install.ps1 | iex"');
   });
 
   it('builds updateCommand', () => {


### PR DESCRIPTION
## Summary

- Replaces `npm install -g @google/antigravity-cli` with the official Google standalone installers
- Windows: `irm https://antigravity.google/cli/install.ps1 | iex` (PowerShell)
- Linux/macOS: `curl -fsSL https://antigravity.google/cli/install.sh | bash`

## Test plan

- [x] `installCommand` tests updated for all 3 platforms (linux, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)