### PR TITLE
ci(llms-full): regen after docs updates

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -273,6 +273,7 @@ Want to build your own skill on top of Fleet? See [docs/writing-skills.md](docs/
 
 | Topic | Link |
 |-------|------|
+| Codebase wiki (architecture, internals, AI Q&A) | [DeepWiki](https://deepwiki.com/Apra-Labs/apra-fleet) |
 | Install, uninstall, the `--llm` flag | [docs/install.md](docs/install.md) |
 | Choosing a provider | [docs/provider-guide.md](docs/provider-guide.md) |
 | FAQ | [docs/FAQ.md](docs/FAQ.md) |
@@ -2017,6 +2018,19 @@ All questions and answers are maintained at:
 
 **[FAQ Index -- GitHub Discussions #127](https://github.com/Apra-Labs/apra-fleet/discussions/127)**
 
+---
+
+Want to explore the codebase or ask questions about how Fleet works internally?
+The **[Fleet DeepWiki](https://deepwiki.com/Apra-Labs/apra-fleet)** has an AI assistant trained on the Fleet source code.
+
+Some useful starting points:
+
+- [How does execute_prompt work end-to-end?](https://deepwiki.com/Apra-Labs/apra-fleet/4.2-work-execution-tools)
+- [How do I register and manage fleet members?](https://deepwiki.com/Apra-Labs/apra-fleet/4.1-member-lifecycle-tools)
+- [What is the doer-reviewer workflow?](https://deepwiki.com/Apra-Labs/apra-fleet/7.1-sprint-lifecycle-and-doer-reviewer-loop)
+
+---
+
 Topics covered:
 
 - **Getting started** -- installation, device requirements, provider support
@@ -2148,40 +2162,41 @@ reference and more `jq` examples.
 This roadmap reflects current plans. Priorities shift based on community feedback.
 Have an idea? [Open a feature request](https://github.com/Apra-Labs/apra-fleet/issues/new/choose).
 
-Items marked 🌱 are good first issues for new contributors.
+Items marked [*] are good first issues for new contributors.
 
 ---
 
 ## Near-term (next 1-2 sprints)
 
-- [ ] **npm publish** — Publish to npm so users can `npx apra-fleet install` 🌱
-- [ ] **Cursor / Windsurf integration guide** — Step-by-step docs for non-Claude-Code AI assistants 🌱
-- [ ] **Codex CLI & GitHub Copilot support** — First-class support as member agent providers — coming soon 🚀
-- [ ] **Member groups / tags** — Tag members (e.g. `gpu`, `build`, `test`) and target prompts at groups
-- [ ] **Session log export** — Export prompt execution history as markdown 🌱
+- [ ] **npm publish** -- Publish to npm so users can `npx apra-fleet install` [*]
+- [ ] **HTTP+SSE transport** -- MCP HTTP+SSE transport enabling remote members to connect over the network
+- [ ] **Web dashboard** -- Browser UI for fleet topology, member status, live prompt monitoring, token/cloud cost visibility, git activity, and audit trail; VS Code extension embeds the same view with clickable file paths ([discussion #188](https://github.com/Apra-Labs/apra-fleet/discussions/188))
+- [ ] **Memory plane integration** -- Connect fleet agents to codebase knowledge indices so task planning starts from a structured map of architecture and relevant files rather than blind token-expensive discovery; encompasses persistent inter-session memory and sprint-accumulated knowledge graphs ([RFC #265](https://github.com/Apra-Labs/apra-fleet/discussions/265), [discussion #249](https://github.com/Apra-Labs/apra-fleet/discussions/249), [PR #266](https://github.com/Apra-Labs/apra-fleet/pull/266))
+- [ ] **Session log export** -- One-click markdown export of `fleet logs` output from the dashboard; builds on session history and listing work ([issue #189](https://github.com/Apra-Labs/apra-fleet/issues/189)) [*]
+- [ ] **Member groups / tags** -- Tag members (e.g. `gpu`, `build`, `test`) and target prompts at groups; categorized grouping in status output ([PR #238](https://github.com/Apra-Labs/apra-fleet/pull/238))
 
-## Medium-term (3-6 months)
+## Medium-term (1-2 months)
 
-- [ ] **Expanded member targets** — Docker containers, Kubernetes pods, WSL instances, Azure VMs, and GCP VMs as first-class fleet members
-- [ ] **Web dashboard** — Browser UI for fleet status and member management (foundation in `dashboard/`) 🌱
-- [ ] **Plugin system** — Community-built plugins for custom tools and providers
-- [ ] **Result aggregation** — Merge outputs from parallel member executions into a unified report
-- [ ] **Cost dashboard** — Visualize token and cloud spend across members
+- [ ] **Agent-to-agent communication** -- Members communicate directly, not only through coordinator ([discussion #196](https://github.com/Apra-Labs/apra-fleet/discussions/196), [issue #152](https://github.com/Apra-Labs/apra-fleet/issues/152))
+- [ ] **Playbooks** -- JIT-compiled orchestration sequences: write environment-neutral runbooks once, fleet compiles them to native scripts per device and caches them; zero LLM cost on repeat runs with autonomous repair on failure ([discussion #194](https://github.com/Apra-Labs/apra-fleet/discussions/194))
+- [ ] **PM as full product lifecycle manager** -- Extend the PM skill through deploy, integration verification, quality grading, log monitoring, and backlog reprioritization; closes the loop beyond PR approval ([discussion #198](https://github.com/Apra-Labs/apra-fleet/discussions/198))
+- [ ] **Extension layer** -- Org-private skills and template overrides that survive fleet updates via a shadowing directory (`~/.apra-fleet/extensions/`); foundation for a community marketplace ([discussion #195](https://github.com/Apra-Labs/apra-fleet/discussions/195))
+- [ ] **Expanded member targets** -- Docker containers, Kubernetes pods, WSL instances, Azure VMs, and GCP VMs as first-class fleet members; includes per-instance data dir isolation for multi-fleet on the same machine ([PR #231](https://github.com/Apra-Labs/apra-fleet/pull/231))
+- [ ] **Multiple providers per member** -- Assign more than one LLM provider to a member and switch between them without re-registration ([issue #125](https://github.com/Apra-Labs/apra-fleet/issues/125))
+- [ ] **Slack notifications** -- Notify a Slack channel when members go offline, get blocked, or complete a task ([issue #77](https://github.com/Apra-Labs/apra-fleet/issues/77))
 
-## Long-term (6+ months)
+## Long-term (3+ months)
 
-- [ ] **Agent-to-agent communication** — Members communicate directly, not only through coordinator
-- [ ] **Distributed task queue** — Priority-based job scheduling with retry and dead-letter handling
-- [ ] **Fleet-as-a-Service** — Hosted version for teams that don't want to self-host
-- [ ] **Terraform / Pulumi provider** — Infrastructure-as-code for fleet topology
-- [ ] **Audit log** — Immutable log of all fleet operations for enterprise governance 🌱
-- [ ] **Multi-fleet federation** — Connect multiple fleet servers for cross-team orchestration
+- [ ] **Fleet-as-a-Service** -- Hosted version for teams that don't want to self-host
+- [ ] **Multi-fleet federation** -- Connect multiple fleet servers for cross-team orchestration
+- [ ] **Terraform / Pulumi provider** -- Infrastructure-as-code for fleet topology
+- [ ] **Audit log** -- Immutable append-only record of all fleet operations and secret usage for enterprise governance ([issue #159](https://github.com/Apra-Labs/apra-fleet/issues/159)) [*]
 
 ---
 
 ## Contributing
 
-Pick any item above (especially 🌱 ones), open an issue to discuss your approach, then submit a PR.
+Pick any item above (especially [*] ones), open an issue to discuss your approach, then submit a PR.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
   </doc>
 


### PR DESCRIPTION
Regenerates llms-full.txt after README, ROADMAP, and FAQ changes merged in PR #286.

Also reinstalls the pre-commit hook from .github/hooks/pre-commit -- the installed
hook on fleet-dev was stale (missing Part 2: llms-full.txt auto-regen). Root cause
of the miss: install-hooks.mjs was not re-run after the regen logic was added to
the hook source.
