### PR TITLE
fix(hooks): self-updating pre-commit hook

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,9 +1,25 @@
 #!/bin/sh
 # pre-commit:
+#   0. Self-update: reinstall if .github/hooks/pre-commit is newer than the installed copy
 #   1. Portability checks (non-ASCII, PS backtick escapes) on staged files
 #   2. Auto-regen llms-full.txt when any of its inputs are staged
 #
 # Works on Windows (Git Bash), Linux, and macOS.
+
+# ============================================================================
+# Part 0: self-update
+# ============================================================================
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$REPO_ROOT" ]; then
+  HOOK_SRC="$REPO_ROOT/.github/hooks/pre-commit"
+  HOOK_DST="$REPO_ROOT/.git/hooks/pre-commit"
+  if [ -f "$HOOK_SRC" ] && [ -f "$HOOK_DST" ] && [ "$HOOK_SRC" -nt "$HOOK_DST" ]; then
+    cp "$HOOK_SRC" "$HOOK_DST"
+    chmod +x "$HOOK_DST"
+    echo "pre-commit: hook updated from .github/hooks -- re-running"
+    exec "$HOOK_DST" "$@"
+  fi
+fi
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACM)
 [ -z "$STAGED" ] && exit 0


### PR DESCRIPTION
## Summary

Adds a self-update check (Part 0) to the pre-commit hook. On every commit, the
hook compares the mtime of .github/hooks/pre-commit against the installed
.git/hooks/pre-commit. If the source is newer, it copies itself, re-chmod, and
re-execs -- so developers on existing clones silently get hook updates after a
git pull, with no manual npm install required.

## Why

The llms-full.txt regen (Part 2) was added to .github/hooks/pre-commit but
fleet-dev had a stale installed hook that predated it, causing llms-full.txt to
fall out of sync without any warning. This fix makes the hook self-healing.

## Test plan

- [ ] Modify .github/hooks/pre-commit, touch a .md file, git commit -- confirm
      "pre-commit: hook updated" message appears before the commit proceeds
- [ ] Second commit without changing the hook -- confirm no self-update message
