### PR TITLE
feat(auth): browser fallback + broader terminal detection for OOB credential entry

### DIFF
--- a/src/services/auth-socket.ts
+++ b/src/services/auth-socket.ts
@@ -8,6 +8,7 @@ import { FLEET_DIR } from '../paths.js';
 import { encryptPassword } from '../utils/crypto.js';
 import { logError } from '../utils/log-helpers.js';
 import { OOB_TIMEOUT_MS } from '../utils/oob-timeout.js';
+import { launchAuthWeb } from './auth-web.js';
 
 const SOCKET_PATH = path.join(FLEET_DIR, 'auth.sock');
 const PENDING_TTL_MS = 10 * 60 * 1000; // 10 minutes
@@ -98,29 +99,10 @@ export async function ensureAuthSocket(): Promise<void> {
         try {
           const msg = JSON.parse(line);
           if (msg.type === 'auth' && msg.member_name && msg.password) {
-            const pending = pendingRequests.get(msg.member_name);
-            if (!pending) {
-              conn.write(JSON.stringify({ type: 'ack', ok: false, error: `No pending auth for ${msg.member_name}` }) + '\n');
-              return;
-            }
-            // Encrypt immediately, discard plaintext
-            pending.encryptedPassword = encryptPassword(msg.password);
-            if (msg.persist !== undefined) pending.persist = !!msg.persist;
+            const res = submitPassword(msg.member_name, msg.password, msg.persist);
             // Best-effort: JS strings are immutable; original may persist in V8 heap until GC
             (msg as any).password = '';
-            conn.write(JSON.stringify({ type: 'ack', ok: true }) + '\n');
-            // Kill the spawned terminal process if one was launched
-            if (pending.spawned_pid) {
-              killProcess(pending.spawned_pid);
-              pending.spawned_pid = undefined;
-            }
-            // Resolve any waiting tool handler
-            const waiter = passwordWaiters.get(msg.member_name);
-            if (waiter) {
-              clearTimeout(waiter.timer);
-              passwordWaiters.delete(msg.member_name);
-              waiter.resolve(pending.encryptedPassword);
-            }
+            conn.write(JSON.stringify({ type: 'ack', ...res }) + '\n');
           } else {
             conn.write(JSON.stringify({ type: 'ack', ok: false, error: 'Invalid message' }) + '\n');
           }
@@ -183,6 +165,32 @@ export function getPendingPassword(memberName: string): string | null {
   const pw = entry.encryptedPassword;
   pendingRequests.delete(memberName);
   return pw;
+}
+
+/**
+ * Deliver a plaintext credential to a pending auth request: encrypt it
+ * immediately, store it on the pending entry, and resolve any waiting tool
+ * handler. Shared by the socket handler (CLI entry) and the browser fallback
+ * (local web UI entry) so both delivery paths behave identically.
+ */
+export function submitPassword(memberName: string, plaintext: string, persist?: boolean): { ok: boolean; error?: string } {
+  const pending = pendingRequests.get(memberName);
+  if (!pending) return { ok: false, error: `No pending auth for ${memberName}` };
+  // Encrypt immediately; plaintext is never stored or logged.
+  pending.encryptedPassword = encryptPassword(plaintext);
+  if (persist !== undefined) pending.persist = !!persist;
+  // Kill the spawned terminal process if one was launched.
+  if (pending.spawned_pid) {
+    killProcess(pending.spawned_pid);
+    pending.spawned_pid = undefined;
+  }
+  const waiter = passwordWaiters.get(memberName);
+  if (waiter) {
+    clearTimeout(waiter.timer);
+    passwordWaiters.delete(memberName);
+    waiter.resolve(pending.encryptedPassword);
+  }
+  return { ok: true };
 }
 
 /**
@@ -326,6 +334,12 @@ async function collectOobInput(
   await ensureAuthSocket();
   createPendingAuth(memberName);
 
+  // Tear-down for the local browser UI if it ends up being the active
+  // collector; called on every exit path. A holder object (rather than a bare
+  // let) so the assignment inside the Promise executor below stays visible to
+  // the type checker at the call sites.
+  const webUi: { close: (() => void) | null } = { close: null };
+
   try {
     const passwordPromise = waitForPassword(memberName, waitTimeoutMs);
 
@@ -340,6 +354,20 @@ async function collectOobInput(
       });
 
       if (result.startsWith('fallback:')) {
+        // No terminal available. For credential entry, try the local browser UI
+        // before giving up to a manual CLI instruction. Confirm prompts and
+        // test-injected launchers stay on the original path.
+        if (mode !== 'confirm' && !_opts?.launchFn) {
+          const webPrompt = _opts?.prompt
+            ?? (mode === 'api-key' ? `Enter API key for ${memberName}` : `Enter SSH password for ${memberName}`);
+          const web = launchAuthWeb(memberName, mode, webPrompt, (value) => submitPassword(memberName, value));
+          if (web.kind === 'launched') {
+            webUi.close = web.close;
+            // Leave this promise pending: passwordPromise resolves when the
+            // browser POSTs the value, or rejects on timeout.
+            return;
+          }
+        }
         const manualMsg = result.slice('fallback:'.length);
         resolve({ fallback: `🔐 ${manualMsg}\n\nOnce the user has entered the ${inputType}, call ${toolName} again with the same parameters.` });
       }
@@ -359,11 +387,13 @@ async function collectOobInput(
         ]);
         const persist = pendingRequests.get(memberName)?.persist;
         pendingRequests.delete(memberName);
+        webUi.close?.();
         return { password: pw, persist };
       } catch {
         const waiter = passwordWaiters.get(memberName);
         if (waiter) { clearTimeout(waiter.timer); passwordWaiters.delete(memberName); }
         pendingRequests.delete(memberName);
+        webUi.close?.();
         return { fallback: cancelledMessage };
       }
     }
@@ -379,11 +409,13 @@ async function collectOobInput(
         passwordWaiters.delete(memberName);
       }
       pendingRequests.delete(memberName);
+      webUi.close?.();
       return raceResult;
     }
 
     const persist = pendingRequests.get(memberName)?.persist;
     pendingRequests.delete(memberName);
+    webUi.close?.();
     return { password: raceResult as string, persist };
   } catch (err: any) {
     // Clean up the pending request if the user cancelled.
@@ -393,6 +425,7 @@ async function collectOobInput(
       passwordWaiters.delete(memberName);
     }
     pendingRequests.delete(memberName);
+    webUi.close?.();
 
     if (err.message === 'cancelled') {
       return { fallback: cancelledMessage };
@@ -527,14 +560,54 @@ export function hasInteractiveDesktop(): boolean {
   return process.env.SESSIONNAME === 'Console';
 }
 
+interface TerminalEntry {
+  bin: string;
+  execArgs: string[]; // arguments that precede the command to run
+}
+
 /**
- * Detect available terminal emulator on Linux.
+ * Detect available terminal emulator on Linux/BSD.
+ * Checks $TERM_PROGRAM first (set by kitty, WezTerm, Ghostty, etc.) then
+ * probes a broad list ordered by popularity on modern distros.
+ * Each entry includes the exec-flag convention for that terminal.
  */
-function findLinuxTerminal(): string | null {
-  for (const term of ['gnome-terminal', 'xterm', 'x-terminal-emulator']) {
+function findLinuxTerminal(): TerminalEntry | null {
+  // $TERM_PROGRAM is set by several terminals when they launch a shell
+  const termProg = process.env.TERM_PROGRAM;
+  const termProgramMap: Record<string, TerminalEntry> = {
+    kitty:   { bin: 'kitty',    execArgs: [] },
+    WezTerm: { bin: 'wezterm',  execArgs: ['start', '--'] },
+    ghostty: { bin: 'ghostty',  execArgs: ['-e'] },
+  };
+  if (termProg && termProgramMap[termProg]) {
+    const entry = termProgramMap[termProg];
     try {
-      execSync(`which ${term}`, { stdio: 'ignore' });
-      return term;
+      execSync(`which ${entry.bin}`, { stdio: 'ignore' });
+      return entry;
+    } catch { /* not in PATH, fall through */ }
+  }
+
+  // Ordered probe list: most common on modern Linux first
+  const candidates: TerminalEntry[] = [
+    { bin: 'kitty',             execArgs: [] },
+    { bin: 'alacritty',         execArgs: ['-e'] },
+    { bin: 'foot',              execArgs: [] },
+    { bin: 'wezterm',           execArgs: ['start', '--'] },
+    { bin: 'ghostty',           execArgs: ['-e'] },
+    { bin: 'gnome-terminal',    execArgs: ['--'] },
+    { bin: 'konsole',           execArgs: ['-e'] },
+    { bin: 'xfce4-terminal',    execArgs: ['-x'] },
+    { bin: 'mate-terminal',     execArgs: ['-x'] },
+    { bin: 'x-terminal-emulator', execArgs: ['-e'] },
+    { bin: 'urxvt',             execArgs: ['-e'] },
+    { bin: 'xterm',             execArgs: ['-e'] },
+    { bin: 'st',                execArgs: ['-e'] },
+  ];
+
+  for (const entry of candidates) {
+    try {
+      execSync(`which ${entry.bin}`, { stdio: 'ignore' });
+      return entry;
     } catch { /* not found */ }
   }
   return null;
@@ -642,17 +715,12 @@ export function launchAuthTerminal(
         if (pending) pending.spawned_pid = child.pid;
       }
     } else {
-      // Linux: find available terminal emulator. Most support an execute flag.
+      // Linux: find available terminal emulator and use its exec-flag convention.
       const terminal = findLinuxTerminal();
       if (!terminal) {
         return `fallback:Could not find a terminal emulator. Ask the user to run manually:\n  ${[cmd, ...args].join(' ')}\nAlternatively, pre-store the value with credential_store_set and reference it as {{secure.NAME}} in the credential field.`;
       }
-      if (terminal === 'gnome-terminal') {
-        child = spawn(terminal, ['--', ...fullArgs], { detached: true, stdio: 'ignore' });
-      } else {
-        // xterm, x-terminal-emulator etc.
-        child = spawn(terminal, ['-e', ...fullArgs], { detached: true, stdio: 'ignore' });
-      }
+      child = spawn(terminal.bin, [...terminal.execArgs, ...fullArgs], { detached: true, stdio: 'ignore' });
       if (child.pid) {
         const pending = pendingRequests.get(memberName);
         if (pending) pending.spawned_pid = child.pid;

--- a/src/services/auth-web.ts
+++ b/src/services/auth-web.ts
@@ -24,8 +24,21 @@ const MAX_BODY = 64 * 1024;   // reject oversized POST bodies
  * graphical session or no opener available (e.g. headless / SSH).
  */
 function findBrowserOpener(): { cmd: string; args: string[] } | null {
-  if (process.platform === 'darwin') return { cmd: 'open', args: [] };
-  if (process.platform === 'win32') return { cmd: 'cmd', args: ['/c', 'start', ''] };
+  if (process.platform === 'darwin') {
+    // Over SSH there may be no Aqua console session for `open` to target; a
+    // non-zero exit is swallowed by the detached spawn below, so guard here and
+    // fall through to the manual CLI instruction. Mirrors the darwin SSH gate
+    // in launchAuthTerminal (auth-socket.ts).
+    if (process.env.SSH_TTY) return null;
+    return { cmd: 'open', args: [] };
+  }
+  if (process.platform === 'win32') {
+    // Headless Windows (SSH / service account) has no interactive desktop;
+    // mirrors hasInteractiveDesktop() in auth-socket.ts so the caller falls
+    // through to the manual CLI instruction instead of spawning a no-op opener.
+    if (process.env.SESSIONNAME !== 'Console') return null;
+    return { cmd: 'cmd', args: ['/c', 'start', ''] };
+  }
   // Linux / BSD: needs a display and xdg-open
   if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) return null;
   try {

--- a/src/services/auth-web.ts
+++ b/src/services/auth-web.ts
@@ -1,0 +1,211 @@
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { spawn, execSync } from 'node:child_process';
+import { logError } from '../utils/log-helpers.js';
+
+/**
+ * Result of attempting to launch the local browser credential UI.
+ * - 'launched'    : a server is listening and a browser was opened; the value
+ *                   will arrive via the onSubmit callback. close() tears it down.
+ * - 'unavailable' : no way to open a browser here (headless / no opener) — the
+ *                   caller should fall through to the manual CLI instruction.
+ */
+export type AuthWebOutcome =
+  | { kind: 'launched'; close: () => void }
+  | { kind: 'unavailable' };
+
+export type AuthWebMode = 'password' | 'api-key';
+
+const TTL_MS = 2 * 60 * 1000; // single-use window before the server tears down
+const MAX_BODY = 64 * 1024;   // reject oversized POST bodies
+
+/**
+ * Detect how to open the user's default browser. Returns null when there is no
+ * graphical session or no opener available (e.g. headless / SSH).
+ */
+function findBrowserOpener(): { cmd: string; args: string[] } | null {
+  if (process.platform === 'darwin') return { cmd: 'open', args: [] };
+  if (process.platform === 'win32') return { cmd: 'cmd', args: ['/c', 'start', ''] };
+  // Linux / BSD: needs a display and xdg-open
+  if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) return null;
+  try {
+    execSync('which xdg-open', { stdio: 'ignore' });
+    return { cmd: 'xdg-open', args: [] };
+  } catch {
+    return null;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string
+  ));
+}
+
+function formPage(prompt: string, isApiKey: boolean, token: string, error?: string): string {
+  const errHtml = error ? `<p class="err">${escapeHtml(error)}</p>` : '';
+  const placeholder = isApiKey ? 'Secure value' : 'Password';
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>apra-fleet — secure entry</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 15px/1.5 system-ui, sans-serif; margin: 0; display: grid; place-items: center; min-height: 100vh; background: #f5f5f7; }
+  @media (prefers-color-scheme: dark) { body { background: #1c1c1e; color: #f5f5f7; } }
+  main { width: min(92vw, 420px); padding: 2rem; border-radius: 14px; background: Canvas; box-shadow: 0 8px 30px rgba(0,0,0,.12); }
+  h1 { font-size: 1.1rem; margin: 0 0 .25rem; letter-spacing: .02em; }
+  .prompt { margin: 0 0 1.25rem; opacity: .8; }
+  input, button { width: 100%; box-sizing: border-box; font: inherit; padding: .7rem .8rem; border-radius: 9px; }
+  input { border: 1px solid #8884; margin-bottom: .8rem; background: Field; color: FieldText; }
+  button { border: 0; background: #2563eb; color: #fff; font-weight: 600; cursor: pointer; }
+  button:hover { background: #1d4ed8; }
+  .note { font-size: .8rem; opacity: .6; margin: 1rem 0 0; }
+  .err { color: #dc2626; margin: 0 0 1rem; font-size: .85rem; }
+</style>
+</head><body>
+<main>
+  <h1>apra-fleet</h1>
+  <p class="prompt">${escapeHtml(prompt)}</p>
+  ${errHtml}
+  <form method="POST" action="/${token}" autocomplete="off">
+    <input type="password" name="value" placeholder="${placeholder}" autofocus required>
+    <button type="submit">Submit</button>
+  </form>
+  <p class="note">Sent only to 127.0.0.1 on this machine and encrypted immediately. Close this tab after submitting.</p>
+</main>
+</body></html>`;
+}
+
+function donePage(): string {
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>apra-fleet</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 15px/1.5 system-ui, sans-serif; margin: 0; display: grid; place-items: center; min-height: 100vh; background: #f5f5f7; }
+  @media (prefers-color-scheme: dark) { body { background: #1c1c1e; color: #f5f5f7; } }
+  main { text-align: center; padding: 2rem; }
+  h1 { font-size: 1.4rem; }
+</style></head><body>
+<main><h1>✓ Received</h1><p>Encrypted and stored. You can close this tab and return to your session.</p></main>
+</body></html>`;
+}
+
+/**
+ * Spin up a single-use, loopback-only web page that collects one credential and
+ * hands it to onSubmit (which encrypts it immediately). Hardened against the
+ * usual local-server pitfalls:
+ *   - binds to 127.0.0.1 only (never 0.0.0.0)
+ *   - the path carries a 256-bit unguessable token; other paths 404
+ *   - validates the Host header (DNS-rebinding defense)
+ *   - single submission, then tears down; hard TTL backstop
+ *   - never logs the submitted value
+ */
+export function launchAuthWeb(
+  memberName: string,
+  mode: AuthWebMode,
+  prompt: string,
+  onSubmit: (value: string) => { ok: boolean; error?: string },
+  _opts?: { openUrl?: (url: string) => void },
+): AuthWebOutcome {
+  // Resolve how to open the browser. An injected opener (tests) bypasses
+  // environment detection; otherwise we require a real opener to exist.
+  let openUrl: (url: string) => void;
+  if (_opts?.openUrl) {
+    openUrl = _opts.openUrl;
+  } else {
+    const opener = findBrowserOpener();
+    if (!opener) return { kind: 'unavailable' };
+    openUrl = (url) => {
+      try {
+        const child = spawn(opener.cmd, [...opener.args, url], { detached: true, stdio: 'ignore' });
+        child.on('error', (err) => logError('auth_web', `Failed to open browser for ${memberName}: ${err.message}`));
+        child.unref();
+      } catch (err: any) {
+        logError('auth_web', `Failed to open browser for ${memberName}: ${err.message}`);
+      }
+    };
+  }
+
+  const token = crypto.randomBytes(32).toString('hex');
+  const tokenPath = `/${token}`;
+  const isApiKey = mode === 'api-key';
+
+  let closed = false;
+  let ttlTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const server = http.createServer((req, res) => {
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    // DNS-rebinding defense: only accept loopback Host headers.
+    const host = req.headers.host ?? '';
+    if (host !== `127.0.0.1:${port}` && host !== `localhost:${port}`) {
+      res.writeHead(403, { 'Content-Type': 'text/plain' });
+      res.end('Forbidden');
+      return;
+    }
+
+    const pathname = new URL(req.url ?? '/', `http://127.0.0.1:${port}`).pathname;
+    if (pathname !== tokenPath) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+      return;
+    }
+
+    if (req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
+      res.end(formPage(prompt, isApiKey, token));
+      return;
+    }
+
+    if (req.method === 'POST') {
+      let body = '';
+      let tooBig = false;
+      req.on('data', (c: Buffer) => {
+        body += c.toString();
+        if (body.length > MAX_BODY) { tooBig = true; req.destroy(); }
+      });
+      req.on('end', () => {
+        if (tooBig) return;
+        const value = new URLSearchParams(body).get('value') ?? '';
+        if (!value) {
+          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
+          res.end(formPage(prompt, isApiKey, token, 'Value must not be empty.'));
+          return;
+        }
+        const result = onSubmit(value);
+        res.writeHead(result.ok ? 200 : 400, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
+        res.end(result.ok ? donePage() : formPage(prompt, isApiKey, token, result.error ?? 'Submission failed.'));
+        if (result.ok) close(); // single-use
+      });
+      return;
+    }
+
+    res.writeHead(405, { 'Content-Type': 'text/plain' });
+    res.end('Method not allowed');
+  });
+
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    if (ttlTimer) clearTimeout(ttlTimer);
+    try { server.close(); } catch { /* already closing */ }
+  }
+
+  server.on('error', (err) => {
+    logError('auth_web', `Local auth web server error: ${err.message}`);
+    close();
+  });
+
+  server.listen(0, '127.0.0.1', () => {
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    openUrl(`http://127.0.0.1:${port}${tokenPath}`);
+  });
+
+  ttlTimer = setTimeout(close, TTL_MS);
+
+  return { kind: 'launched', close };
+}

--- a/tests/auth-socket.test.ts
+++ b/tests/auth-socket.test.ts
@@ -15,6 +15,7 @@ import {
   hasGraphicalDisplay,
   hasInteractiveDesktop,
   launchAuthTerminal,
+  submitPassword,
 } from '../src/services/auth-socket.js';
 
 describe('auth-socket', () => {
@@ -32,6 +33,38 @@ describe('auth-socket', () => {
     it('returns a named pipe path on Windows', () => {
       // Can only truly test on Windows, but we can verify the function exists
       expect(typeof getSocketPath()).toBe('string');
+    });
+  });
+
+  describe('submitPassword', () => {
+    afterEach(() => {
+      cleanupAuthSocket();
+    });
+
+    it('fails when there is no pending auth for the member', () => {
+      const res = submitPassword('nobody', 'pw');
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain('No pending auth');
+    });
+
+    it('stores an encrypted password on a pending entry and reports ok', () => {
+      createPendingAuth('sub-member');
+      const res = submitPassword('sub-member', 'sup3r-secret');
+      expect(res.ok).toBe(true);
+      // The stored value is encrypted (crypto format is IV:tag:cipher), never plaintext.
+      const stored = getPendingPassword('sub-member');
+      expect(stored).toContain(':');
+      expect(stored).not.toContain('sup3r-secret');
+    });
+
+    it('resolves a waiting handler when the password arrives', async () => {
+      createPendingAuth('wait-member');
+      const waiting = waitForPassword('wait-member', 1000);
+      const res = submitPassword('wait-member', 'delivered');
+      expect(res.ok).toBe(true);
+      const encrypted = await waiting;
+      expect(encrypted).toContain(':');
+      expect(encrypted).not.toContain('delivered');
     });
   });
 

--- a/tests/auth-web.test.ts
+++ b/tests/auth-web.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import http from 'node:http';
+import { launchAuthWeb } from '../src/services/auth-web.js';
+
+interface Resp { status: number; body: string }
+
+function request(url: string, opts: { method?: string; host?: string; body?: string } = {}): Promise<Resp> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const headers: Record<string, string> = {};
+    if (opts.host !== undefined) headers.Host = opts.host;
+    if (opts.body !== undefined) {
+      headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      headers['Content-Length'] = String(Buffer.byteLength(opts.body));
+    }
+    const req = http.request(
+      { hostname: u.hostname, port: u.port, path: u.pathname + u.search, method: opts.method ?? 'GET', headers },
+      (res) => {
+        let b = '';
+        res.on('data', (c) => { b += c; });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: b }));
+      },
+    );
+    req.on('error', reject);
+    if (opts.body !== undefined) req.write(opts.body);
+    req.end();
+  });
+}
+
+/** Launch with an injected opener that captures the URL once the server is listening. */
+function launchCaptured(onSubmit: (v: string) => { ok: boolean; error?: string }) {
+  let resolveUrl!: (u: string) => void;
+  const urlPromise = new Promise<string>((r) => { resolveUrl = r; });
+  const handle = launchAuthWeb('test-member', 'password', 'Enter password for test-member', onSubmit, {
+    openUrl: (u) => resolveUrl(u),
+  });
+  return { handle, urlPromise };
+}
+
+describe('auth-web (local browser credential UI)', () => {
+  it('launches, binds to loopback, and serves a masked form on the token path', async () => {
+    const { handle, urlPromise } = launchCaptured(() => ({ ok: true }));
+    expect(handle.kind).toBe('launched');
+
+    const url = await urlPromise;
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/[a-f0-9]{64}$/);
+
+    const res = await request(url);
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('apra-fleet');
+    expect(res.body).toContain('type="password"');
+
+    if (handle.kind === 'launched') handle.close();
+  });
+
+  it('returns 404 for an unguessable-token mismatch', async () => {
+    const { handle, urlPromise } = launchCaptured(() => ({ ok: true }));
+    const url = await urlPromise;
+    const port = new URL(url).port;
+
+    const res = await request(`http://127.0.0.1:${port}/not-the-token`);
+    expect(res.status).toBe(404);
+
+    if (handle.kind === 'launched') handle.close();
+  });
+
+  it('rejects non-loopback Host headers (DNS-rebinding defense)', async () => {
+    const { handle, urlPromise } = launchCaptured(() => ({ ok: true }));
+    const url = await urlPromise;
+
+    const res = await request(url, { host: 'evil.example.com' });
+    expect(res.status).toBe(403);
+
+    if (handle.kind === 'launched') handle.close();
+  });
+
+  it('accepts a submitted value, calls onSubmit once, then tears down (single-use)', async () => {
+    const onSubmit = vi.fn(() => ({ ok: true }));
+    const { handle, urlPromise } = launchCaptured(onSubmit);
+    const url = await urlPromise;
+
+    const res = await request(url, { method: 'POST', body: 'value=hunter2' });
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('Received');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith('hunter2');
+
+    // Single-use: the server should have closed; a follow-up request is refused.
+    await new Promise((r) => setTimeout(r, 30));
+    await expect(request(url)).rejects.toThrow();
+  });
+
+  it('rejects an empty value with 400 and does not call onSubmit', async () => {
+    const onSubmit = vi.fn(() => ({ ok: true }));
+    const { handle, urlPromise } = launchCaptured(onSubmit);
+    const url = await urlPromise;
+
+    const res = await request(url, { method: 'POST', body: 'value=' });
+    expect(res.status).toBe(400);
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    if (handle.kind === 'launched') handle.close();
+  });
+
+  it('surfaces an onSubmit failure to the page without closing', async () => {
+    const onSubmit = vi.fn(() => ({ ok: false, error: 'No pending auth' }));
+    const { handle, urlPromise } = launchCaptured(onSubmit);
+    const url = await urlPromise;
+
+    const res = await request(url, { method: 'POST', body: 'value=whatever' });
+    expect(res.status).toBe(400);
+    expect(res.body).toContain('No pending auth');
+
+    // Still open after a failed submit — the user can retry.
+    const retry = await request(url);
+    expect(retry.status).toBe(200);
+
+    if (handle.kind === 'launched') handle.close();
+  });
+});

--- a/tests/auth-web.test.ts
+++ b/tests/auth-web.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import http from 'node:http';
 import { launchAuthWeb } from '../src/services/auth-web.js';
 
@@ -116,5 +116,58 @@ describe('auth-web (local browser credential UI)', () => {
     expect(retry.status).toBe(200);
 
     if (handle.kind === 'launched') handle.close();
+  });
+
+  // These exercise the REAL findBrowserOpener() (no injected openUrl), which is
+  // bypassed by every test above. They cover the platform-specific headless
+  // guards that decide whether to fall through to the manual CLI instruction.
+  describe('findBrowserOpener headless detection', () => {
+    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    const origSession = process.env.SESSIONNAME;
+    const origSshTty = process.env.SSH_TTY;
+
+    function setPlatform(p: NodeJS.Platform) {
+      Object.defineProperty(process, 'platform', { value: p, configurable: true });
+    }
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', origPlatform);
+      if (origSession === undefined) delete process.env.SESSIONNAME;
+      else process.env.SESSIONNAME = origSession;
+      if (origSshTty === undefined) delete process.env.SSH_TTY;
+      else process.env.SSH_TTY = origSshTty;
+    });
+
+    it('returns unavailable on headless Windows (SESSIONNAME != Console)', () => {
+      setPlatform('win32');
+      process.env.SESSIONNAME = 'RDP-Tcp#0';
+      const handle = launchAuthWeb('m', 'password', 'Enter password for m', () => ({ ok: true }));
+      expect(handle.kind).toBe('unavailable');
+      if (handle.kind === 'launched') handle.close();
+    });
+
+    it('launches on interactive Windows (SESSIONNAME == Console)', () => {
+      setPlatform('win32');
+      process.env.SESSIONNAME = 'Console';
+      const handle = launchAuthWeb('m', 'password', 'Enter password for m', () => ({ ok: true }));
+      expect(handle.kind).toBe('launched');
+      if (handle.kind === 'launched') handle.close();
+    });
+
+    it('returns unavailable on macOS over SSH (SSH_TTY set)', () => {
+      setPlatform('darwin');
+      process.env.SSH_TTY = '/dev/ttys000';
+      const handle = launchAuthWeb('m', 'password', 'Enter password for m', () => ({ ok: true }));
+      expect(handle.kind).toBe('unavailable');
+      if (handle.kind === 'launched') handle.close();
+    });
+
+    it('launches on local macOS (no SSH_TTY)', () => {
+      setPlatform('darwin');
+      delete process.env.SSH_TTY;
+      const handle = launchAuthWeb('m', 'password', 'Enter password for m', () => ({ ok: true }));
+      expect(handle.kind).toBe('launched');
+      if (handle.kind === 'launched') handle.close();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Out-of-band credential entry previously relied on spawning a terminal that runs `apra-fleet auth <member>`, with detection limited to `gnome-terminal`, `xterm`, and `x-terminal-emulator`. On many setups (kitty/alacritty/foot/konsole, or environments with no spawnable terminal such as the VSCode integrated terminal or tmux) this failed and dead-ended at a "run this manually" message.

This PR:

1. **Broadens terminal detection** — `findLinuxTerminal()` now checks `$TERM_PROGRAM` and probes a wider, ordered list of emulators (kitty, alacritty, foot, wezterm, ghostty, gnome-terminal, konsole, xfce4-terminal, mate-terminal, x-terminal-emulator, urxvt, xterm, st), each with its correct exec-flag convention.
2. **Adds a browser fallback** for `password`/`api-key` entry when no terminal is found — a hardened, loopback-only, single-use HTTP form opened via `xdg-open`/`open`/`start`. The submitted value flows through the same `submitPassword` path as the terminal/socket route, is encrypted immediately, and is never logged or exposed to the LLM.
3. **Extracts `submitPassword()`** so the socket (CLI) and browser paths deliver credentials identically.

The existing manual `apra-fleet auth <member>` message remains as the universal floor for headless/SSH.

Security hardening of the browser fallback:
- binds to `127.0.0.1` only (never `0.0.0.0`)
- 256-bit random token in the URL path; any other path → 404
- `Host`-header validation (DNS-rebinding defense)
- single submission then teardown; 2-minute TTL backstop
- submitted value and live URL never logged

Known limitation: the browser fallback is same-machine only (loopback) and does not help a remotely-hosted server — that would need a secure tunnel or MCP elicitation (out of scope).

Closes #290.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Ran `npm test` — all tests pass (1080 passing, incl. new `auth-web` hardening + `submitPassword` tests)
- [x] Ran `npm run build` — build succeeds (0 errors)
- [x] Manually tested the affected functionality — registered a password-auth member with no terminal available; browser form opened, value submitted, encrypted, and the flow continued

New tests:
- `tests/auth-web.test.ts` — loopback server hardening: token-path 404, non-loopback `Host` → 403, single-use teardown, empty-value rejection, failed-submit retry
- `tests/auth-socket.test.ts` — `submitPassword` unit coverage

## Checklist

- [x] My code follows the existing style and patterns in this codebase
- [x] I have updated documentation where necessary
- [x] Breaking changes are noted above and in the commit message
- [x] No new linting errors introduced
