### PR TITLE
fix(auth): pass --wait to gnome-terminal for OOB credential entry

### DIFF
--- a/src/services/auth-socket.ts
+++ b/src/services/auth-socket.ts
@@ -648,7 +648,12 @@ export function launchAuthTerminal(
         return `fallback:Could not find a terminal emulator. Ask the user to run manually:\n  ${[cmd, ...args].join(' ')}\nAlternatively, pre-store the value with credential_store_set and reference it as {{secure.NAME}} in the credential field.`;
       }
       if (terminal === 'gnome-terminal') {
-        child = spawn(terminal, ['--', ...fullArgs], { detached: true, stdio: 'ignore' });
+        // --wait is required: without it, gnome-terminal hands the window off to
+        // gnome-terminal-server and the client process exits immediately (code 0).
+        // That premature exit makes collectOobInput see raceResult===null and fall
+        // through to the 500ms grace window, cancelling before the user can type.
+        // With --wait the client stays alive until the secret CLI exits.
+        child = spawn(terminal, ['--wait', '--', ...fullArgs], { detached: true, stdio: 'ignore' });
       } else {
         // xterm, x-terminal-emulator etc.
         child = spawn(terminal, ['-e', ...fullArgs], { detached: true, stdio: 'ignore' });

--- a/tests/auth-terminal-wait.test.ts
+++ b/tests/auth-terminal-wait.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Capture spawn calls so we can assert on the args passed to the terminal emulator.
+const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+
+vi.mock('node:child_process', () => {
+  return {
+    spawn: (cmd: string, args: string[]) => {
+      spawnCalls.push({ cmd, args });
+      // Minimal fake ChildProcess: records handlers, never auto-exits.
+      return {
+        pid: 4242,
+        on: () => {},
+        unref: () => {},
+        stdin: { write: () => {}, end: () => {} },
+      };
+    },
+    // findLinuxTerminal() does `which <term>`; make gnome-terminal resolve.
+    execSync: (command: string) => {
+      if (command.includes('which gnome-terminal')) return Buffer.from('/usr/bin/gnome-terminal');
+      throw new Error('not found');
+    },
+    ChildProcess: class {},
+  };
+});
+
+describe('launchAuthTerminal -- Linux gnome-terminal --wait', () => {
+  beforeEach(() => {
+    spawnCalls.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it.skipIf(process.platform !== 'linux')(
+    'passes --wait so the client process stays alive until the secret CLI exits',
+    async () => {
+      // Ensure the graphical-display branch is taken (not the headless fallback).
+      vi.stubEnv('DISPLAY', ':0');
+      vi.stubEnv('WAYLAND_DISPLAY', '');
+
+      const { launchAuthTerminal } = await import('../src/services/auth-socket.js');
+      const result = launchAuthTerminal('mach1', [], () => {});
+
+      expect(result).toBe('launched');
+      expect(spawnCalls.length).toBe(1);
+      const { cmd, args } = spawnCalls[0];
+      expect(cmd).toBe('gnome-terminal');
+      // --wait must precede the '--' separator that introduces the command.
+      const waitIdx = args.indexOf('--wait');
+      const sepIdx = args.indexOf('--');
+      expect(waitIdx).toBeGreaterThanOrEqual(0);
+      expect(sepIdx).toBeGreaterThan(waitIdx);
+    },
+  );
+});


### PR DESCRIPTION
## Problem

When collecting an out-of-band credential on Linux via `gnome-terminal`, the terminal hands the new window off to `gnome-terminal-server` and the spawned client process exits immediately with code 0 (~340ms). `collectOobInput` then sees `raceResult === null` and falls through to its 500ms grace window, cancelling the request before the user can type the password -- even though the terminal window is still open and waiting for input.

## Fix

Pass `--wait` to `gnome-terminal`. This keeps the client process alive until the secret CLI exits, so the password submission wins the race instead of the spurious early exit.

```
spawn(terminal, ['--wait', '--', ...fullArgs], { detached: true, stdio: 'ignore' })
```

## Tests

Adds `tests/auth-terminal-wait.test.ts` asserting `--wait` precedes the `--` separator in the gnome-terminal spawn args. Passing locally.

## Note on blindfold

This patches `src/services/auth-socket.ts`, which is the in-tree copy used on `main`. PR #274 slices this code into the separate `blindfold` module, where the same one-line fix (at `src/auth-socket.ts`) plus test will be applied separately and the submodule pointer bumped. This PR keeps `main` correct in the meantime.