### PR TITLE
fix(cloud): expand $HOME in long_running TASK_DIR so monitor_task can find status (#297)

### DIFF
--- a/src/services/cloud/task-wrapper.ts
+++ b/src/services/cloud/task-wrapper.ts
@@ -31,7 +31,7 @@ export interface TaskConfig {
 export function generateTaskWrapper(config: TaskConfig): string {
   const cmdB64 = Buffer.from(config.command).toString('base64');
   const restartB64 = Buffer.from(config.restartCommand ?? config.command).toString('base64');
-  const taskDir = `~/.fleet-tasks/${config.taskId}`;
+  const taskDir = `$HOME/.fleet-tasks/${config.taskId}`;
 
   // We build the bash script as an array of lines then join, using
   // plain string concatenation for shell $VAR references to avoid

--- a/tests/task-wrapper.test.ts
+++ b/tests/task-wrapper.test.ts
@@ -29,6 +29,18 @@ describe('generateTaskWrapper - python3 removal', () => {
   });
 });
 
+describe('generateTaskWrapper - TASK_DIR uses $HOME (not tilde)', () => {
+  it('TASK_DIR contains $HOME/.fleet-tasks/', () => {
+    const script = generateTaskWrapper(baseConfig);
+    expect(script).toContain('TASK_DIR="$HOME/.fleet-tasks/');
+  });
+
+  it('does not contain a quoted literal tilde path', () => {
+    const script = generateTaskWrapper(baseConfig);
+    expect(script).not.toContain('"~/.fleet-tasks');
+  });
+});
+
 describe('generateTaskWrapper - restart_command (F1)', () => {
   it('MAIN_CMD and RESTART_CMD are same base64 when restartCommand is omitted', () => {
     const script = generateTaskWrapper(baseConfig);


### PR DESCRIPTION
## Summary
- **Root cause**: `generateTaskWrapper()` set `TASK_DIR="~/.fleet-tasks/<id>"` with the tilde inside double quotes, so bash treated `~` as a literal character. This created a `~/.fleet-tasks/` directory under the launch CWD (the member work folder) instead of under `$HOME`, splitting task artifacts from where `monitor_task` reads them (`$HOME/.fleet-tasks/<id>/`).
- **Fix**: Replace `~` with `$HOME` in the `taskDir` variable (`src/services/cloud/task-wrapper.ts:34`). `$HOME` expands correctly inside double quotes and handles paths with spaces.
- **Test**: Added regression test asserting the wrapper contains `$HOME/.fleet-tasks/` and does not contain the quoted literal tilde form `"~/.fleet-tasks`.

## Out of scope
The secondary ssh-inactivity-timeout issue mentioned in #297 is intentionally not addressed here.

Closes #297

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (85 files, 1364 tests passed, 14 skipped)
- [x] New test in `tests/task-wrapper.test.ts` covers both positive ($HOME present) and negative (no quoted tilde) assertions