### PR TITLE
fix(install): drop invalid bare-wildcard 'tracker_*' from Claude allow list

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -241,18 +241,25 @@ function mergeHooksConfig(paths: ProviderInstallConfig, hooksConfig: any, provid
 
 
 
-function mergePermissions(paths: ProviderInstallConfig): void {
-  const settings = readConfig(paths);
-
-  const requiredPerms = [
+export function buildRequiredPerms(paths: ProviderInstallConfig): string[] {
+  const perms = [
     'mcp__apra-fleet__*',
     'activate_skill(*)',
-    'tracker_*',
     'Agent(*)',
     `Read(${paths.skillsDir.replace(/\\/g, '/')}/**)`,
     `Read(${paths.fleetSkillsDir.replace(/\\/g, '/')}/**)`,
     `Read(${path.join(paths.configDir, 'skills').replace(/\\/g, '/')}/**)`,
   ];
+  if (paths.name !== 'Claude') {
+    perms.push('tracker_*');
+  }
+  return perms;
+}
+
+function mergePermissions(paths: ProviderInstallConfig): void {
+  const settings = readConfig(paths);
+
+  const requiredPerms = buildRequiredPerms(paths);
 
   settings.permissions = settings.permissions || {};
   settings.permissions.allow = settings.permissions.allow || [];

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -241,6 +241,13 @@ function mergeHooksConfig(paths: ProviderInstallConfig, hooksConfig: any, provid
 
 
 
+const CLAUDE_INVALID_RULES = ['tracker_*'];
+
+export function pruneInvalidRules(allow: string[], providerName: string): string[] {
+  if (providerName !== 'Claude') return allow;
+  return allow.filter(rule => !CLAUDE_INVALID_RULES.includes(rule));
+}
+
 export function buildRequiredPerms(paths: ProviderInstallConfig): string[] {
   const perms = [
     'mcp__apra-fleet__*',
@@ -263,6 +270,7 @@ function mergePermissions(paths: ProviderInstallConfig): void {
 
   settings.permissions = settings.permissions || {};
   settings.permissions.allow = settings.permissions.allow || [];
+  settings.permissions.allow = pruneInvalidRules(settings.permissions.allow as string[], paths.name);
   const existing = new Set(settings.permissions.allow as string[]);
   for (const perm of requiredPerms) {
     if (!existing.has(perm)) {

--- a/tests/install-permissions.test.ts
+++ b/tests/install-permissions.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { getProviderInstallConfig } from '../src/cli/config.js';
+import { buildRequiredPerms } from '../src/cli/install.js';
+
+describe('buildRequiredPerms', () => {
+  it('does not include tracker_* for Claude provider', () => {
+    const paths = getProviderInstallConfig('claude');
+    const perms = buildRequiredPerms(paths);
+    expect(perms).not.toContain('tracker_*');
+    for (const p of perms) {
+      expect(p).not.toMatch(/^[a-zA-Z_]+\*$/);
+    }
+  });
+
+  it('includes tracker_* for Gemini provider', () => {
+    const paths = getProviderInstallConfig('gemini');
+    const perms = buildRequiredPerms(paths);
+    expect(perms).toContain('tracker_*');
+  });
+
+  it('always includes mcp__apra-fleet__* and Agent(*)', () => {
+    for (const provider of ['claude', 'gemini', 'codex'] as const) {
+      const perms = buildRequiredPerms(getProviderInstallConfig(provider));
+      expect(perms).toContain('mcp__apra-fleet__*');
+      expect(perms).toContain('Agent(*)');
+    }
+  });
+});

--- a/tests/install-permissions.test.ts
+++ b/tests/install-permissions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getProviderInstallConfig } from '../src/cli/config.js';
-import { buildRequiredPerms } from '../src/cli/install.js';
+import { buildRequiredPerms, pruneInvalidRules } from '../src/cli/install.js';
 
 describe('buildRequiredPerms', () => {
   it('does not include tracker_* for Claude provider', () => {
@@ -24,5 +24,39 @@ describe('buildRequiredPerms', () => {
       expect(perms).toContain('mcp__apra-fleet__*');
       expect(perms).toContain('Agent(*)');
     }
+  });
+});
+
+describe('pruneInvalidRules', () => {
+  it('removes tracker_* from existing Claude allow list', () => {
+    const allow = ['mcp__apra-fleet__*', 'tracker_*', 'Agent(*)'];
+    const result = pruneInvalidRules(allow, 'Claude');
+    expect(result).not.toContain('tracker_*');
+    expect(result).toContain('mcp__apra-fleet__*');
+    expect(result).toContain('Agent(*)');
+  });
+
+  it('preserves tracker_* for Gemini provider', () => {
+    const allow = ['mcp__apra-fleet__*', 'tracker_*', 'Agent(*)'];
+    const result = pruneInvalidRules(allow, 'Gemini');
+    expect(result).toContain('tracker_*');
+  });
+
+  it('preserves tracker_* for non-Claude providers', () => {
+    for (const name of ['Gemini', 'Codex', 'Copilot', 'Antigravity']) {
+      const allow = ['tracker_*', 'other_rule'];
+      const result = pruneInvalidRules(allow, name);
+      expect(result).toContain('tracker_*');
+    }
+  });
+
+  it('is a no-op when tracker_* is not present for Claude', () => {
+    const allow = ['mcp__apra-fleet__*', 'Agent(*)'];
+    const result = pruneInvalidRules(allow, 'Claude');
+    expect(result).toEqual(allow);
+  });
+
+  it('handles empty allow list', () => {
+    expect(pruneInvalidRules([], 'Claude')).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

`mergePermissions()` in `src/cli/install.ts` unconditionally added `tracker_*` to the `permissions.allow` list. This is a bare-wildcard tool name that is only valid in Gemini CLI -- Claude Code rejects it in allow rules, printing an "Invalid settings ... allow: Invalid permission rule tracker_*" warning on every launch.

## Root cause

`tracker_*` is a Gemini CLI builtin tool glob. It was added to the shared `requiredPerms` array without gating on the provider, so it leaked into Claude settings.json.

## Fix

- Extracted `buildRequiredPerms(paths)` as a small pure helper (exported for testing)
- `tracker_*` is only pushed when `paths.name !== "Claude"`
- No behavior change for Gemini, Codex, Copilot, or Antigravity providers
- **NEW: Auto-prune on upgrade** -- `mergePermissions()` now calls `pruneInvalidRules()` before the dedup loop, removing stale `tracker_*` entries from existing Claude settings.json files. This is a zero-action migration: upgrading users get the invalid rule cleaned up automatically, not just new installs. Non-Claude providers are unaffected.

## Test plan

- [x] New `tests/install-permissions.test.ts` with 8 cases:
  - Claude provider: `tracker_*` absent in new installs, no bare-wildcard entries
  - Gemini provider: `tracker_*` present
  - All providers: core perms always present
  - pruneInvalidRules: removes `tracker_*` from existing Claude allow list
  - pruneInvalidRules: preserves `tracker_*` for Gemini and other non-Claude providers
  - pruneInvalidRules: no-op when `tracker_*` not present
  - pruneInvalidRules: handles empty allow list
- [x] `npm run build` succeeds
- [x] `npm test` passes (1372 passed, 14 skipped)