### PR TITLE
fix(e2e): switch opencode suites to GitHub-hosted runners with zero-setup free models

### DIFF
--- a/.github/e2e/lite-suites.json
+++ b/.github/e2e/lite-suites.json
@@ -6,7 +6,7 @@
       "id": "s10",
       "provider": "opencode",
       "cli": "opencode",
-      "model": "ollama/qwen3-coder:30b",
+      "model": "opencode/deepseek-v4-flash-free",
       "minCommits": 4,
       "expectedIssues": 3
     }

--- a/.github/e2e/members.json
+++ b/.github/e2e/members.json
@@ -41,9 +41,7 @@
   "opencode": {
     "host": "192.168.1.102",
     "username": "akhil",
-    "work_folder": "/home/akhil/git/apra-fleet-e2e",
-    "endpoint": "http://localhost:11434/v1",
-    "_comment": "OpenCode uses a user-provisioned Ollama endpoint; CI must ensure Ollama is running and the model is pulled before the suite starts"
+    "work_folder": "/home/akhil/git/apra-fleet-e2e"
   },
   "toy_projects": {
     "github":    "https://github.com/Apra-Labs/fleet-e2e-toy",

--- a/.github/e2e/suites.json
+++ b/.github/e2e/suites.json
@@ -94,28 +94,28 @@
       "pm":       { "os": "linux",   "provider": "opencode", "runner": "fleet-opencode" },
       "doer":     { "os": "linux",   "provider": "opencode", "type": "remote" },
       "reviewer": { "os": "linux",   "provider": "opencode", "type": "remote" },
-      "model": "ollama/qwen3-coder:30b",
+      "model": "opencode/deepseek-v4-flash-free",
       "vcs": "github"
     },
     "s9.1": {
       "pm":       { "os": "windows", "provider": "opencode", "runner": "fleet-opencode-win" },
       "doer":     { "os": "local_doer_windows",     "provider": "opencode", "type": "local" },
       "reviewer": { "os": "local_reviewer_windows", "provider": "opencode", "type": "local" },
-      "model": "ollama/qwen3-coder:30b",
+      "model": "opencode/deepseek-v4-flash-free",
       "vcs": "github"
     },
     "s9.2": {
       "pm":       { "os": "linux",   "provider": "opencode", "runner": "fleet-opencode" },
       "doer":     { "os": "local_doer_linux",     "provider": "opencode", "type": "local" },
       "reviewer": { "os": "local_reviewer_linux", "provider": "opencode", "type": "local" },
-      "model": "ollama/qwen3-coder:30b",
+      "model": "opencode/deepseek-v4-flash-free",
       "vcs": "github"
     },
     "s9.3": {
       "pm":       { "os": "macos",   "provider": "opencode", "runner": "fleet-opencode-mac" },
       "doer":     { "os": "local_doer_macos",     "provider": "opencode", "type": "local" },
       "reviewer": { "os": "local_reviewer_macos", "provider": "opencode", "type": "local" },
-      "model": "ollama/qwen3-coder:30b",
+      "model": "opencode/deepseek-v4-flash-free",
       "vcs": "github"
     }
   }

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -154,13 +154,15 @@ jobs:
             fi
           fi
 
-      - name: Verify OpenCode CLI if PM provider is opencode
+      - name: Install OpenCode CLI if not present
         if: steps.suite.outputs.pm_provider == 'opencode'
         shell: bash
         run: |
-          echo "Verifying OpenCode CLI is installed..."
-          opencode --version || { echo "::error::opencode CLI not found; install with: npm install -g opencode-ai"; exit 1; }
-          echo "OpenCode CLI verified"
+          if ! command -v opencode &> /dev/null; then
+            echo "OpenCode not found -- installing via npm..."
+            npm install -g opencode-ai
+          fi
+          opencode --version || { echo "::error::opencode CLI install failed"; exit 1; }
 
       - name: Prepare clean PM environment
         shell: bash

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -31,10 +31,10 @@ jobs:
          || inputs.suite == 's8.1' && 'fleet-windows'
          || inputs.suite == 's8.2' && 'fleet-linux'
          || inputs.suite == 's8.3' && 'fleet-macos'
-         || inputs.suite == 's9'   && 'fleet-opencode'
-         || inputs.suite == 's9.1' && 'fleet-opencode-win'
-         || inputs.suite == 's9.2' && 'fleet-opencode'
-         || inputs.suite == 's9.3' && 'fleet-opencode-mac'
+         || inputs.suite == 's9'   && 'ubuntu-latest'
+         || inputs.suite == 's9.1' && 'windows-latest'
+         || inputs.suite == 's9.2' && 'ubuntu-latest'
+         || inputs.suite == 's9.3' && 'macos-latest'
          || 'fleet-macos' }}
 
     steps:
@@ -154,19 +154,13 @@ jobs:
             fi
           fi
 
-      - name: Verify OpenCode + Ollama if PM provider is opencode
+      - name: Verify OpenCode CLI if PM provider is opencode
         if: steps.suite.outputs.pm_provider == 'opencode'
         shell: bash
         run: |
           echo "Verifying OpenCode CLI is installed..."
           opencode --version || { echo "::error::opencode CLI not found; install with: npm install -g opencode-ai"; exit 1; }
-          MEMBERS=$(cat .github/e2e/members.json)
-          ENDPOINT=$(echo "$MEMBERS" | jq -r '.opencode.endpoint // "http://localhost:11434/v1"')
-          echo "Verifying Ollama endpoint at $ENDPOINT ..."
-          curl -sf "$ENDPOINT/models" > /dev/null 2>&1 \
-            || curl -sf "$(echo "$ENDPOINT" | sed 's|/v1$||')/api/tags" > /dev/null 2>&1 \
-            || { echo "::error::Ollama endpoint not reachable at $ENDPOINT"; exit 1; }
-          echo "OpenCode CLI and Ollama endpoint verified"
+          echo "OpenCode CLI verified"
 
       - name: Prepare clean PM environment
         shell: bash


### PR DESCRIPTION
## Summary

Migrates all OpenCode E2E suites (s9, s9.1, s9.2, s9.3, s10) from self-hosted Ollama-backed runners to standard GitHub-hosted runners using a free hosted model. No local GPU or infrastructure is required to run these suites.

## Changes

### Runners (fleet-e2e.yml, suites.json)
- s9, s9.2: fleet-opencode -> ubuntu-latest
- s9.1: fleet-opencode-win -> windows-latest
- s9.3: fleet-opencode-mac -> macos-latest

### Model (suites.json, lite-suites.json)
- ollama/qwen3-coder:30b -> opencode/deepseek-v4-flash-free across all four s9 suites and s10 lite suite

### Workflow (fleet-e2e.yml)
- Replaced the "Verify OpenCode + Ollama" step (which curled a local Ollama endpoint) with "Install OpenCode CLI if not present" (auto-installs via npm install -g opencode-ai on fresh GitHub-hosted runners)
- Removed all Ollama endpoint verification logic -- hosted free models need no local server

### Config (members.json)
- Removed endpoint and _comment fields from the opencode member entry (Ollama config no longer needed)

### Submodule (vendor/apra-pm)
- Bumped to d141720 (s9 opencode suites green) then fcdd919 (revert manual opencode scenario)

## Why

OpenCode's hosted free models (deepseek-v4-flash-free) require no local Ollama server or GPU. Self-hosted runners were only needed to serve the local model. Switching to GitHub-hosted runners:
- Unblocks contributors who do not have self-hosted runners
- Eliminates CI dependency on a specific machine being online with Ollama running and the model pre-pulled
- Reduces fleet maintenance burden (no runner registration, no model management)