### PR TITLE
docs(readme): add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](https://github.com/Apra-Labs/apra-fleet/releases)
 [![MCP](https://img.shields.io/badge/MCP-compatible-8A2BE2.svg)](https://modelcontextprotocol.io)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Apra-Labs/apra-fleet)
 
 ### One goal. A team of AI agents that plan, execute, and review each other's work, and run across every machine you own.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,6 +7,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](https://github.com/Apra-Labs/apra-fleet/releases)
 [![MCP](https://img.shields.io/badge/MCP-compatible-8A2BE2.svg)](https://modelcontextprotocol.io)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Apra-Labs/apra-fleet)
 
 ### One goal. A team of AI agents that plan, execute, and review each other's work, and run across every machine you own.
 


### PR DESCRIPTION
## Summary
- Adds a DeepWiki badge (https://deepwiki.com/Apra-Labs/apra-fleet) to the existing badge row in README.md, alongside CI/License/Platform/MCP.
- Matches Apra-Labs/apra-pm#18.
- llms-full.txt auto-regenerated by the pre-commit hook to reflect the README change.

## Test plan
- [x] Docs-only change, no code touched
- [x] Rendered markdown reviewed manually (badge syntax valid, matches existing badge style)