### PR TITLE
feat(cli): repoint apra-fleet join to fleet-dashboard's real API

### DIFF
--- a/src/cli/join.ts
+++ b/src/cli/join.ts
@@ -1,14 +1,24 @@
 /**
- * `apra-fleet join <token>` (apra-fleet-us9.5/fnz.4): exchanges a
- * hub-issued enrollment token for a machine JWT, entirely via an OUTBOUND
- * call to the hub -- no local server needs to accept any inbound
- * connection for this (docs/hub-spoke-master-plan.md section 4). Stores
- * the result locally for apra-fleet-us9.6 (spoke mode, not yet built) to
- * eventually use for its outbound hub connection.
+ * `apra-fleet join <member-jwt>` (apra-fleet-6bf, superseding apra-fleet-us9.5/
+ * fnz.4's hub-service-based flow): activates a device using a member JWT
+ * that a human already obtained out-of-band from fleet-dashboard
+ * (POST /v1/ws/:id/members via the dashboard UI, per the AGREED "1b" flow in
+ * docs/bootstrap-sync-design-proposal.md -- fleet-dashboard has no
+ * short-lived exchange-token endpoint yet, so the long-lived member JWT
+ * itself is the credential handed to the device).
+ *
+ * This calls fleet-dashboard's POST /v1/ws/:id/members/:mid/connect
+ * (docs/api-contract.md "Members (JWT-scoped agents)") -- documented as
+ * "apra-fleet.exe's first call after registration", which both validates the
+ * token (rejecting an unknown/revoked/wrong-workspace/wrong-member token
+ * before anything is stored locally) and flips the member's status from
+ * "awaiting-connect" to "online" server-side. workspaceId and memberId are
+ * read off the token's own `ws`/`sub` claims (decoded, not
+ * cryptographically verified -- fleet-dashboard is the only party that can
+ * verify the signature; an invalid token simply gets rejected by connect).
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
 import { FLEET_DIR } from '../paths.js';
 
 export const HUB_CREDENTIALS_PATH = path.join(FLEET_DIR, 'hub-credentials.json');
@@ -22,15 +32,28 @@ export interface HubCredentials {
 
 export interface JoinDeps {
   fetch: typeof fetch;
-  hostname(): string;
 }
 
-const realDeps: JoinDeps = { fetch: (...a) => globalThis.fetch(...a), hostname: () => os.hostname() };
+const realDeps: JoinDeps = { fetch: (...a) => globalThis.fetch(...a) };
+
+interface MemberJwtClaims {
+  sub?: string;
+  ws?: string;
+}
+
+function decodeMemberJwtClaims(token: string): MemberJwtClaims {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('token is not a valid JWT (expected header.payload.signature)');
+  }
+  const payload = Buffer.from(parts[1], 'base64url').toString('utf-8');
+  return JSON.parse(payload) as MemberJwtClaims;
+}
 
 export async function runJoin(args: string[], deps: JoinDeps = realDeps): Promise<void> {
   const token = args[0];
   if (!token) {
-    console.error('Usage: apra-fleet join <token> [--hub-url <url>]');
+    console.error('Usage: apra-fleet join <member-jwt> [--hub-url <url>]');
     process.exitCode = 1;
     return;
   }
@@ -40,17 +63,33 @@ export async function runJoin(args: string[], deps: JoinDeps = realDeps): Promis
     ? args[hubUrlIdx + 1]
     : (process.env.APRA_FLEET_HUB_URL ?? 'https://fleet.apralabs.com');
 
-  const hostname = deps.hostname();
+  let claims: MemberJwtClaims;
+  try {
+    claims = decodeMemberJwtClaims(token);
+  } catch (err: any) {
+    console.error(`Invalid member JWT: ${err.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!claims.ws || !claims.sub) {
+    console.error('Invalid member JWT: missing workspace (ws) or member (sub) claim');
+    process.exitCode = 1;
+    return;
+  }
+
+  const workspaceId = claims.ws;
+  const memberId = claims.sub;
 
   let response: Response;
   try {
-    response = await deps.fetch(`${hubUrl}/join/exchange`, {
+    response = await deps.fetch(`${hubUrl}/v1/ws/${workspaceId}/members/${memberId}/connect`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token, hostname }),
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({}),
     });
   } catch (err: any) {
-    console.error(`Could not reach hub at ${hubUrl}: ${err.message}`);
+    console.error(`Could not reach fleet-dashboard at ${hubUrl}: ${err.message}`);
     process.exitCode = 1;
     return;
   }
@@ -62,13 +101,13 @@ export async function runJoin(args: string[], deps: JoinDeps = realDeps): Promis
     return;
   }
 
-  const result = await response.json() as { machineId: string; workspaceId: string; jwt: string };
+  const result = await response.json() as { member: { id: string; name?: string } };
 
   fs.mkdirSync(FLEET_DIR, { recursive: true, mode: 0o700 });
-  const credentials: HubCredentials = { hubUrl, machineId: result.machineId, workspaceId: result.workspaceId, jwt: result.jwt };
+  const credentials: HubCredentials = { hubUrl, machineId: memberId, workspaceId, jwt: token };
   fs.writeFileSync(HUB_CREDENTIALS_PATH, JSON.stringify(credentials, null, 2), { mode: 0o600 });
 
-  console.log(`Enrolled machine ${result.machineId} in workspace ${result.workspaceId}.`);
+  console.log(`Enrolled machine ${result.member.id} in workspace ${workspaceId}.`);
   console.log(`Hub credentials stored at ${HUB_CREDENTIALS_PATH}.`);
   console.log('Spoke mode (outbound hub connectivity, apra-fleet-us9.6) is not yet built -- this credential is stored for that future use.');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ Usage:
   apra-fleet auth --oauth [--llm <provider>] secure.<name>    Resolve token from persistent credential store
   apra-fleet auth --api-key [--llm <provider>] <token>        Set API key in shell profiles / system env
   apra-fleet auth --api-key [--llm <provider>] secure.<name>  Resolve API key from persistent credential store
-  apra-fleet join <token> [--hub-url <url>]  Exchange a hub enrollment token for a machine JWT (apra-fleet-us9.5/fnz.4)
+  apra-fleet join <member-jwt> [--hub-url <url>]  Activate a device using a member JWT obtained out-of-band from fleet-dashboard (apra-fleet-6bf)
   apra-fleet spoke <origin-member-id>        Run as an outbound hub-connected spoke (apra-fleet-jfn); requires apra-fleet join first
   apra-fleet --version        Print version
   apra-fleet --help           Show this help`);

--- a/tests/join.test.ts
+++ b/tests/join.test.ts
@@ -25,10 +25,20 @@ afterEach(() => {
 });
 
 function fakeDeps(fetchImpl: typeof fetch) {
-  return { fetch: fetchImpl, hostname: () => 'test-hostname' };
+  return { fetch: fetchImpl };
 }
 
-describe('apra-fleet join <token> (apra-fleet-us9.5/fnz.4)', () => {
+// A fleet-dashboard member JWT is a real signed JWT; join.ts only decodes
+// the payload locally (it has no way to verify the signature -- only
+// fleet-dashboard's backend can), so a fake unsigned header.payload.sig
+// with the right claims shape is a faithful test double.
+function fakeMemberJwt(claims: { sub: string; ws: string }): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url');
+  return `${header}.${payload}.fake-signature`;
+}
+
+describe('apra-fleet join <member-jwt> (apra-fleet-6bf)', () => {
   it('prints usage and sets a non-zero exit code when no token is given', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     await joinMod.runJoin([], fakeDeps(vi.fn() as any));
@@ -38,48 +48,77 @@ describe('apra-fleet join <token> (apra-fleet-us9.5/fnz.4)', () => {
     errorSpy.mockRestore();
   });
 
-  it('exchanges the token with the hub and stores the resulting credentials locally', async () => {
+  it('rejects a malformed token before making any network call', async () => {
+    const fetchMock = vi.fn();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await joinMod.runJoin(['not-a-jwt'], fakeDeps(fetchMock));
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid member JWT'));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+    errorSpy.mockRestore();
+  });
+
+  it('rejects a token whose payload is missing ws/sub claims', async () => {
+    const badToken = `${Buffer.from('{}').toString('base64url')}.${Buffer.from('{}').toString('base64url')}.sig`;
+    const fetchMock = vi.fn();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await joinMod.runJoin([badToken], fakeDeps(fetchMock));
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('missing workspace (ws) or member (sub) claim'));
+    expect(fetchMock).not.toHaveBeenCalled();
+    process.exitCode = 0;
+    errorSpy.mockRestore();
+  });
+
+  it('calls fleet-dashboard connect with the decoded workspace/member ids and stores credentials locally', async () => {
+    const token = fakeMemberJwt({ sub: 'member-1', ws: 'ws-1' });
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ machineId: 'm-1', workspaceId: 'ws-1', jwt: 'the-jwt' }),
+      json: async () => ({ member: { id: 'member-1', name: 'alice' } }),
     });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await joinMod.runJoin(['tok-123', '--hub-url', 'https://custom-hub.example.com'], fakeDeps(fetchMock));
+    await joinMod.runJoin([token, '--hub-url', 'https://custom-dashboard.example.com'], fakeDeps(fetchMock));
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://custom-hub.example.com/join/exchange',
+      'https://custom-dashboard.example.com/v1/ws/ws-1/members/member-1/connect',
       expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ token: 'tok-123', hostname: 'test-hostname' }),
+        headers: expect.objectContaining({ Authorization: `Bearer ${token}` }),
       }),
     );
 
     const stored = JSON.parse(fs.readFileSync(joinMod.HUB_CREDENTIALS_PATH, 'utf-8'));
     expect(stored).toEqual({
-      hubUrl: 'https://custom-hub.example.com',
-      machineId: 'm-1',
+      hubUrl: 'https://custom-dashboard.example.com',
+      machineId: 'member-1',
       workspaceId: 'ws-1',
-      jwt: 'the-jwt',
+      jwt: token,
     });
     logSpy.mockRestore();
   });
 
-  it('defaults to APRA_FLEET_HUB_URL env var, then the public hub URL, when --hub-url is omitted', async () => {
-    process.env.APRA_FLEET_HUB_URL = 'https://env-hub.example.com';
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ machineId: 'm', workspaceId: 'ws', jwt: 'j' }) });
+  it('defaults to APRA_FLEET_HUB_URL env var, then the public dashboard URL, when --hub-url is omitted', async () => {
+    process.env.APRA_FLEET_HUB_URL = 'https://env-dashboard.example.com';
+    const token = fakeMemberJwt({ sub: 'm', ws: 'ws' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ member: { id: 'm' } }) });
     vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await joinMod.runJoin(['tok'], fakeDeps(fetchMock));
+    await joinMod.runJoin([token], fakeDeps(fetchMock));
 
-    expect(fetchMock).toHaveBeenCalledWith('https://env-hub.example.com/join/exchange', expect.anything());
+    expect(fetchMock).toHaveBeenCalledWith('https://env-dashboard.example.com/v1/ws/ws/members/m/connect', expect.anything());
   });
 
-  it('reports a clear error and sets exitCode=1 when the hub rejects the token', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized', text: async () => '{"error":"invalid, expired, or already-used token"}' });
+  it('reports a clear error and sets exitCode=1 when fleet-dashboard rejects the token', async () => {
+    const token = fakeMemberJwt({ sub: 'member-1', ws: 'ws-1' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized', text: async () => '{"error":"invalid_token"}' });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await joinMod.runJoin(['bad-token'], fakeDeps(fetchMock));
+    await joinMod.runJoin([token], fakeDeps(fetchMock));
 
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('401'));
     expect(process.exitCode).toBe(1);
@@ -88,13 +127,14 @@ describe('apra-fleet join <token> (apra-fleet-us9.5/fnz.4)', () => {
     errorSpy.mockRestore();
   });
 
-  it('reports a clear error and sets exitCode=1 when the hub is unreachable', async () => {
+  it('reports a clear error and sets exitCode=1 when fleet-dashboard is unreachable', async () => {
+    const token = fakeMemberJwt({ sub: 'member-1', ws: 'ws-1' });
     const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await joinMod.runJoin(['tok'], fakeDeps(fetchMock));
+    await joinMod.runJoin([token], fakeDeps(fetchMock));
 
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Could not reach hub'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Could not reach fleet-dashboard'));
     expect(process.exitCode).toBe(1);
     process.exitCode = 0;
     errorSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Closes apra-fleet-6bf, now unblocked since fleet-dashboard-anw (ironWall on members.ts) closed.
- `apra-fleet join <member-jwt>` no longer exchanges a token against apra-fleet-reorg's own retiring hub-service. Per the AGREED docs/bootstrap-sync-design-proposal.md "1b" flow, it now activates a device using a member JWT a human already obtained out-of-band from fleet-dashboard (POST /v1/ws/:id/members via the dashboard UI), calling fleet-dashboard's POST /v1/ws/:id/members/:mid/connect.
- HubCredentials shape and src/cli/spoke.ts's consumption of it are unchanged.

## Note on base branch
This PR targets `chore/hub-service-retire-and-docs` (not `main`) -- that branch (and the underlying `feat/hub-spoke-migration` it stacks on) is not yet merged to `main`, so targeting `main` directly would show the entire feature's diff, not just this change. Stack: main <- feat/hub-spoke-migration <- chore/hub-service-retire-and-docs (PR #320) <- this PR.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run tests/join.test.ts` -- 7/7 passing (rewritten for the new JWT/connect flow)
- [x] Full suite: 2135/2135 passing, 18 skipped (pre-existing), zero regressions

https://claude.ai/code/session_01NqDBN8WWZMpD2uCg5NC4dv