### PR TITLE
feat(sync): pull-sync workspace config from fleet-dashboard

### DIFF
--- a/src/services/cloud-sync.ts
+++ b/src/services/cloud-sync.ts
@@ -1,0 +1,115 @@
+/**
+ * Pull-sync (apra-fleet-aho): fetches the SaaS-connected workspace's
+ * member/project config from fleet-dashboard's GET /v1/ws/:id/bootstrap
+ * (fleet-dashboard-1il) and caches it as a sibling JSON file, per
+ * docs/bootstrap-sync-design-proposal.md question 2 ("one JSON file or
+ * two, not JSON vs. a DB") -- deliberately NOT merged into
+ * registry.ts's registry.json, since a fleet-dashboard "workspace member"
+ * (a cloud collaborator/agent identity) is a different concept from this
+ * file's local SSH/relay-connected Agent registry.
+ *
+ * Sync is a plain on-demand fetch (no background polling daemon, per
+ * question 4) with fail-open behavior (question 5): network failure or a
+ * 5xx/429 response falls back to the last-synced cache rather than
+ * blocking the caller, but a 401 is a distinct, non-fail-open state
+ * (rotation has no grace period -- silently retrying on a dead credential
+ * would mask a deliberate revocation) that callers must surface, not swallow.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { FLEET_DIR } from '../paths.js';
+import { HUB_CREDENTIALS_PATH, type HubCredentials } from '../cli/join.js';
+import { enforceOwnerOnly } from '../utils/file-permissions.js';
+
+export const CLOUD_CACHE_PATH = path.join(FLEET_DIR, 'cloud-cache.json');
+
+export interface CloudCache {
+  workspaceId: string;
+  // Kept as unknown[] (not a narrowed Member/Project type) so unrecognized
+  // fields fleet-dashboard adds later round-trip through this cache
+  // untouched, per the negotiation's additive-only contract-evolution rule.
+  members: unknown[];
+  projects: unknown[];
+  lastSyncedAt: number;
+}
+
+export type CloudSyncResult =
+  | { status: 'synced'; cache: CloudCache }
+  | { status: 'offline'; cache: CloudCache | null }
+  | { status: 'not-connected' }
+  | { status: 'credential-expired' };
+
+export interface CloudSyncDeps {
+  fetch: typeof fetch;
+  now(): number;
+  readCredentials(): HubCredentials | null;
+}
+
+const realDeps: CloudSyncDeps = {
+  fetch: (...a) => globalThis.fetch(...a),
+  now: () => Date.now(),
+  readCredentials: readHubCredentials,
+};
+
+export function readHubCredentials(): HubCredentials | null {
+  if (!fs.existsSync(HUB_CREDENTIALS_PATH)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(HUB_CREDENTIALS_PATH, 'utf-8')) as HubCredentials;
+  } catch {
+    return null;
+  }
+}
+
+export function readCloudCache(): CloudCache | null {
+  if (!fs.existsSync(CLOUD_CACHE_PATH)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(CLOUD_CACHE_PATH, 'utf-8')) as CloudCache;
+  } catch {
+    return null;
+  }
+}
+
+function writeCloudCache(cache: CloudCache): void {
+  fs.mkdirSync(FLEET_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(CLOUD_CACHE_PATH, JSON.stringify(cache, null, 2), { mode: 0o600 });
+  enforceOwnerOnly(CLOUD_CACHE_PATH);
+}
+
+/**
+ * Fail-open triggers on network failure or any non-401 error response
+ * (5xx, 429, or anything else fleet-dashboard might return) -- never on
+ * 401, which is surfaced as its own distinct `credential-expired` status
+ * so a caller can prompt for re-enrollment/rotation instead of silently
+ * operating on stale data next to a dead credential.
+ */
+export async function syncCloudCache(deps: CloudSyncDeps = realDeps): Promise<CloudSyncResult> {
+  const creds = deps.readCredentials();
+  if (!creds) return { status: 'not-connected' };
+
+  let response: Response;
+  try {
+    response = await deps.fetch(`${creds.hubUrl}/v1/ws/${creds.workspaceId}/bootstrap`, {
+      headers: { Authorization: `Bearer ${creds.jwt}` },
+    });
+  } catch {
+    return { status: 'offline', cache: readCloudCache() };
+  }
+
+  if (response.status === 401) {
+    return { status: 'credential-expired' };
+  }
+
+  if (!response.ok) {
+    return { status: 'offline', cache: readCloudCache() };
+  }
+
+  const body = await response.json().catch(() => null) as { members?: unknown[]; projects?: unknown[] } | null;
+  const cache: CloudCache = {
+    workspaceId: creds.workspaceId,
+    members: body?.members ?? [],
+    projects: body?.projects ?? [],
+    lastSyncedAt: deps.now(),
+  };
+  writeCloudCache(cache);
+  return { status: 'synced', cache };
+}

--- a/src/tools/list-members.ts
+++ b/src/tools/list-members.ts
@@ -7,6 +7,7 @@ import { getOsCommands } from '../os/index.js';
 import { getProvider } from '../providers/index.js';
 import { getAgentOS, groupByCategory, formatAgentHost } from '../utils/agent-helpers.js';
 import type { Agent } from '../types.js';
+import { syncCloudCache } from '../services/cloud-sync.js';
 
 export const listMembersSchema = z.object({
   format: z.enum(['compact', 'json']).default('compact').describe('Output format: "compact" (default, few lines) or "json" (structured data for detailed rendering)'),
@@ -80,10 +81,25 @@ export async function listMembers(input?: ListMembersInput): Promise<string> {
   const authStatusPromises = agents.map(getAuthStatus);
   const authStatuses = await Promise.all(authStatusPromises);
 
+  // SaaS-connected devices (apra-fleet-aho) additionally surface the
+  // cloud workspace's own member/project list -- a fleet-dashboard
+  // "workspace member" is a distinct concept from this file's local
+  // SSH/relay Agent registry above, so it's reported as its own section
+  // rather than merged into `agents`. A standalone (no hub-credentials.json)
+  // instance gets `status: 'not-connected'` and this adds nothing to the
+  // output, so existing standalone behavior/tests are unaffected.
+  const cloudSync = await syncCloudCache();
+
   if (format === 'json') {
     return JSON.stringify({
       server_version: serverVersion,
       total: agents.length,
+      cloud: cloudSync.status === 'not-connected' ? undefined : {
+        status: cloudSync.status,
+        members: cloudSync.status === 'synced' ? cloudSync.cache.members : cloudSync.status === 'offline' ? (cloudSync.cache?.members ?? []) : [],
+        projects: cloudSync.status === 'synced' ? cloudSync.cache.projects : cloudSync.status === 'offline' ? (cloudSync.cache?.projects ?? []) : [],
+        lastSyncedAt: cloudSync.status === 'synced' ? cloudSync.cache.lastSyncedAt : cloudSync.status === 'offline' ? (cloudSync.cache?.lastSyncedAt ?? null) : null,
+      },
       members: agents.map((a, i) => ({
         id: a.id,
         name: a.friendlyName,
@@ -109,7 +125,15 @@ export async function listMembers(input?: ListMembersInput): Promise<string> {
   const combined = agents.map((agent, i) => ({ agent, authStatus: authStatuses[i] }));
   const { grouped, sortedKeys } = groupByCategory(combined, ({ agent: a }) => a.category?.trim());
 
-  let t = `${agents.length} member(s)\n`;
+  let t = '';
+  if (cloudSync.status === 'synced') {
+    t += `[cloud] ${cloudSync.cache.members.length} workspace member(s), ${cloudSync.cache.projects.length} project(s)\n`;
+  } else if (cloudSync.status === 'offline') {
+    t += `[cloud] fleet-dashboard unreachable -- showing last synced data (${cloudSync.cache?.members.length ?? 0} member(s), ${cloudSync.cache?.projects.length ?? 0} project(s))\n`;
+  } else if (cloudSync.status === 'credential-expired') {
+    t += `[cloud] credential expired or revoked -- run \`apra-fleet join <member-jwt>\` again\n`;
+  }
+  t += `${agents.length} member(s)\n`;
   for (const category of sortedKeys) {
     const members = grouped.get(category)!;
     t += `\n[${category}]\n`;

--- a/tests/cloud-sync.test.ts
+++ b/tests/cloud-sync.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Same eager-FLEET_DIR-evaluation caveat as tests/join.test.ts -- fresh tmp
+// dir + dynamic re-import per test, not a plain env var set after import.
+let tmpDataDir: string;
+let cloudSyncMod: typeof import('../src/services/cloud-sync.js');
+
+beforeEach(async () => {
+  tmpDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-cloud-sync-test-'));
+  process.env.APRA_FLEET_DATA_DIR = tmpDataDir;
+  vi.resetModules();
+  cloudSyncMod = await import('../src/services/cloud-sync.js');
+});
+
+afterEach(() => {
+  delete process.env.APRA_FLEET_DATA_DIR;
+  vi.resetModules();
+  fs.rmSync(tmpDataDir, { recursive: true, force: true });
+});
+
+const CREDS = { hubUrl: 'https://dashboard.example.com', machineId: 'member-1', workspaceId: 'ws-1', jwt: 'the-jwt' };
+
+function depsWithCreds(fetchImpl: typeof fetch, creds: typeof CREDS | null = CREDS, now = () => 1000) {
+  return { fetch: fetchImpl, now, readCredentials: () => creds };
+}
+
+describe('syncCloudCache (apra-fleet-aho)', () => {
+  it('returns not-connected when there are no hub credentials (standalone mode)', async () => {
+    const fetchMock = vi.fn();
+    const result = await cloudSyncMod.syncCloudCache(depsWithCreds(fetchMock, null));
+    expect(result).toEqual({ status: 'not-connected' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches GET /v1/ws/:id/bootstrap with the member JWT and caches the result', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ members: [{ id: 'm1' }], projects: [{ id: 'p1' }] }),
+    });
+
+    const result = await cloudSyncMod.syncCloudCache(depsWithCreds(fetchMock));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://dashboard.example.com/v1/ws/ws-1/bootstrap',
+      expect.objectContaining({ headers: { Authorization: 'Bearer the-jwt' } }),
+    );
+    expect(result).toEqual({
+      status: 'synced',
+      cache: { workspaceId: 'ws-1', members: [{ id: 'm1' }], projects: [{ id: 'p1' }], lastSyncedAt: 1000 },
+    });
+
+    const onDisk = cloudSyncMod.readCloudCache();
+    expect(onDisk).toEqual(result.status === 'synced' ? result.cache : undefined);
+  });
+
+  it('preserves unrecognized fields on members/projects (additive-only contract evolution)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ members: [{ id: 'm1', futureField: 'x' }], projects: [] }),
+    });
+
+    const result = await cloudSyncMod.syncCloudCache(depsWithCreds(fetchMock));
+
+    expect(result.status).toBe('synced');
+    expect((result as any).cache.members[0]).toEqual({ id: 'm1', futureField: 'x' });
+  });
+
+  it('fails open to the last-synced cache on a network error, without throwing', async () => {
+    const okFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ members: [{ id: 'm1' }], projects: [] }) });
+    await cloudSyncMod.syncCloudCache(depsWithCreds(okFetch));
+
+    const failingFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await cloudSyncMod.syncCloudCache(depsWithCreds(failingFetch));
+
+    expect(result.status).toBe('offline');
+    expect((result as any).cache.members).toEqual([{ id: 'm1' }]);
+  });
+
+  it('fails open to the last-synced cache on a 5xx response', async () => {
+    const okFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ members: [{ id: 'm1' }], projects: [] }) });
+    await cloudSyncMod.syncCloudCache(depsWithCreds(okFetch));
+
+    const failingFetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    const result = await cloudSyncMod.syncCloudCache(depsWithCreds(failingFetch));
+
+    expect(result.status).toBe('offline');
+    expect((result as any).cache.members).toEqual([{ id: 'm1' }]);
+  });
+
+  it('fails open to null cache when offline and nothing was ever synced', async () => {
+    const failingFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await cloudSyncMod.syncCloudCache(depsWithCreds(failingFetch));
+    expect(result).toEqual({ status: 'offline', cache: null });
+  });
+
+  it('does NOT fail open on 401 -- surfaces credential-expired instead of serving stale cache', async () => {
+    const okFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ members: [{ id: 'm1' }], projects: [] }) });
+    await cloudSyncMod.syncCloudCache(depsWithCreds(okFetch));
+
+    const unauthorizedFetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await cloudSyncMod.syncCloudCache(depsWithCreds(unauthorizedFetch));
+
+    expect(result).toEqual({ status: 'credential-expired' });
+  });
+});

--- a/tests/list-members.test.ts
+++ b/tests/list-members.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { listMembers } from '../src/tools/list-members.js';
 import { addAgent } from '../src/services/registry.js';
 import { makeTestAgent, backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
+import { syncCloudCache } from '../src/services/cloud-sync.js';
 
 // Mock connection-dependent helpers so tests run offline
 vi.mock('../src/services/strategy.js', () => ({
@@ -16,6 +17,13 @@ vi.mock('../src/providers/index.js', () => ({
     oauthCredentialFiles: () => [],
     authEnvVar: undefined,
   }),
+}));
+
+// Cloud sync (apra-fleet-aho) defaults to not-connected below so the
+// existing standalone-mode tests above are unaffected; individual tests
+// override this to prove list_members surfaces the other states.
+vi.mock('../src/services/cloud-sync.js', () => ({
+  syncCloudCache: vi.fn(async () => ({ status: 'not-connected' })),
 }));
 
 beforeEach(() => backupAndResetRegistry());
@@ -81,5 +89,60 @@ describe('list_members -- tags filter', () => {
     expect(parsed.members).toHaveLength(1);
     expect(parsed.members[0].name).toBe('both-worker');
     expect(parsed.members[0].tags).toEqual(expect.arrayContaining(['gpu', 'doer']));
+  });
+});
+
+describe('list_members -- cloud workspace section (apra-fleet-aho)', () => {
+  afterEach(() => {
+    vi.mocked(syncCloudCache).mockReset();
+    vi.mocked(syncCloudCache).mockResolvedValue({ status: 'not-connected' } as any);
+  });
+
+  it('omits the cloud section entirely in standalone (not-connected) mode', async () => {
+    addAgent(makeTestAgent({ id: 'member-a', friendlyName: 'alpha' }));
+
+    const compact = await listMembers({ format: 'compact' });
+    expect(compact).not.toContain('[cloud]');
+
+    const json = JSON.parse(await listMembers({ format: 'json' }));
+    expect(json.cloud).toBeUndefined();
+  });
+
+  it('surfaces synced cloud members/projects in both formats', async () => {
+    vi.mocked(syncCloudCache).mockResolvedValue({
+      status: 'synced',
+      cache: { workspaceId: 'ws-1', members: [{ id: 'm1' }], projects: [{ id: 'p1' }], lastSyncedAt: 123 },
+    } as any);
+    addAgent(makeTestAgent({ id: 'member-a', friendlyName: 'alpha' }));
+
+    const compact = await listMembers({ format: 'compact' });
+    expect(compact).toContain('[cloud] 1 workspace member(s), 1 project(s)');
+
+    const json = JSON.parse(await listMembers({ format: 'json' }));
+    expect(json.cloud).toEqual({ status: 'synced', members: [{ id: 'm1' }], projects: [{ id: 'p1' }], lastSyncedAt: 123 });
+  });
+
+  it('surfaces stale cached data and an unreachable notice when offline', async () => {
+    vi.mocked(syncCloudCache).mockResolvedValue({
+      status: 'offline',
+      cache: { workspaceId: 'ws-1', members: [{ id: 'm1' }], projects: [], lastSyncedAt: 999 },
+    } as any);
+    addAgent(makeTestAgent({ id: 'member-a', friendlyName: 'alpha' }));
+
+    const compact = await listMembers({ format: 'compact' });
+    expect(compact).toContain('[cloud] fleet-dashboard unreachable');
+    expect(compact).toContain('1 member(s), 0 project(s)');
+  });
+
+  it('surfaces a re-enrollment prompt on credential-expired, never silently falling back to cache', async () => {
+    vi.mocked(syncCloudCache).mockResolvedValue({ status: 'credential-expired' } as any);
+    addAgent(makeTestAgent({ id: 'member-a', friendlyName: 'alpha' }));
+
+    const compact = await listMembers({ format: 'compact' });
+    expect(compact).toContain('[cloud] credential expired or revoked');
+    expect(compact).toContain('apra-fleet join');
+
+    const json = JSON.parse(await listMembers({ format: 'json' }));
+    expect(json.cloud).toEqual({ status: 'credential-expired', members: [], projects: [], lastSyncedAt: null });
   });
 });


### PR DESCRIPTION
## Summary
- Closes apra-fleet-aho, unblocked now that fleet-dashboard-1il (GET /v1/ws/:id/bootstrap) shipped.
- Closes apra-fleet-db4 -- resolved with no code changes per the AGREED negotiation's round-2 scope narrowing (no device-initiated member registration; presence/status already covered by connect/heartbeat, unchanged).
- New src/services/cloud-sync.ts: on-demand pull of workspace members/projects into a sibling cloud-cache.json, fail-open on network/5xx/429, distinct credential-expired state on 401.
- Wired into list_members: [cloud] section (compact) / cloud field (json); invisible in standalone mode.

## Note on base branch
Stacked on feat/enrollment-repoint-fleet-dashboard (PR #321), itself stacked on chore/hub-service-retire-and-docs (PR #320) <- feat/hub-spoke-migration <- main. Same reasoning as #321: targeting main directly would show the whole unmerged feature's diff.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run tests/cloud-sync.test.ts tests/list-members.test.ts` -- 16/16 passing
- [x] Full suite: 2146/2146 passing, 18 skipped (pre-existing), zero regressions

https://claude.ai/code/session_01NqDBN8WWZMpD2uCg5NC4dv