### PR TITLE
docs(watch): document logging.previewChars config knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Want to build your own skill on top of Fleet? See [docs/writing-skills.md](docs/
 | FAQ | [docs/FAQ.md](docs/FAQ.md) |
 | Troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
 | Keeping Fleet updated (`apra-fleet update`) | [docs/features/update.md](docs/features/update.md) |
+| Live member activity (`apra-fleet watch`, `logging.previewChars`) | [docs/features/watch.md](docs/features/watch.md) |
 | Secure credentials and passwords | [docs/features/oob-auth.md](docs/features/oob-auth.md) |
 | Member category and tags | [docs/features/member-tags.md](docs/features/member-tags.md) |
 | Enabling SSH on a remote machine (if it does not have it yet) | [docs/ssh-setup.md](docs/ssh-setup.md) |

--- a/docs/features/watch.md
+++ b/docs/features/watch.md
@@ -133,6 +133,21 @@ styling, shell-completion helper.
 - Push-based SSE/WebSocket sink and a multi-pane web/TUI.
 - PM `status.md` feature-name labeling (branch names shown in the interim).
 
+## Configuration
+
+`~/.apra-fleet/data/config.json` (i.e. `FLEET_DIR/data/config.json`):
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `logging.previewChars` | `256` | Max chars of a command/prompt written to the fleet log. Invalid values warn and fall back to the default. `watch` renders the full prompt from the session transcript when available; the log line is an identifier, not a full record. |
+
+Example:
+```json
+{
+  "logging": { "previewChars": 512 }
+}
+```
+
 ## Known gotchas
 
 - Output volume: a broad scope with many active members interleaves a lot;
@@ -144,6 +159,10 @@ styling, shell-completion helper.
 - Backfill (`--tail`) applies to the fleet log and local transcripts; a remote
   transcript starts streaming from the moment `watch` attaches (primes to EOF),
   so it has no history backfill.
+- Long commands/prompts are truncated in the fleet log (default 256 chars,
+  configurable via `logging.previewChars`). The full prompt is still visible in
+  `watch` for any member whose transcript is being tailed; non-Claude or
+  offline-remote members show the truncated preview only.
 - Remote tailing opens one dedicated SSH connection per remote Claude member for
   the lifetime of the `watch`; it is closed cleanly on Ctrl-C. If a member is
   asleep/unreachable the channel simply fails soft and is retried on the next

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -322,6 +322,7 @@ Want to build your own skill on top of Fleet? See [docs/writing-skills.md](docs/
 | FAQ | [docs/FAQ.md](docs/FAQ.md) |
 | Troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
 | Keeping Fleet updated (`apra-fleet update`) | [docs/features/update.md](docs/features/update.md) |
+| Live member activity (`apra-fleet watch`, `logging.previewChars`) | [docs/features/watch.md](docs/features/watch.md) |
 | Secure credentials and passwords | [docs/features/oob-auth.md](docs/features/oob-auth.md) |
 | Member category and tags | [docs/features/member-tags.md](docs/features/member-tags.md) |
 | Enabling SSH on a remote machine (if it does not have it yet) | [docs/ssh-setup.md](docs/ssh-setup.md) |


### PR DESCRIPTION
Follow-up to #319.

Documents the \logging.previewChars\ config knob introduced by the log-retention fix in #319, which was flagged as a minor open item before merge.

## Changes
- \docs/features/watch.md\ -- new **Configuration** section with a table for \logging.previewChars\ (default 256, validates with warn-and-fallback, JSON example); new **Known gotchas** bullet on fleet-log truncation and transcript fallback behavior.
- \README.md\ -- added \pra-fleet watch\ / \logging.previewChars\ row to the Documentation table.