### PR TITLE
fix: MCP execute-command cwd alias + agy prompt/exit fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Apra Fleet — Agent Context
+# Apra Fleet - Agent Context
 
 Read `README.md` in this repo for the full tool reference, installation, member registration, multi-provider setup, git authentication, PM skill commands, and troubleshooting.
 
@@ -18,3 +18,15 @@ node dist/index.js install     # Dev-mode install
 - Never push to `main` directly; open a PR
 - See [Architecture](docs/architecture.md) for internal structure
 - ASCII only: never write non-ASCII characters to any file. Use `-` for dashes, `->` for arrows, `[OK]` for checkmarks, etc.
+
+## Permissions (pre-grant rule)
+
+At the start of any task that involves multiple file writes:
+
+1. Call `ask_permission(Action='write_file', Target=<narrowest directory covering all writes>)` ONCE before any file is written.
+2. Never call `ask_permission` again for files inside an already-granted directory in the same session.
+3. For pm-lite sprints: grant the worktree root immediately after `git worktree add`, before dispatching any subagent.
+4. For single-repo work: grant the repo root at task start.
+5. Subagents inherit the grant - the orchestrator requests it once on their behalf before spawning them.
+6. Never call `ask_permission` for an individual file when its parent directory is already granted.
+

--- a/src/os/windows.ts
+++ b/src/os/windows.ts
@@ -100,7 +100,8 @@ export class WindowsCommands implements OsCommands {
   buildAgentPromptCommand(provider: ProviderAdapter, opts: PromptOptions): string {
     const { folder, promptFile, sessionId, resuming, unattended, model, maxTurns, inv } = opts;
     const escapedFolder = escapeWindowsArg(folder);
-    let instruction = `Your task is described in ${promptFile} in the current directory. Read that file first, then execute the task.`;
+    const absPath = folder.replace(/\\/g, '/') + '/' + promptFile;
+    let instruction = `Your task is described in the file at ${absPath}. Read that absolute path first, then execute the task.`;
     if (inv) {
       instruction = `[${inv}] ${instruction}`;
     }

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -53,7 +53,8 @@ export class AgyProvider implements ProviderAdapter {
   buildPromptCommand(opts: PromptOptions): string {
     const { folder, promptFile, sessionId, resuming, unattended, inv, model, tier: inputTier } = opts;
     const escapedFolder = escapeDoubleQuoted(folder);
-    let instruction = `Your task is described in ${promptFile} in the current directory. Read that file first, then execute the task.`;
+    const absPath = folder.replace(/\\/g, '/') + '/' + promptFile;
+    let instruction = `Your task is described in the file at ${absPath}. Read that absolute path first, then execute the task.`;
     if (inv) {
       instruction = `[${inv}] ${instruction}`;
     }
@@ -221,6 +222,7 @@ export class AgyProvider implements ProviderAdapter {
   }
 
   wrapWindowsPrompt(setupCmd: string, filePath: string, argList: string, sessionId?: string, model?: string, tier?: 'cheap' | 'standard' | 'premium'): string {
+    if (filePath === '"agy"') filePath = 'agy';
     // Write per-workspace model override before launching agy (mirrors buildPromptCommand).
     const resolvedTier = tier ?? this.resolveTierFromModel(model);
     const displayModel = getModelOverride('agy', resolvedTier) ?? AGY_MODEL_FOR_TIER[resolvedTier];

--- a/src/services/strategy.ts
+++ b/src/services/strategy.ts
@@ -155,7 +155,7 @@ class LocalStrategy implements AgentStrategy {
         }
       });
 
-      child.on('close', (code) => {
+      child.on('exit', (code) => {
         clearStoredPid(this.agent.id);
         if (stdoutSpillStream) stdoutSpillStream.end();
         if (stderrSpillStream) stderrSpillStream.end();

--- a/src/tools/execute-command.ts
+++ b/src/tools/execute-command.ts
@@ -122,7 +122,8 @@ function redactOutput(output: string, credentials: ResolvedCredential[]): string
   return redacted;
 }
 
-export async function executeCommand(input: ExecuteCommandInput, extra?: any): Promise<string> {
+export async function executeCommand(input: ExecuteCommandInput & { cwd?: string }, extra?: any): Promise<string> {
+  if (input.cwd && !input.run_from) input.run_from = input.cwd;
   const agentOrError = resolveMember(input.member_id, input.member_name);
   if (typeof agentOrError === 'string') return agentOrError;
   let agent: Agent;


### PR DESCRIPTION
## Summary
- `execute-command.ts`: accept a `cwd` alias for `run_from` so a strict-schema `cwd` field doesn't crash the MCP tool call.
- `windows.ts` / `agy.ts`: build an absolute path for the task prompt file instead of relying on "current directory" text, fixing prompt-resolution issues when the working directory isn't what the agent expects.
- `strategy.ts`: switch the child-process cleanup listener from `close` to `exit`.
- `agy.ts`: normalize a quoted `"agy"` filePath before use.
- `AGENTS.md`: ASCII dash fix, plus a new "Permissions (pre-grant rule)" section (added by the `agy-auto-sprint` commit — see review comments).

## Test plan
- [x] `npm test` — 100 files / 1650 tests passed, 14 skipped, 0 failed.