### PR TITLE
fix(apra-fleet-eft.13): ephemeral ports for dashboard test servers, not fixed ones

### DIFF
--- a/packages/apra-fleet-workflow/src/viewer/index.mjs
+++ b/packages/apra-fleet-workflow/src/viewer/index.mjs
@@ -415,7 +415,7 @@ const HTML_TEMPLATE = (dashboardExtensions) => `<!DOCTYPE html>
 </html>`;
 
 export function createDashboardViewer(workflow, opts = {}) {
-    const port = opts.port || 8080;
+    const port = (typeof opts.port === 'number') ? opts.port : 8080;
     const dashboardExtensions = opts.dashboardExtensions || [];
     
     const state = {
@@ -622,7 +622,7 @@ export function createDashboardViewer(workflow, opts = {}) {
     });
 
     server.listen(port, () => {
-        console.log(`[Viewer] Workflow Dashboard live at http://localhost:${port}`);
+        console.log(`[Viewer] Workflow Dashboard live at http://localhost:${server.address().port}`);
     });
 
     workflow.on('end', () => {

--- a/packages/apra-fleet-workflow/test/apra-fleet-workflow-viewer-lifecycle.test.mjs
+++ b/packages/apra-fleet-workflow/test/apra-fleet-workflow-viewer-lifecycle.test.mjs
@@ -171,7 +171,7 @@ describe('apra-fleet-unw.10: engine end event', () => {
         const endEvents = [];
         wf.on('end', (res) => endEvents.push(res));
 
-        const server = createDashboardViewer(wf, { port: 18091, name: 'Lifecycle Success Test' });
+        const server = createDashboardViewer(wf, { port: 0, name: 'Lifecycle Success Test' });
         await withServer(server, async (port) => {
             const before = JSON.parse(await httpGet(port, '/state'));
             assert.strictEqual(before.status, 'running', 'dashboard must start in the running/LIVE state');
@@ -197,7 +197,7 @@ describe('apra-fleet-unw.10: engine end event', () => {
         const endEvents = [];
         wf.on('end', (res) => endEvents.push(res));
 
-        const server = createDashboardViewer(wf, { port: 18092, name: 'Lifecycle Failure Test' });
+        const server = createDashboardViewer(wf, { port: 0, name: 'Lifecycle Failure Test' });
         await withServer(server, async (port) => {
             await assert.rejects(() => engine.executeFile(fixture('test-end-event-failure.mjs'), {}));
 
@@ -223,7 +223,7 @@ describe('apra-fleet-unw.10: cooperative /stop', () => {
         const endEvents = [];
         wf.on('end', (res) => endEvents.push(res));
 
-        const server = createDashboardViewer(wf, { port: 18093, name: 'Stop Test' });
+        const server = createDashboardViewer(wf, { port: 0, name: 'Stop Test' });
 
         const originalExit = process.exit;
         let exitCalled = false;
@@ -355,7 +355,7 @@ describe('server-side sprint-state persistence (auto-save on finish, stop, or ex
         await withTempCwd(async (dir) => {
             const wf = new FleetWorkflow(createMockFleetApi());
             const engine = new WorkflowEngine(wf);
-            const server = createDashboardViewer(wf, { port: 18094, name: 'Persist Success Test' });
+            const server = createDashboardViewer(wf, { port: 0, name: 'Persist Success Test' });
 
             await withServer(server, async (port) => {
                 const result = await engine.executeFile(fixture('test-end-event-success.mjs'), {});
@@ -387,7 +387,7 @@ describe('server-side sprint-state persistence (auto-save on finish, stop, or ex
             const activityStarts = [];
             wf.on('activity:start', (meta) => activityStarts.push(meta));
 
-            const server = createDashboardViewer(wf, { port: 18095, name: 'Persist Stop Test' });
+            const server = createDashboardViewer(wf, { port: 0, name: 'Persist Stop Test' });
 
             await withServer(server, async (port) => {
                 const runPromise = engine.executeFile(fixture('test-stop-pending-agent.mjs'), {});
@@ -418,7 +418,7 @@ describe('server-side sprint-state persistence (auto-save on finish, stop, or ex
             const activityStarts = [];
             wf.on('activity:start', (meta) => activityStarts.push(meta));
 
-            const server = createDashboardViewer(wf, { port: 18096, name: 'Persist SIGINT Test' });
+            const server = createDashboardViewer(wf, { port: 0, name: 'Persist SIGINT Test' });
 
             const originalExit = process.exit;
             let exitCode = null;
@@ -461,7 +461,7 @@ describe('server-side sprint-state persistence (auto-save on finish, stop, or ex
         await withTempCwd(async (dir) => {
             const wf = new FleetWorkflow(createMockFleetApi());
             const engine = new WorkflowEngine(wf);
-            const server = createDashboardViewer(wf, { port: 18098, name: 'Persist Manual Endpoint Test' });
+            const server = createDashboardViewer(wf, { port: 0, name: 'Persist Manual Endpoint Test' });
 
             await withServer(server, async (port) => {
                 // No 'end' yet -- run is still "running". A manual /save_logs
@@ -493,7 +493,7 @@ describe('server-side sprint-state persistence (auto-save on finish, stop, or ex
         await withTempCwd(async (dir) => {
             const wf = new FleetWorkflow(createMockFleetApi());
             const engine = new WorkflowEngine(wf);
-            const server = createDashboardViewer(wf, { port: 18097, name: 'Persist Idempotency Test' });
+            const server = createDashboardViewer(wf, { port: 0, name: 'Persist Idempotency Test' });
 
             const originalExit = process.exit;
             let exitCalled = false;

--- a/packages/apra-fleet-workflow/test/test-runner.test.mjs
+++ b/packages/apra-fleet-workflow/test/test-runner.test.mjs
@@ -193,11 +193,7 @@ describe('WorkflowEngine executing fixture scripts against a mock fleet API', ()
 describe('createDashboardViewer', () => {
     test('serves the dashboard and reflects workflow activity over loopback only', async () => {
         const wf = new FleetWorkflow(createMockFleetApi());
-        // NOTE: createDashboardViewer uses `opts.port || 8080`, so port: 0 would
-        // silently fall back to the default port rather than an OS-assigned
-        // ephemeral one. Use a fixed high port on loopback instead; nothing
-        // external is involved.
-        const server = createDashboardViewer(wf, { port: 18080, name: 'Test Dashboard' });
+        const server = createDashboardViewer(wf, { port: 0, name: 'Test Dashboard' });
 
         try {
             await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

Fixes apra-fleet-eft.13, root-caused live during the apra-fleet-eft auto-sprint's fatal transport-timeout failure.

`createDashboardViewer()` computed its listen port as `opts.port || 8080`, which silently coerced an explicit `port: 0` (OS-assigned ephemeral) back to the default 8080 -- so callers wanting a real ephemeral port were forced to hardcode a fixed high port instead. Two test files did exactly that across 9 servers (18080-18098 in test-runner.test.mjs and apra-fleet-workflow-viewer-lifecycle.test.mjs).

This mattered because a doer's own leftover background test-server process on one of those fixed ports (orphaned by a prior, transport-timed-out sprint dispatch) collides with any retry that runs the same test file. The stuck retry itself then times out too, leaving yet another orphan on the same port -- a self-reinforcing cascade. That's exactly what happened: every streak from eft.2 onward failed with "Transport closed"/timeout until the sprint gave up entirely.

## Changes

- `viewer/index.mjs`: `const port = opts.port || 8080` -> explicit `typeof opts.port === 'number'` check, so `port: 0` is honored. Startup log now reads the actual bound port via `server.address()` instead of echoing the literal input (which printed `localhost:0` whenever ephemeral binding was used).
- `test-runner.test.mjs` / `apra-fleet-workflow-viewer-lifecycle.test.mjs`: switched all 9 `createDashboardViewer()` calls to `port: 0`. Both files already read the real bound port back via `server.address()`/a shared `withServer()` helper for all their own HTTP calls, so no other test logic needed to change.

## Test plan

- [x] `apra-fleet-workflow` full suite: 118/118 passing
- [x] Both directly-touched test files individually: 25/25 (test-runner.test.mjs + viewer-lifecycle) and 13/13 (viewer-lifecycle alone) passing