### PR TITLE
fix(tests): resolve Windows CI flakiness in two real-subprocess tests

### DIFF
--- a/tests/register-member-bootstrap-gate.test.ts
+++ b/tests/register-member-bootstrap-gate.test.ts
@@ -26,11 +26,21 @@ describe('register-member interactive bootstrap gate', () => {
 
   afterEach(() => {
     restoreRegistry();
-    fs.rmSync(workFolder, { recursive: true, force: true });
+    // maxRetries/retryDelay: on Windows, a just-exited child process (spawned
+    // during registerMember()'s real connection/version/auth checks) can hold
+    // an OS-level file handle open for a brief window after Node reports it
+    // exited -- rmSync would otherwise intermittently fail with EBUSY.
+    fs.rmSync(workFolder, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     delete process.env.APRA_FLEET_ENABLE_INTERACTIVE_BOOTSTRAP;
     vi.resetModules();
   });
 
+  // Generous timeout (vitest default is 5000ms): registerMember() for a
+  // local member runs real subprocess-based connection/version/auth checks
+  // unconditionally (strategy.testConnection(), uname/version/ps, etc.) --
+  // this test only mocks the interactive-bootstrap piece being asserted on,
+  // not those checks. That real subprocess work is measurably slower on
+  // Windows CI runners than the default budget allows.
   it('does NOT call checkRunningInstance or spawn a process by default under NODE_ENV=test', async () => {
     expect(process.env.NODE_ENV).toBe('test');
     delete process.env.APRA_FLEET_ENABLE_INTERACTIVE_BOOTSTRAP;
@@ -60,8 +70,9 @@ describe('register-member interactive bootstrap gate', () => {
     } finally {
       __resetInteractiveBootstrapDeps();
     }
-  });
+  }, 20000);
 
+  // Same real-subprocess-work rationale as the test above.
   it('uses injected fakes (no real network/spawn/CLI call) when explicitly opted in via env', async () => {
     process.env.APRA_FLEET_ENABLE_INTERACTIVE_BOOTSTRAP = '1';
 
@@ -124,5 +135,5 @@ describe('register-member interactive bootstrap gate', () => {
     } finally {
       __resetInteractiveBootstrapDeps();
     }
-  });
+  }, 20000);
 });

--- a/tests/strategy-utf8-chunk-boundary.test.ts
+++ b/tests/strategy-utf8-chunk-boundary.test.ts
@@ -44,9 +44,17 @@ describe('LocalStrategy stdout UTF-8 chunk-boundary handling (apra-fleet-grq)', 
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    // maxRetries/retryDelay: on Windows, the just-exited `node` child process
+    // spawned below can hold an OS-level file handle open for a brief window
+    // after Node reports it exited -- rmSync would otherwise intermittently
+    // fail with EBUSY.
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
+  // Generous timeout (vitest default is 5000ms): this spawns a real `node`
+  // child process and waits on a deliberate 50ms cross-chunk delay plus real
+  // process-startup overhead, which is measurably slower on Windows CI
+  // runners than the default budget allows.
   it('does not corrupt a multi-byte UTF-8 character split across two stdout chunks', async () => {
     const member = makeTestLocalAgent({ workFolder: tmpDir });
     const strategy = getStrategy(member);
@@ -59,5 +67,5 @@ describe('LocalStrategy stdout UTF-8 chunk-boundary handling (apra-fleet-grq)', 
     // decoded independently (see strategy.ts stdout 'data' handler).
     expect(result.stdout).not.toContain('�');
     expect(result.stdout).toContain('\u{1F4CB} Response from fleet-reorg: done');
-  });
+  }, 20000);
 });


### PR DESCRIPTION
## Summary
Follow-up to #331. With the ubuntu/macos CI blocker fixed there, the `windows-latest` job could finally run to completion for the first time in days (it was previously cancelled by fail-fast on every run before finishing) -- revealing two previously-masked, genuine Windows-only test timeouts:

- `tests/register-member-bootstrap-gate.test.ts` -- `registerMember()` unconditionally runs real subprocess-based connection/version/auth checks (only the interactive-bootstrap piece is mocked), which is measurably slower on Windows CI than vitest's 5000ms default `testTimeout`.
- `tests/strategy-utf8-chunk-boundary.test.ts` -- spawns a real `node` child process with a deliberate 50ms cross-chunk delay plus real process-startup overhead.

Both pass reliably in isolation locally (confirmed on Windows) in ~1-2s -- comfortably within a bumped timeout, just not the tight default under CI load. The additional `EBUSY`-on-rmdir and doubled-mock-call-count failures in the bootstrap-gate file were cascading symptoms of the first test timing out mid-flight (its `finally` cleanup running late and bleeding into the next test), not independent bugs.

## Changes
- Bump both tests' timeouts to 20000ms.
- Add `maxRetries`/`retryDelay` to both files' `afterEach` `fs.rmSync` calls as defense-in-depth against the well-known Windows behavior where a just-exited child process can hold a file handle open briefly after Node reports it exited.

## Test plan
- [x] Reproduced and confirmed fixed locally on Windows (both tests pass with margin)
- [x] `npm test` (root) -- 167/167 files, 2299/2299 tests pass
- [x] `npm test --workspaces --if-present` -- 317/317 pass