### PR TITLE
fix(build): stop sourcing agent contract files from dist/agents in build-binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build": "npm run build:contract && tsc",
     "build:contract": "npm run build --workspace=@apralabs/fleet-api-contract",
     "gen:openapi": "npm run gen:openapi --workspace=@apralabs/fleet-api-contract",
+    "vendor-pm": "node scripts/vendor-pm.mjs",
     "build:sea": "node scripts/build-sea.mjs",
     "build:sea-config": "node scripts/gen-sea-config.mjs",
     "build:sea-package": "node scripts/package-sea.mjs",
@@ -56,7 +57,7 @@
     "integration": "tsc && npx tsx tests/integration.test.ts",
     "verify:submodule": "node scripts/check-vendor-submodule.mjs",
     "prepare": "node scripts/install-hooks.mjs",
-    "prepublishOnly": "node scripts/vendor-pm.mjs && npm run vendor-schemas --workspace=@apralabs/apra-fleet-se && npm run build && npm run build:se"
+    "prepublishOnly": "npm run vendor-pm && npm run vendor-schemas --workspace=@apralabs/apra-fleet-se && npm run build && npm run build:se"
   },
   "keywords": [
     "ai-agent",

--- a/scripts/gen-sea-config.mjs
+++ b/scripts/gen-sea-config.mjs
@@ -88,14 +88,14 @@ for (const [name, assetPath] of Object.entries(allScripts)) {
 
 const skills = collectFiles(join(root, 'vendor', 'apra-pm', 'skills', 'pm'), 'vendor/apra-pm/skills/pm', 'vendor/apra-pm/skills/pm');
 const fleetSkills = collectFiles(join(root, 'skills', 'fleet'), 'skills/fleet');
-// Agents are sourced from dist/agents, NOT vendor/apra-pm/agents directly -- unlike
-// skills, the agent role files contain a `<!-- GRAPH-SEMANTICS -->` marker that
-// scripts/vendor-pm.mjs resolves (inlining vendor/apra-pm/agents/_shared/GRAPH-SEMANTICS.md)
-// during its submodule -> dist/agents copy step. Reading straight from the submodule here
-// would embed the literal, unresolved marker into the SEA binary. Requires vendor-pm.mjs to
-// have already run (prepublishOnly already sequences it first for this reason).
-const distAgentsDir = join(root, 'dist', 'agents');
-const agents = collectFiles(distAgentsDir, 'dist/agents', 'dist/agents');
+// Sourced straight from the submodule, same as agentSchemas below -- no dist/agents
+// copy step required. (Used to read from dist/agents so scripts/vendor-pm.mjs could
+// inline a `<!-- GRAPH-SEMANTICS -->` marker into each agent file first; apra-pm
+// PR#29 replaced that marker with an explicit prose pointer to
+// vendor/apra-pm/agents/_shared/GRAPH-SEMANTICS.md in every agent file, so there is
+// nothing left for vendor-pm.mjs to resolve here.)
+const agentsDir = join(root, 'vendor', 'apra-pm', 'agents');
+const agents = collectFiles(agentsDir, 'vendor/apra-pm/agents', 'vendor/apra-pm/agents');
 
 if (Object.keys(skills).length === 0) {
   console.error('Error: vendor/apra-pm submodule is not initialized (skills/pm is empty).');
@@ -103,8 +103,8 @@ if (Object.keys(skills).length === 0) {
   process.exit(1);
 }
 if (Object.keys(agents).length === 0) {
-  console.error('Error: dist/agents is empty or missing.');
-  console.error('Run: node scripts/vendor-pm.mjs (must run before gen-sea-config.mjs)');
+  console.error('Error: vendor/apra-pm submodule is not initialized (agents is empty).');
+  console.error('Run: git submodule update --init');
   process.exit(1);
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -185,28 +185,16 @@ function buildDevManifest(root: string): AssetManifest {
   const pmSkillsDir = fs.existsSync(vendorPmSkills) ? vendorPmSkills : path.join(root, 'dist', 'skills', 'pm');
   const pmBase = fs.existsSync(vendorPmSkills) ? 'vendor/apra-pm/skills/pm' : 'dist/skills/pm';
 
-  // Agents are different: each vendor/apra-pm/agents/*.md file contains an
-  // unresolved `<!-- GRAPH-SEMANTICS -->` marker that only scripts/vendor-pm.mjs
-  // resolves (inlining agents/_shared/GRAPH-SEMANTICS.md) during its
-  // submodule -> dist/agents copy step. Reading the raw submodule here, as
-  // this used to do (preferring vendor/apra-pm/agents whenever the submodule
-  // was present on disk -- true for every dev-mode checkout), shipped that
-  // literal unresolved marker string into every non-SEA install. Prefer
-  // dist/agents (already build-resolved) whenever it exists; only fall back
-  // to the raw submodule -- with a warning -- if the build hasn't run yet.
-  const vendorAgents = path.join(root, 'vendor', 'apra-pm', 'agents');
-  const distAgents = path.join(root, 'dist', 'agents');
-  const distAgentsExists = fs.existsSync(distAgents);
-  const agentsDir = distAgentsExists ? distAgents : vendorAgents;
-  const agentsBase = distAgentsExists ? 'dist/agents' : 'vendor/apra-pm/agents';
-  if (!distAgentsExists && fs.existsSync(vendorAgents)) {
-    console.warn(
-      'Warning: dist/agents not found -- installing agent contracts directly from ' +
-      'vendor/apra-pm/agents. Run `node scripts/vendor-pm.mjs` first (or `npm run build`) ' +
-      'so the <!-- GRAPH-SEMANTICS --> marker is resolved; otherwise installed agent files ' +
-      'will contain the literal, unresolved marker text.'
-    );
-  }
+  // Read straight from the submodule -- same as skills above. (Each
+  // vendor/apra-pm/agents/*.md file used to contain an unresolved
+  // `<!-- GRAPH-SEMANTICS -->` marker that only scripts/vendor-pm.mjs's
+  // submodule -> dist/agents copy step resolved, which is why this used to
+  // prefer dist/agents when present and warn on the raw-submodule fallback.
+  // apra-pm PR#29 replaced that marker with an explicit prose pointer to
+  // vendor/apra-pm/agents/_shared/GRAPH-SEMANTICS.md in every agent file, so
+  // there is nothing left to resolve and no dist/agents dependency here.)
+  const agentsDir = path.join(root, 'vendor', 'apra-pm', 'agents');
+  const agentsBase = 'vendor/apra-pm/agents';
 
   const skills = collectFilesRec(pmSkillsDir, pmBase, pmBase);
   const agents = collectFilesRec(agentsDir, agentsBase, agentsBase);
@@ -1005,11 +993,9 @@ Then re-run:  apra-fleet install`);
       }
     } else {
       const root = findProjectRoot();
-      // Same dist/agents-first preference as the manifest-building step
-      // above (and for the same reason: only dist/agents has the
-      // <!-- GRAPH-SEMANTICS --> marker resolved).
-      const distAgentsSrc = path.join(root, 'dist', 'agents');
-      const agentsSrc = fs.existsSync(distAgentsSrc) ? distAgentsSrc : path.join(root, 'vendor', 'apra-pm', 'agents');
+      // Read straight from the submodule, same as the manifest-building
+      // step above -- no dist/agents dependency (see that step's comment).
+      const agentsSrc = path.join(root, 'vendor', 'apra-pm', 'agents');
       for (const entry of fs.readdirSync(agentsSrc, { withFileTypes: true })) {
         if (entry.isDirectory()) continue;
         let content = fs.readFileSync(path.join(agentsSrc, entry.name), 'utf-8');


### PR DESCRIPTION
## Summary
Follow-up to #331/#332. With build-and-test finally green, the build-binary job (which needs: build-and-test) could run for the first time in days -- and failed on all 3 platforms:

```
Error: dist/agents is empty or missing.
Run: node scripts/vendor-pm.mjs (must run before gen-sea-config.mjs)
```

Root cause, not a missing CI step: gen-sea-config.mjs's agent-.md sourcing only needed dist/agents because scripts/vendor-pm.mjs used to inline a marker (from agents/_shared/GRAPH-SEMANTICS.md) into each agent file during its submodule -> dist/agents copy. apra-pm PR#29 already replaced that marker with an explicit prose pointer in every agent file (verified locally: vendor-pm.mjs's own injection step now resolves 0 markers), so the dist/agents dependency is dead weight. `main` never had this dependency; gen-sea-config.mjs's own agentSchemas section already reads straight from vendor/apra-pm/agents/schemas for the same reason -- this file had drifted internally inconsistent.

## Changes
- `scripts/gen-sea-config.mjs`: source agent .md files straight from `vendor/apra-pm/agents`, matching `agentSchemas`/`skills`.
- `src/cli/install.ts`: same revert in both the SEA-manifest-building step and the dev-mode (non-SEA) install step.
- Bonus fix: installed agent files reference the shared graph-semantics file as "the sibling file installed alongside this one," but vendor-pm.mjs explicitly stripped that file from dist/agents -- so a SEA-mode install was shipping agent contracts with a dangling reference. Reading straight from the submodule includes it.
- `package.json`: add a `vendor-pm` script alias (`node scripts/vendor-pm.mjs`) so `prepublishOnly` doesn't hand-invoke the raw script path. `build:binary` no longer needs it at all.
- No `.github/workflows/ci.yml` changes needed -- the fix is entirely in the scripts, so build-binary's existing steps just work.

## Test plan
- [x] Fresh `npm run build:binary` (no `dist/`, no `vendor-pm.mjs` run first) completes end-to-end
- [x] Resulting SEA binary's `--version` runs correctly
- [x] `npx vitest run tests/` -- 167/167 files, 2299/2299 tests pass