### PR TITLE
fix(members): provision role-agent files to remote fleet members (apra-fleet-0ei)

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -127,6 +127,17 @@ export function getProviderInstallConfig(provider: LlmProvider): ProviderInstall
   }
 }
 
+/**
+ * Home-relative agents dir for a provider (e.g. '.claude/agents'), or undefined
+ * when the provider has no agents dir (codex, copilot). Derived from
+ * getProviderInstallConfig() so install and remote provisioning cannot drift.
+ */
+export function getAgentsDirRelative(provider: LlmProvider): string | undefined {
+  const paths = getProviderInstallConfig(provider);
+  if (!paths.agentsDir) return undefined;
+  return path.relative(home, paths.agentsDir).replace(/\\/g, '/');
+}
+
 export function readConfig(paths: ProviderInstallConfig): any {
   if (!fs.existsSync(paths.settingsFile)) return {};
   const content = fs.readFileSync(paths.settingsFile, 'utf-8').trim();

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -168,6 +168,33 @@ function loadManifest(): AssetManifest {
   return buildDevManifest(findProjectRoot());
 }
 
+/**
+ * Recursively load every agent asset (role agents + _shared/ + schemas/) as
+ * {relPath, content} pairs, relPath relative to the agents dir root.
+ * Shared by install (writes to disk) and agent-provisioner (hashes for remote diffing).
+ */
+export function loadAgentAssets(): Array<{ relPath: string; content: string }> {
+  const results: Array<{ relPath: string; content: string }> = [];
+  if (isSea()) {
+    const manifest = loadManifest();
+    for (const [relPath, assetKey] of Object.entries(manifest.agents)) {
+      results.push({ relPath, content: extractAsset(assetKey) });
+    }
+    return results;
+  }
+
+  const root = findProjectRoot();
+  const vendorAgents = path.join(root, 'vendor', 'apra-pm', 'agents');
+  const agentsSrc = fs.existsSync(vendorAgents) ? vendorAgents : path.join(root, 'dist', 'agents');
+  const agentsBase = fs.existsSync(vendorAgents) ? 'vendor/apra-pm/agents' : 'dist/agents';
+
+  const collected = collectFilesRec(agentsSrc, agentsBase, agentsBase);
+  for (const [relPath, rootRelativeLabel] of Object.entries(collected)) {
+    results.push({ relPath, content: fs.readFileSync(path.join(root, rootRelativeLabel), 'utf-8') });
+  }
+  return results;
+}
+
 function extractAsset(key: string): string {
   if (isSea()) {
     return getSeaAsset(key);

--- a/src/os/linux.ts
+++ b/src/os/linux.ts
@@ -290,4 +290,10 @@ export class LinuxCommands implements OsCommands {
     }
     return stdout.trim();
   }
+
+  // --- Agent provisioning ---
+
+  hashFilesRecursive(dir: string): string {
+    return `cd "${escapeDoubleQuoted(dir)}" 2>/dev/null && find . -type f -exec sha256sum {} + 2>/dev/null || true`;
+  }
 }

--- a/src/os/macos.ts
+++ b/src/os/macos.ts
@@ -43,4 +43,11 @@ export class MacOSCommands extends LinuxCommands {
   override parseMemory(stdout: string): string {
     return stdout.trim().substring(0, 200);
   }
+
+  // --- Agent provisioning ---
+  // stock macOS has no sha256sum -- shasum -a 256 is the built-in equivalent
+
+  override hashFilesRecursive(dir: string): string {
+    return `cd "${escapeDoubleQuoted(dir)}" 2>/dev/null && find . -type f -exec shasum -a 256 {} + 2>/dev/null || true`;
+  }
 }

--- a/src/os/os-commands.ts
+++ b/src/os/os-commands.ts
@@ -68,4 +68,8 @@ export interface OsCommands {
   // --- Resource output parsing ---
   parseMemory(stdout: string): string;
   parseDisk(stdout: string): string;
+
+  // --- Agent provisioning ---
+  /** List "<sha256>  ./<relpath>" for every file under a home-relative dir (recursive). Empty output if dir is missing/empty. */
+  hashFilesRecursive(dir: string): string;
 }

--- a/src/os/windows.ts
+++ b/src/os/windows.ts
@@ -314,4 +314,13 @@ $merged | ConvertTo-Json -Depth 99 | Set-Content -Path $p -NoNewline;
   parseDisk(stdout: string): string {
     return stdout.trim().substring(0, 200);
   }
+
+  // --- Agent provisioning ---
+
+  hashFilesRecursive(dir: string): string {
+    const winDir = dir.replace(/\//g, '\\').replace(/'/g, "''");
+    const psScript = `$b = Join-Path $HOME '${winDir}'; if (Test-Path $b) { Get-ChildItem -Path $b -Recurse -File | ForEach-Object { $h = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLower(); $r = $_.FullName.Substring($b.Length + 1).Replace('\\', '/'); "$h  ./$r" } }`;
+    const encoded = Buffer.from(psScript, 'utf16le').toString('base64');
+    return `powershell -EncodedCommand ${encoded}`;
+  }
 }

--- a/src/services/agent-provisioner.ts
+++ b/src/services/agent-provisioner.ts
@@ -1,0 +1,159 @@
+/**
+ * Provisions role-agent definition files (planner.md, doer.md, reviewer.md,
+ * _shared/, schemas/, ...) onto remote fleet members.
+ *
+ * install() writes these files into the operator's own home directory, so a
+ * local member (which shares the operator's home) always has them. A remote
+ * member has its own home dir and never receives them unless we push them --
+ * this module hash-diffs the canonical set against what's on the remote box
+ * and pushes only what's missing or stale.
+ */
+import { createHash } from 'node:crypto';
+import type { Agent, LlmProvider } from '../types.js';
+import { getOsCommands } from '../os/index.js';
+import { getAgentOS } from '../utils/agent-helpers.js';
+import { getStrategy } from './strategy.js';
+import { uploadContentToHome } from './sftp.js';
+import { loadAgentAssets } from '../cli/install.js';
+import { getAgentsDirRelative } from '../cli/config.js';
+import { transformAgentForOpenCode } from '../cli/agent-transform.js';
+
+export interface CanonicalAgentFile {
+  relPath: string;
+  content: string;
+  sha256: string;
+}
+
+export interface ProvisionResult {
+  pushed: string[];
+  skippedReason?: string;
+  warning?: string;
+}
+
+function sha256Hex(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex').toLowerCase();
+}
+
+/**
+ * Load the canonical agent asset set for a provider, applying the same
+ * install-time transform (opencode frontmatter rewrite) before hashing so the
+ * hash matches what actually gets written to the remote box.
+ */
+export function loadCanonicalAgentSet(provider: LlmProvider): CanonicalAgentFile[] {
+  const assets = loadAgentAssets();
+  return assets.map(({ relPath, content }) => {
+    const transformed = provider === 'opencode'
+      ? transformAgentForOpenCode(content, relPath)
+      : content;
+    return { relPath, content: transformed, sha256: sha256Hex(transformed) };
+  });
+}
+
+/** Home-relative agents dir for a provider, or null when the provider has no agent files (codex, copilot). */
+export function remoteAgentsDir(provider: LlmProvider): string | null {
+  return getAgentsDirRelative(provider) ?? null;
+}
+
+const HASH_LINE_RE = /^([0-9a-fA-F]{64})\s+\*?(.+)$/;
+
+/**
+ * One round trip: list "<sha256>  ./<relpath>" for every file under `dir` on
+ * the remote box. Returns hashes=null with failed=true if the probe itself
+ * failed (non-zero exit, transport error, or unparseable output) -- callers
+ * must NOT blind-push in that case. An empty/missing remote dir is a
+ * successful probe that yields an empty map.
+ */
+export async function probeRemoteAgentHashes(
+  agent: Agent,
+  dir: string
+): Promise<{ hashes: Map<string, string> | null; failed: boolean }> {
+  const cmds = getOsCommands(getAgentOS(agent));
+  const strategy = getStrategy(agent);
+
+  let result;
+  try {
+    result = await strategy.execCommand(cmds.hashFilesRecursive(dir), 15000);
+  } catch {
+    return { hashes: null, failed: true };
+  }
+
+  if (result.code !== 0) {
+    return { hashes: null, failed: true };
+  }
+
+  const trimmed = result.stdout.trim();
+  if (trimmed === '') {
+    return { hashes: new Map(), failed: false };
+  }
+
+  const hashes = new Map<string, string>();
+  let matched = 0;
+  let total = 0;
+  for (const rawLine of trimmed.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    total++;
+    const m = HASH_LINE_RE.exec(line);
+    if (!m) continue;
+    matched++;
+    let relPath = m[2].trim().replace(/\\/g, '/');
+    if (relPath.startsWith('./')) relPath = relPath.slice(2);
+    hashes.set(relPath, m[1].toLowerCase());
+  }
+
+  // Non-empty output but nothing parsed as a valid hash line -- garbled, don't trust it.
+  if (total > 0 && matched === 0) {
+    return { hashes: null, failed: true };
+  }
+
+  return { hashes, failed: false };
+}
+
+/** Files that are missing on the remote or whose content hash differs. Extra remote files are left alone. */
+export function diffAgentSet(canonical: CanonicalAgentFile[], remote: Map<string, string>): CanonicalAgentFile[] {
+  return canonical.filter(f => remote.get(f.relPath) !== f.sha256);
+}
+
+/**
+ * Ensure a remote member has an up-to-date copy of the canonical agent set.
+ * Never throws -- all failure modes surface as `warning` so callers can log
+ * and continue (registration/update must not fail because provisioning did).
+ */
+export async function provisionAgents(agent: Agent): Promise<ProvisionResult> {
+  try {
+    if (agent.agentType === 'local') {
+      return { pushed: [], skippedReason: 'local member shares operator home' };
+    }
+
+    const provider = agent.llmProvider ?? 'claude';
+    const dir = remoteAgentsDir(provider);
+    if (!dir) {
+      return { pushed: [], skippedReason: `${provider} does not use role-agent files` };
+    }
+
+    const { hashes, failed } = await probeRemoteAgentHashes(agent, dir);
+    if (failed || hashes === null) {
+      return { pushed: [], warning: 'Could not verify remote agent files -- skipped provisioning (probe failed)' };
+    }
+
+    const canonical = loadCanonicalAgentSet(provider);
+    const stale = diffAgentSet(canonical, hashes);
+    if (stale.length === 0) {
+      return { pushed: [] };
+    }
+
+    const { success, failed: uploadFailed } = await uploadContentToHome(
+      agent,
+      stale.map(f => ({ relPath: f.relPath, content: f.content })),
+      dir
+    );
+
+    const result: ProvisionResult = { pushed: success };
+    if (uploadFailed.length > 0) {
+      result.warning = `Failed to provision ${uploadFailed.length} agent file(s): ${uploadFailed.map(f => f.path).join(', ')}`;
+    }
+    return result;
+  } catch (err: any) {
+    return { pushed: [], warning: `Agent provisioning failed: ${err?.message ?? String(err)}` };
+  }
+}

--- a/src/services/sftp.ts
+++ b/src/services/sftp.ts
@@ -37,6 +37,15 @@ async function sftpMkdirRecursive(sftp: import('ssh2').SFTPWrapper, remotePath: 
   }
 }
 
+function sftpWriteFile(sftp: import('ssh2').SFTPWrapper, remotePath: string, data: Buffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.writeFile(remotePath, data, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
 function sftpPut(sftp: import('ssh2').SFTPWrapper, localPath: string, remotePath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     sftp.fastPut(localPath, remotePath, (err) => {
@@ -82,6 +91,37 @@ export async function uploadViaSFTP(
       success.push(fileName);
     } catch (err: any) {
       failed.push({ path: fileName, error: err.message });
+    }
+  }
+
+  return { success, failed };
+}
+
+/**
+ * Write in-memory file contents directly to home-relative paths on the remote
+ * machine -- no local temp files. baseDir + relPath is resolved by the SFTP
+ * server relative to the connecting user's home directory.
+ */
+export async function uploadContentToHome(
+  agent: Agent,
+  files: Array<{ relPath: string; content: string }>,
+  baseDir: string
+): Promise<{ success: string[]; failed: { path: string; error: string }[] }> {
+  const client = await getConnection(agent);
+  const sftp = await getSFTP(client);
+
+  const base = baseDir.replace(/\\/g, '/').replace(/\/$/, '');
+  const success: string[] = [];
+  const failed: { path: string; error: string }[] = [];
+
+  for (const file of files) {
+    const remotePath = `${base}/${file.relPath}`;
+    try {
+      await sftpMkdirRecursive(sftp, path.posix.dirname(remotePath));
+      await sftpWriteFile(sftp, remotePath, Buffer.from(file.content, 'utf-8'));
+      success.push(file.relPath);
+    } catch (err: any) {
+      failed.push({ path: file.relPath, error: err.message });
     }
   }
 

--- a/src/tools/register-member.ts
+++ b/src/tools/register-member.ts
@@ -18,6 +18,7 @@ import { logLine } from '../utils/log-helpers.js';
 import { CURATED_CHEAP_MODELS, CURATED_STANDARD_MODELS, CURATED_PREMIUM_MODELS } from '../cli/config.js';
 import { writeAgyWorkspaceOverlays } from '../cli/install.js';
 import { validateOpenCodeModelTiers } from '../utils/opencode-model-validation.js';
+import { provisionAgents, type ProvisionResult } from '../services/agent-provisioner.js';
 
 export const registerMemberSchema = z.object({
   friendly_name: z.string()
@@ -225,6 +226,7 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
   let detectedOS: Agent['os'] = isCloud ? 'linux' : undefined;
   let claudeVersion: string | undefined;
   let connResult: { ok: boolean; latencyMs?: number; error?: string } = { ok: true };
+  let agentProvisionResult: ProvisionResult | undefined;
 
   if (!skipSshOps) {
     const strategy = getStrategy(tempAgent);
@@ -290,6 +292,14 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
 
     await Promise.all([versionCheck, authCheck, mkdirCheck]);
 
+    // --- Provision role-agent definition files (planner.md, doer.md, ...) ---
+    // Remote members have their own home dir and never receive these via install() --
+    // only when connectivity is confirmed do we attempt the probe/push round trip.
+    if (connResult.ok) {
+      agentProvisionResult = await provisionAgents(tempAgent);
+      if (agentProvisionResult.warning) warnings.push(agentProvisionResult.warning);
+    }
+
     // --- Validate opencode model_tiers against available models ---
     if (!skipSshOps && (input.llm_provider ?? 'claude') === 'opencode' && normalizedModelTiers) {
       const { warnings: tierWarnings } = await validateOpenCodeModelTiers(tempAgent, normalizedModelTiers);
@@ -299,6 +309,7 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
     tempAgent.os = detectedOS;
     if (isCloud) {
       warnings.push(`${input.llm_provider ?? 'claude'} CLI and auth not verified — run provision_llm_auth after the instance starts.`);
+      warnings.push('Agent files not provisioned -- run update_member after the instance starts.');
     }
   }
 
@@ -347,6 +358,15 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
   }
   if (claudeVersion) {
     result += `  CLI:     ${claudeVersion}\n`;
+  }
+  if (agentProvisionResult) {
+    if (agentProvisionResult.skippedReason) {
+      result += `  Agents:  skipped (${agentProvisionResult.skippedReason})\n`;
+    } else if (agentProvisionResult.pushed.length > 0) {
+      result += `  Agents:  ${agentProvisionResult.pushed.length} file(s) provisioned\n`;
+    } else {
+      result += `  Agents:  up to date\n`;
+    }
   }
   if (!isLocal) {
     result += `  Auth:    ${tempAgent.authType}\n`;

--- a/src/tools/update-member.ts
+++ b/src/tools/update-member.ts
@@ -10,6 +10,8 @@ import { logLine } from '../utils/log-helpers.js';
 import type { Agent } from '../types.js';
 import { CURATED_CHEAP_MODELS, CURATED_STANDARD_MODELS, CURATED_PREMIUM_MODELS } from '../cli/config.js';
 import { validateOpenCodeModelTiers } from '../utils/opencode-model-validation.js';
+import { provisionAgents } from '../services/agent-provisioner.js';
+import { getStrategy } from '../services/strategy.js';
 
 export const updateMemberSchema = z.object({
   ...memberIdentifier,
@@ -214,6 +216,21 @@ export async function updateMember(input: UpdateMemberInput): Promise<string> {
   logLine('update_member', `id=${updated.id} name=${updated.friendlyName}`, updated);
   writeStatusline();
 
+  // --- Re-provision role-agent files for remote members ---
+  // Cheap (one probe round trip when up to date); also doubles as the manual retry
+  // path when a prior registration/update left agent files stale or unprovisioned.
+  // Does NOT start a stopped cloud member -- testConnection() failure just skips.
+  let agentProvisionResult: { pushed: string[]; skippedReason?: string; warning?: string } | undefined;
+  if (updated.agentType === 'remote') {
+    const conn = await getStrategy(updated).testConnection();
+    if (!conn.ok) {
+      warnings.push(`Could not reach member -- agent files not re-provisioned: ${conn.error ?? 'connection failed'}`);
+    } else {
+      agentProvisionResult = await provisionAgents(updated);
+      if (agentProvisionResult.warning) warnings.push(agentProvisionResult.warning);
+    }
+  }
+
   let result = `✅ Member "${updated.friendlyName}" updated.\n\n`;
   result += `  Icon:    ${updated.icon ?? DEFAULT_ICON}\n`;
   result += `  ID:      ${updated.id}\n`;
@@ -230,6 +247,15 @@ export async function updateMember(input: UpdateMemberInput): Promise<string> {
   if (updated.modelCheap) result += `  Model Cheap: ${updated.modelCheap}\n`;
   if (updated.modelStandard) result += `  Model Standard: ${updated.modelStandard}\n`;
   if (updated.modelPremium) result += `  Model Premium: ${updated.modelPremium}\n`;
+  if (agentProvisionResult) {
+    if (agentProvisionResult.skippedReason) {
+      result += `  Agents:  skipped (${agentProvisionResult.skippedReason})\n`;
+    } else if (agentProvisionResult.pushed.length > 0) {
+      result += `  Agents:  ${agentProvisionResult.pushed.length} file(s) provisioned\n`;
+    } else {
+      result += `  Agents:  up to date\n`;
+    }
+  }
   if (updated.modelTiers) {
     const mt = updated.modelTiers;
     result += `  Model Tiers: cheap=${mt.cheap ?? '-'} standard=${mt.standard ?? '-'} premium=${mt.premium ?? '-'}\n`;

--- a/src/tools/update-member.ts
+++ b/src/tools/update-member.ts
@@ -10,7 +10,7 @@ import { logLine } from '../utils/log-helpers.js';
 import type { Agent } from '../types.js';
 import { CURATED_CHEAP_MODELS, CURATED_STANDARD_MODELS, CURATED_PREMIUM_MODELS } from '../cli/config.js';
 import { validateOpenCodeModelTiers } from '../utils/opencode-model-validation.js';
-import { provisionAgents } from '../services/agent-provisioner.js';
+import { provisionAgents, remoteAgentsDir } from '../services/agent-provisioner.js';
 import { getStrategy } from '../services/strategy.js';
 
 export const updateMemberSchema = z.object({
@@ -220,8 +220,10 @@ export async function updateMember(input: UpdateMemberInput): Promise<string> {
   // Cheap (one probe round trip when up to date); also doubles as the manual retry
   // path when a prior registration/update left agent files stale or unprovisioned.
   // Does NOT start a stopped cloud member -- testConnection() failure just skips.
+  // Short-circuits before the connectivity check for providers with no agents dir
+  // (codex, copilot) -- no point spending a real SSH round trip just to skip.
   let agentProvisionResult: { pushed: string[]; skippedReason?: string; warning?: string } | undefined;
-  if (updated.agentType === 'remote') {
+  if (updated.agentType === 'remote' && remoteAgentsDir(updated.llmProvider ?? 'claude') !== null) {
     const conn = await getStrategy(updated).testConnection();
     if (!conn.ok) {
       warnings.push(`Could not reach member -- agent files not re-provisioned: ${conn.error ?? 'connection failed'}`);

--- a/tests/agent-provisioner.test.ts
+++ b/tests/agent-provisioner.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Tests for agent-provisioner.ts -- hash-based detection + provider-aware
+ * provisioning of role-agent definition files (planner.md, doer.md, etc.)
+ * onto remote fleet members.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import { makeTestAgent, makeTestLocalAgent, backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
+import type { SSHExecResult } from '../src/types.js';
+import { getOsCommands } from '../src/os/index.js';
+
+const mockExecCommand = vi.fn<(cmd: string, timeout?: number) => Promise<SSHExecResult>>();
+
+vi.mock('../src/services/strategy.js', () => ({
+  getStrategy: () => ({ execCommand: mockExecCommand }),
+}));
+
+const FAKE_AGENT_ASSETS = [
+  { relPath: 'planner.md', content: '---\nname: planner\ndescription: Plans work\ntools: [Read, Grep]\n---\nPlanner body' },
+  { relPath: 'doer.md', content: '---\nname: doer\ndescription: Does work\ntools: [Read, Edit, Write, Bash]\n---\nDoer body' },
+  { relPath: '_shared/conventions.md', content: 'Shared conventions text -- no frontmatter here' },
+  { relPath: 'schemas/plan.schema.json', content: '{"type":"object","properties":{}}' },
+];
+
+vi.mock('../src/cli/install.js', () => ({
+  loadAgentAssets: () => FAKE_AGENT_ASSETS,
+}));
+
+const mockUploadContentToHome = vi.fn();
+vi.mock('../src/services/sftp.js', () => ({
+  uploadContentToHome: (...args: any[]) => mockUploadContentToHome(...args),
+}));
+
+import {
+  loadCanonicalAgentSet,
+  remoteAgentsDir,
+  probeRemoteAgentHashes,
+  diffAgentSet,
+  provisionAgents,
+} from '../src/services/agent-provisioner.js';
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s, 'utf-8').digest('hex');
+}
+
+const OK: SSHExecResult = { stdout: '', stderr: '', code: 0 };
+
+beforeEach(() => {
+  backupAndResetRegistry();
+  vi.clearAllMocks();
+  mockUploadContentToHome.mockResolvedValue({ success: [], failed: [] });
+});
+
+afterEach(() => {
+  restoreRegistry();
+});
+
+// ---------------------------------------------------------------------------
+// loadCanonicalAgentSet
+// ---------------------------------------------------------------------------
+
+describe('loadCanonicalAgentSet', () => {
+  it('includes role agents, _shared/, and schemas/ with correct hashes for claude', () => {
+    const set = loadCanonicalAgentSet('claude');
+    expect(set.map(f => f.relPath).sort()).toEqual([
+      '_shared/conventions.md',
+      'doer.md',
+      'planner.md',
+      'schemas/plan.schema.json',
+    ]);
+
+    const planner = set.find(f => f.relPath === 'planner.md')!;
+    expect(planner.content).toBe(FAKE_AGENT_ASSETS[0].content);
+    expect(planner.sha256).toBe(sha256(FAKE_AGENT_ASSETS[0].content));
+    expect(planner.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('transforms .md files for opencode before hashing (mode: subagent)', () => {
+    const set = loadCanonicalAgentSet('opencode');
+    const planner = set.find(f => f.relPath === 'planner.md')!;
+    expect(planner.content).toContain('mode: subagent');
+    expect(planner.content).not.toBe(FAKE_AGENT_ASSETS[0].content);
+    expect(planner.sha256).toBe(sha256(planner.content));
+    // Hash differs from the untransformed claude set for the same file.
+    const claudeSet = loadCanonicalAgentSet('claude');
+    expect(planner.sha256).not.toBe(claudeSet.find(f => f.relPath === 'planner.md')!.sha256);
+  });
+
+  it('passes schemas/*.json through unchanged for opencode (no-op transform, no frontmatter)', () => {
+    const set = loadCanonicalAgentSet('opencode');
+    const schema = set.find(f => f.relPath === 'schemas/plan.schema.json')!;
+    expect(schema.content).toBe(FAKE_AGENT_ASSETS[3].content);
+    expect(schema.sha256).toBe(sha256(FAKE_AGENT_ASSETS[3].content));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// remoteAgentsDir
+// ---------------------------------------------------------------------------
+
+describe('remoteAgentsDir', () => {
+  it('maps each provider to its home-relative agents dir', () => {
+    expect(remoteAgentsDir('claude')).toBe('.claude/agents');
+    expect(remoteAgentsDir('gemini')).toBe('.gemini/agents');
+    expect(remoteAgentsDir('agy')).toBe('.gemini/antigravity-cli/agents');
+    expect(remoteAgentsDir('opencode')).toBe('.config/opencode/agents');
+  });
+
+  it('returns null for codex and copilot (no agents dir)', () => {
+    expect(remoteAgentsDir('codex')).toBeNull();
+    expect(remoteAgentsDir('copilot')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// probeRemoteAgentHashes
+// ---------------------------------------------------------------------------
+
+describe('probeRemoteAgentHashes', () => {
+  const agent = makeTestAgent({ os: 'linux' });
+
+  it('parses sha256sum-style output (linux)', async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: 'aaaa000000000000000000000000000000000000000000000000000000000001  ./planner.md\n'
+        + 'bbbb000000000000000000000000000000000000000000000000000000000002  ./_shared/conventions.md\n',
+      stderr: '',
+      code: 0,
+    });
+
+    const { hashes, failed } = await probeRemoteAgentHashes(agent, '.claude/agents');
+    expect(failed).toBe(false);
+    expect(hashes!.get('planner.md')).toBe('aaaa000000000000000000000000000000000000000000000000000000000001');
+    expect(hashes!.get('_shared/conventions.md')).toBe('bbbb000000000000000000000000000000000000000000000000000000000002');
+  });
+
+  it('parses shasum -a 256-style output (macos, single space separator with *)', async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: 'cccc000000000000000000000000000000000000000000000000000000000003 *./doer.md\n',
+      stderr: '',
+      code: 0,
+    });
+
+    const { hashes, failed } = await probeRemoteAgentHashes(agent, '.claude/agents');
+    expect(failed).toBe(false);
+    expect(hashes!.get('doer.md')).toBe('cccc000000000000000000000000000000000000000000000000000000000003');
+  });
+
+  it('parses Windows Get-FileHash output: backslash paths + uppercase hash normalized', async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: 'DDDD000000000000000000000000000000000000000000000000000000000004  ./_shared/conventions.md\n'
+        + 'EEEE000000000000000000000000000000000000000000000000000000000005  ./schemas\\plan.schema.json\n',
+      stderr: '',
+      code: 0,
+    });
+
+    const { hashes, failed } = await probeRemoteAgentHashes(agent, '.claude/agents');
+    expect(failed).toBe(false);
+    expect(hashes!.get('_shared/conventions.md')).toBe('dddd000000000000000000000000000000000000000000000000000000000004');
+    expect(hashes!.get('schemas/plan.schema.json')).toBe('eeee000000000000000000000000000000000000000000000000000000000005');
+  });
+
+  it('treats empty output as an empty map (missing/empty dir), not a failure', async () => {
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: '', code: 0 });
+
+    const { hashes, failed } = await probeRemoteAgentHashes(agent, '.claude/agents');
+    expect(failed).toBe(false);
+    expect(hashes).not.toBeNull();
+    expect(hashes!.size).toBe(0);
+  });
+
+  it('treats non-zero exit code as a failed probe', async () => {
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: 'boom', code: 1 });
+
+    const { hashes, failed } = await probeRemoteAgentHashes(agent, '.claude/agents');
+    expect(failed).toBe(true);
+    expect(hashes).toBeNull();
+  });
+
+  it('treats garbled output as a failed probe (no blind push)', async () => {
+    mockExecCommand.mockResolvedValue({ stdout: 'not a hash listing at all\njust noise', stderr: '', code: 0 });
+
+    const { hashes, failed } = await probeRemoteAgentHashes(agent, '.claude/agents');
+    expect(failed).toBe(true);
+    expect(hashes).toBeNull();
+  });
+
+  it('treats a transport/exec error as a failed probe', async () => {
+    mockExecCommand.mockRejectedValue(new Error('ssh timeout'));
+
+    const { hashes, failed } = await probeRemoteAgentHashes(agent, '.claude/agents');
+    expect(failed).toBe(true);
+    expect(hashes).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diffAgentSet
+// ---------------------------------------------------------------------------
+
+describe('diffAgentSet', () => {
+  it('pushes everything when the remote map is empty', () => {
+    const canonical = loadCanonicalAgentSet('claude');
+    const stale = diffAgentSet(canonical, new Map());
+    expect(stale.length).toBe(canonical.length);
+  });
+
+  it('pushes nothing when every hash matches', () => {
+    const canonical = loadCanonicalAgentSet('claude');
+    const remote = new Map(canonical.map(f => [f.relPath, f.sha256]));
+    const stale = diffAgentSet(canonical, remote);
+    expect(stale).toEqual([]);
+  });
+
+  it('pushes only stale/missing files, leaves extra remote files alone', () => {
+    const canonical = loadCanonicalAgentSet('claude');
+    const remote = new Map(canonical.map(f => [f.relPath, f.sha256]));
+    remote.set('planner.md', 'stale-hash-does-not-match');
+    remote.set('extra-file-not-in-canonical.md', sha256('whatever'));
+
+    const stale = diffAgentSet(canonical, remote);
+    expect(stale.map(f => f.relPath)).toEqual(['planner.md']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// provisionAgents
+// ---------------------------------------------------------------------------
+
+describe('provisionAgents', () => {
+  it('is a no-op for local members', async () => {
+    const local = makeTestLocalAgent();
+    const result = await provisionAgents(local);
+    expect(result.pushed).toEqual([]);
+    expect(result.skippedReason).toBe('local member shares operator home');
+    expect(mockExecCommand).not.toHaveBeenCalled();
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+  });
+
+  it('skips codex members (no agents dir)', async () => {
+    const agent = makeTestAgent({ llmProvider: 'codex', os: 'linux' });
+    const result = await provisionAgents(agent);
+    expect(result.pushed).toEqual([]);
+    expect(result.skippedReason).toContain('codex');
+    expect(mockExecCommand).not.toHaveBeenCalled();
+  });
+
+  it('skips copilot members (no agents dir)', async () => {
+    const agent = makeTestAgent({ llmProvider: 'copilot', os: 'linux' });
+    const result = await provisionAgents(agent);
+    expect(result.pushed).toEqual([]);
+    expect(result.skippedReason).toContain('copilot');
+  });
+
+  it('warns without throwing when the probe fails, and does not push', async () => {
+    const agent = makeTestAgent({ llmProvider: 'claude', os: 'linux' });
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: 'boom', code: 1 });
+
+    const result = await provisionAgents(agent);
+    expect(result.pushed).toEqual([]);
+    expect(result.warning).toBeDefined();
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+  });
+
+  it('never throws even if execCommand rejects', async () => {
+    const agent = makeTestAgent({ llmProvider: 'claude', os: 'linux' });
+    mockExecCommand.mockRejectedValue(new Error('connection reset'));
+
+    await expect(provisionAgents(agent)).resolves.toEqual(
+      expect.objectContaining({ pushed: [], warning: expect.any(String) })
+    );
+  });
+
+  it('pushes only stale/missing files when the remote is partially up to date', async () => {
+    const agent = makeTestAgent({ llmProvider: 'claude', os: 'linux' });
+    const canonical = loadCanonicalAgentSet('claude');
+    const plannerHash = canonical.find(f => f.relPath === 'planner.md')!.sha256;
+    const doerHash = canonical.find(f => f.relPath === 'doer.md')!.sha256;
+
+    // planner.md is already up to date; doer.md is missing entirely; the other two are stale.
+    mockExecCommand.mockResolvedValue({
+      stdout: `${plannerHash}  ./planner.md\nstalehashstalehashstalehashstalehashstalehashstalehashstalehas  ./_shared/conventions.md\n`,
+      stderr: '',
+      code: 0,
+    });
+    mockUploadContentToHome.mockResolvedValue({
+      success: ['_shared/conventions.md', 'doer.md', 'schemas/plan.schema.json'],
+      failed: [],
+    });
+
+    const result = await provisionAgents(agent);
+
+    expect(mockUploadContentToHome).toHaveBeenCalledTimes(1);
+    const [calledAgent, calledFiles, calledDir] = mockUploadContentToHome.mock.calls[0];
+    expect(calledAgent).toBe(agent);
+    expect(calledDir).toBe('.claude/agents');
+    expect(calledFiles.map((f: any) => f.relPath).sort()).toEqual(
+      ['_shared/conventions.md', 'doer.md', 'schemas/plan.schema.json'].sort()
+    );
+    expect(result.pushed.length).toBe(3);
+    expect(result.warning).toBeUndefined();
+    void doerHash; // referenced for readability of the fixture above
+  });
+
+  it('reports upload failures as a warning without throwing', async () => {
+    const agent = makeTestAgent({ llmProvider: 'claude', os: 'linux' });
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: '', code: 0 }); // empty remote -> push all
+    mockUploadContentToHome.mockResolvedValue({
+      success: ['planner.md'],
+      failed: [{ path: 'doer.md', error: 'permission denied' }],
+    });
+
+    const result = await provisionAgents(agent);
+    expect(result.pushed).toEqual(['planner.md']);
+    expect(result.warning).toContain('doer.md');
+  });
+
+  it('returns no-op when everything is already up to date', async () => {
+    const agent = makeTestAgent({ llmProvider: 'claude', os: 'linux' });
+    const canonical = loadCanonicalAgentSet('claude');
+    const stdout = canonical.map(f => `${f.sha256}  ./${f.relPath}\n`).join('');
+    mockExecCommand.mockResolvedValue({ stdout, stderr: '', code: 0 });
+
+    const result = await provisionAgents(agent);
+    expect(result.pushed).toEqual([]);
+    expect(result.warning).toBeUndefined();
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// os-commands hashFilesRecursive per-OS shape
+// ---------------------------------------------------------------------------
+
+describe('provisionAgents: OS x provider matrix -- axes never mix', () => {
+  // OS picks the probe command syntax (hashFilesRecursive); provider picks
+  // the probed directory AND the expected (possibly transformed) content
+  // hashes. Neither axis should ever leak into the other: probing a windows
+  // member must use windows syntax regardless of provider, and diffing must
+  // use the requested provider's directory/hashes regardless of member OS.
+  const OSES = ['linux', 'macos', 'windows'] as const;
+  const PROVIDERS = ['claude', 'opencode'] as const;
+
+  for (const os of OSES) {
+    for (const provider of PROVIDERS) {
+      it(`${os} x ${provider}: probes with ${os} syntax against the ${provider} dir and provider-correct hashes`, async () => {
+        const agent = makeTestAgent({ llmProvider: provider, os });
+        mockExecCommand.mockResolvedValue({ stdout: '', stderr: '', code: 0 }); // empty remote -> push all
+        mockUploadContentToHome.mockResolvedValue({ success: [], failed: [] });
+
+        await provisionAgents(agent);
+
+        expect(mockExecCommand).toHaveBeenCalledTimes(1);
+        const [probedCmd] = mockExecCommand.mock.calls[0];
+        const expectedDir = remoteAgentsDir(provider)!;
+
+        // OS axis: the probe command must match this member's OS syntax, not any other OS's.
+        const expectedCmd = getOsCommands(os).hashFilesRecursive(expectedDir);
+        expect(probedCmd).toBe(expectedCmd);
+        for (const otherOs of OSES.filter(o => o !== os)) {
+          expect(probedCmd).not.toBe(getOsCommands(otherOs).hashFilesRecursive(expectedDir));
+        }
+
+        // Provider axis: the files pushed must carry this provider's (possibly
+        // transformed) hashes, never the other provider's.
+        expect(mockUploadContentToHome).toHaveBeenCalledTimes(1);
+        const [, pushedFiles, calledDir] = mockUploadContentToHome.mock.calls[0];
+        expect(calledDir).toBe(expectedDir);
+        const plannerPushed = pushedFiles.find((f: any) => f.relPath === 'planner.md');
+        const expectedContent = loadCanonicalAgentSet(provider).find(f => f.relPath === 'planner.md')!.content;
+        const otherProviderContent = loadCanonicalAgentSet(
+          PROVIDERS.find(p => p !== provider)!
+        ).find(f => f.relPath === 'planner.md')!.content;
+        expect(plannerPushed.content).toBe(expectedContent);
+        expect(plannerPushed.content).not.toBe(otherProviderContent);
+      });
+    }
+  }
+
+  it('a claude-hashed remote listing never satisfies an opencode diff (and vice versa)', () => {
+    const claudeSet = loadCanonicalAgentSet('claude');
+    const opencodeSet = loadCanonicalAgentSet('opencode');
+    const remoteHasClaudeHashes = new Map(claudeSet.map(f => [f.relPath, f.sha256]));
+
+    // Diffing opencode's canonical set against a remote that actually holds
+    // untransformed claude hashes must treat every .md file as stale --
+    // the transform means the hashes can never coincidentally match.
+    const staleAgainstClaudeRemote = diffAgentSet(opencodeSet, remoteHasClaudeHashes);
+    expect(staleAgainstClaudeRemote.map(f => f.relPath).sort()).toEqual(
+      ['doer.md', 'planner.md'].sort()
+    );
+
+    // The reverse also holds.
+    const remoteHasOpencodeHashes = new Map(opencodeSet.map(f => [f.relPath, f.sha256]));
+    const staleAgainstOpencodeRemote = diffAgentSet(claudeSet, remoteHasOpencodeHashes);
+    expect(staleAgainstOpencodeRemote.map(f => f.relPath).sort()).toEqual(
+      ['doer.md', 'planner.md'].sort()
+    );
+  });
+});
+
+describe('hashFilesRecursive (os-commands)', () => {
+  it('linux: cd into dir + find/sha256sum, non-fatal on missing dir', () => {
+    const cmd = getOsCommands('linux').hashFilesRecursive('.claude/agents');
+    expect(cmd).toContain('cd ".claude/agents"');
+    expect(cmd).toContain('sha256sum');
+    expect(cmd).toContain('find . -type f');
+    expect(cmd).toContain('|| true');
+  });
+
+  it('macos: uses shasum -a 256 instead of sha256sum', () => {
+    const cmd = getOsCommands('macos').hashFilesRecursive('.claude/agents');
+    expect(cmd).toContain('cd ".claude/agents"');
+    expect(cmd).toContain('shasum -a 256');
+    expect(cmd).not.toContain('sha256sum');
+  });
+
+  it('windows: emits a base64-encoded PowerShell -EncodedCommand', () => {
+    const cmd = getOsCommands('windows').hashFilesRecursive('.claude/agents');
+    expect(cmd.startsWith('powershell -EncodedCommand ')).toBe(true);
+    const encoded = cmd.replace('powershell -EncodedCommand ', '');
+    const decoded = Buffer.from(encoded, 'base64').toString('utf16le');
+    expect(decoded).toContain('Join-Path $HOME');
+    expect(decoded).toContain('.claude\\agents');
+    expect(decoded).toContain('Get-FileHash');
+    expect(decoded).toContain('SHA256');
+    expect(decoded).toContain('.ToLower()');
+  });
+});

--- a/tests/agent-provisioner.test.ts
+++ b/tests/agent-provisioner.test.ts
@@ -276,9 +276,11 @@ describe('provisionAgents', () => {
     const plannerHash = canonical.find(f => f.relPath === 'planner.md')!.sha256;
     const doerHash = canonical.find(f => f.relPath === 'doer.md')!.sha256;
 
-    // planner.md is already up to date; doer.md is missing entirely; the other two are stale.
+    // planner.md is already up to date; doer.md is missing entirely; _shared/conventions.md
+    // is present but its hash doesn't match canonical (a valid 64-char hex hash, just the wrong one).
+    const wrongHash = 'deadbeef'.repeat(8);
     mockExecCommand.mockResolvedValue({
-      stdout: `${plannerHash}  ./planner.md\nstalehashstalehashstalehashstalehashstalehashstalehashstalehas  ./_shared/conventions.md\n`,
+      stdout: `${plannerHash}  ./planner.md\n${wrongHash}  ./_shared/conventions.md\n`,
       stderr: '',
       code: 0,
     });

--- a/tests/cloud-provider.test.ts
+++ b/tests/cloud-provider.test.ts
@@ -232,6 +232,13 @@ vi.mock('../src/services/strategy.js', () => ({
   }),
 }));
 
+// Agent provisioning is exercised in tests/agent-provisioner.test.ts and the
+// dedicated register/update-member provisioning tests -- stub it out here so
+// these unrelated cloud tests don't attempt real SFTP uploads.
+vi.mock('../src/services/agent-provisioner.js', () => ({
+  provisionAgents: vi.fn().mockResolvedValue({ pushed: [] }),
+}));
+
 // Partially mock aws.js: keep the real AwsCloudProvider class but replace the
 // awsProvider singleton so registerMember tests can control instance state.
 vi.mock('../src/services/cloud/aws.js', async (importOriginal) => {

--- a/tests/cloud-provider.test.ts
+++ b/tests/cloud-provider.test.ts
@@ -237,6 +237,7 @@ vi.mock('../src/services/strategy.js', () => ({
 // these unrelated cloud tests don't attempt real SFTP uploads.
 vi.mock('../src/services/agent-provisioner.js', () => ({
   provisionAgents: vi.fn().mockResolvedValue({ pushed: [] }),
+  remoteAgentsDir: () => '.claude/agents',
 }));
 
 // Partially mock aws.js: keep the real AwsCloudProvider class but replace the

--- a/tests/model-tiers.test.ts
+++ b/tests/model-tiers.test.ts
@@ -27,6 +27,13 @@ vi.mock('../src/services/strategy.js', () => ({
   }),
 }));
 
+// Agent provisioning is exercised in tests/agent-provisioner.test.ts and the
+// dedicated register/update-member provisioning tests -- stub it out here so
+// these unrelated model-tier tests don't attempt real SFTP uploads.
+vi.mock('../src/services/agent-provisioner.js', () => ({
+  provisionAgents: vi.fn().mockResolvedValue({ pushed: [] }),
+}));
+
 // -- resolveModelForTier unit tests --
 
 describe('resolveModelForTier', () => {

--- a/tests/model-tiers.test.ts
+++ b/tests/model-tiers.test.ts
@@ -32,6 +32,7 @@ vi.mock('../src/services/strategy.js', () => ({
 // these unrelated model-tier tests don't attempt real SFTP uploads.
 vi.mock('../src/services/agent-provisioner.js', () => ({
   provisionAgents: vi.fn().mockResolvedValue({ pushed: [] }),
+  remoteAgentsDir: () => '.claude/agents',
 }));
 
 // -- resolveModelForTier unit tests --

--- a/tests/register-member-oob.test.ts
+++ b/tests/register-member-oob.test.ts
@@ -26,6 +26,7 @@ vi.mock('../src/services/statusline.js', () => ({
 // these unrelated OOB tests don't attempt real SFTP uploads.
 vi.mock('../src/services/agent-provisioner.js', () => ({
   provisionAgents: vi.fn().mockResolvedValue({ pushed: [] }),
+  remoteAgentsDir: () => '.claude/agents',
 }));
 
 const mockCollectOobPassword = vi.fn<(name: string, tool: string, opts?: any) => Promise<{ password?: string; fallback?: string; persist?: boolean }>>();

--- a/tests/register-member-oob.test.ts
+++ b/tests/register-member-oob.test.ts
@@ -21,6 +21,13 @@ vi.mock('../src/services/statusline.js', () => ({
   writeStatusline: vi.fn(),
 }));
 
+// Agent provisioning is exercised in tests/agent-provisioner.test.ts and the
+// dedicated register/update-member provisioning tests -- stub it out here so
+// these unrelated OOB tests don't attempt real SFTP uploads.
+vi.mock('../src/services/agent-provisioner.js', () => ({
+  provisionAgents: vi.fn().mockResolvedValue({ pushed: [] }),
+}));
+
 const mockCollectOobPassword = vi.fn<(name: string, tool: string, opts?: any) => Promise<{ password?: string; fallback?: string; persist?: boolean }>>();
 const mockCollectOobApiKey = vi.fn<(name: string, tool: string, opts?: any) => Promise<{ password?: string; fallback?: string; persist?: boolean }>>();
 

--- a/tests/register-member-provisioning.test.ts
+++ b/tests/register-member-provisioning.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Extends register_member coverage for agent-provisioner integration:
+ * remote members should get role-agent files pushed when connectivity is
+ * confirmed; provisioning failure must not block registration; unreachable
+ * cloud members skip with a warning telling the operator to retry via
+ * update_member.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
+import { registerMember } from '../src/tools/register-member.js';
+import type { SSHExecResult } from '../src/types.js';
+
+const mockExecCommand = vi.fn<(cmd: string, timeout?: number) => Promise<SSHExecResult>>();
+const mockTestConnection = vi.fn();
+
+vi.mock('../src/services/strategy.js', () => ({
+  getStrategy: () => ({
+    execCommand: mockExecCommand,
+    testConnection: mockTestConnection,
+    transferFiles: vi.fn(),
+    close: vi.fn(),
+  }),
+}));
+
+vi.mock('../src/services/statusline.js', () => ({
+  writeStatusline: vi.fn(),
+}));
+
+const mockGetInstanceState = vi.fn();
+vi.mock('../src/services/cloud/aws.js', () => ({
+  awsProvider: {
+    getInstanceState: (...args: any[]) => mockGetInstanceState(...args),
+    getPublicIp: vi.fn(),
+  },
+}));
+
+const mockUploadContentToHome = vi.fn();
+vi.mock('../src/services/sftp.js', () => ({
+  uploadContentToHome: (...args: any[]) => mockUploadContentToHome(...args),
+}));
+
+const FAKE_AGENT_ASSETS = [
+  { relPath: 'planner.md', content: 'planner body' },
+  { relPath: 'doer.md', content: 'doer body' },
+];
+vi.mock('../src/cli/install.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/cli/install.js')>();
+  return {
+    ...actual,
+    loadAgentAssets: () => FAKE_AGENT_ASSETS,
+  };
+});
+
+describe('register_member: agent provisioning integration', () => {
+  beforeEach(() => {
+    backupAndResetRegistry();
+    vi.clearAllMocks();
+    mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 5 });
+    // Generic execCommand fallback for OS detect / CLI checks / mkdir.
+    mockExecCommand.mockResolvedValue({ stdout: 'Linux', stderr: '', code: 0 });
+    mockUploadContentToHome.mockResolvedValue({ success: [], failed: [] });
+    mockGetInstanceState.mockResolvedValue('running');
+  });
+
+  afterEach(() => {
+    restoreRegistry();
+  });
+
+  it('provisions agent files for a reachable remote member and reports the count', async () => {
+    // Remote agents dir is empty -> both canonical files are pushed.
+    mockExecCommand.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('find . -type f')) return { stdout: '', stderr: '', code: 0 };
+      return { stdout: 'Linux', stderr: '', code: 0 };
+    });
+    mockUploadContentToHome.mockResolvedValue({ success: ['planner.md', 'doer.md'], failed: [] });
+
+    const result = await registerMember({
+      friendly_name: 'prov-test',
+      member_type: 'remote',
+      host: '192.168.1.110',
+      username: 'akhil',
+      work_folder: '~/git/prov-test',
+      auth_type: 'password',
+      password: 'pw',
+    });
+
+    expect(result).toContain('Member registered successfully');
+    expect(result).toContain('Agents:  2 file(s) provisioned');
+    expect(mockUploadContentToHome).toHaveBeenCalledTimes(1);
+  });
+
+  it('appends a warning but still registers the member when provisioning (probe) fails', async () => {
+    mockExecCommand.mockImplementation(async (cmd: string) => {
+      if (cmd.includes('find . -type f')) return { stdout: '', stderr: 'boom', code: 1 };
+      return { stdout: 'Linux', stderr: '', code: 0 };
+    });
+
+    const result = await registerMember({
+      friendly_name: 'prov-fail-test',
+      member_type: 'remote',
+      host: '192.168.1.111',
+      username: 'akhil',
+      work_folder: '~/git/prov-fail-test',
+      auth_type: 'password',
+      password: 'pw',
+    });
+
+    expect(result).toContain('Member registered successfully');
+    expect(result).toContain('Could not verify remote agent files');
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+  });
+
+  it('warns to run update_member for a stopped/unreachable cloud member and skips provisioning', async () => {
+    mockGetInstanceState.mockResolvedValue('stopped');
+
+    const result = await registerMember({
+      friendly_name: 'cloud-stopped-test',
+      member_type: 'remote',
+      host: '192.168.1.112',
+      username: 'akhil',
+      work_folder: '~/git/cloud-test',
+      auth_type: 'key',
+      key_path: '~/.ssh/id_rsa',
+      cloud_provider: 'aws',
+      cloud_instance_id: 'i-0123456789abcdef0',
+      cloud_region: 'us-east-1',
+      cloud_state: 'stopped',
+    } as any);
+
+    expect(result).toContain('Agent files not provisioned -- run update_member after the instance starts.');
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unattended-mode.test.ts
+++ b/tests/unattended-mode.test.ts
@@ -20,6 +20,13 @@ vi.mock('../src/services/strategy.js', () => ({
   }),
 }));
 
+// Agent provisioning is exercised in tests/agent-provisioner.test.ts and the
+// dedicated register/update-member provisioning tests -- stub it out here so
+// these unrelated unattended-mode tests don't attempt real SFTP uploads.
+vi.mock('../src/services/agent-provisioner.js', () => ({
+  provisionAgents: vi.fn().mockResolvedValue({ pushed: [] }),
+}));
+
 vi.mock('../src/services/onboarding.js', () => ({
   loadOnboardingState: () => ({ bannerShown: true, firstMemberRegistered: true, firstPromptExecuted: true, multiMemberNudgeShown: true }),
   saveOnboardingState: vi.fn(),

--- a/tests/unattended-mode.test.ts
+++ b/tests/unattended-mode.test.ts
@@ -25,6 +25,7 @@ vi.mock('../src/services/strategy.js', () => ({
 // these unrelated unattended-mode tests don't attempt real SFTP uploads.
 vi.mock('../src/services/agent-provisioner.js', () => ({
   provisionAgents: vi.fn().mockResolvedValue({ pushed: [] }),
+  remoteAgentsDir: () => '.claude/agents',
 }));
 
 vi.mock('../src/services/onboarding.js', () => ({

--- a/tests/update-member.test.ts
+++ b/tests/update-member.test.ts
@@ -1,12 +1,37 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { makeTestAgent, makeTestLocalAgent, backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
 import { addAgent, getAllAgents } from '../src/services/registry.js';
 import { updateMember } from '../src/tools/update-member.js';
 import { credentialSet, credentialDelete } from '../src/services/credential-store.js';
+import type { SSHExecResult } from '../src/types.js';
+
+const mockExecCommand = vi.fn<(cmd: string, timeout?: number) => Promise<SSHExecResult>>();
+const mockTestConnection = vi.fn();
+
+// Default: connection "fails" so provisionAgents is skipped for tests that don't
+// care about it -- keeps the many pre-existing update-member tests from making
+// real network calls now that update_member re-provisions agent files for remote
+// members. Dedicated provisioning tests below override this per-case.
+vi.mock('../src/services/strategy.js', () => ({
+  getStrategy: () => ({
+    execCommand: mockExecCommand,
+    testConnection: mockTestConnection,
+  }),
+}));
+
+const mockUploadContentToHome = vi.fn();
+vi.mock('../src/services/sftp.js', () => ({
+  uploadContentToHome: (...args: any[]) => mockUploadContentToHome(...args),
+}));
 
 describe('updateMember', () => {
   beforeEach(() => {
     backupAndResetRegistry();
+    mockExecCommand.mockReset();
+    mockTestConnection.mockReset();
+    mockUploadContentToHome.mockReset();
+    mockTestConnection.mockResolvedValue({ ok: false, error: 'not reachable in this test' });
+    mockUploadContentToHome.mockResolvedValue({ success: [], failed: [] });
   });
 
   afterEach(() => {
@@ -181,5 +206,91 @@ describe('updateMember', () => {
 
     expect(result).not.toContain('Warning:');
     expect(result).toContain('Member "test-agent" updated.');
+  });
+});
+
+describe('updateMember -- agent re-provisioning (remote members)', () => {
+  beforeEach(() => {
+    backupAndResetRegistry();
+    mockExecCommand.mockReset();
+    mockTestConnection.mockReset();
+    mockUploadContentToHome.mockReset();
+    mockTestConnection.mockResolvedValue({ ok: false, error: 'not reachable in this test' });
+    mockUploadContentToHome.mockResolvedValue({ success: [], failed: [] });
+  });
+
+  afterEach(() => {
+    restoreRegistry();
+  });
+
+  it('re-provisions agent files once connectivity is confirmed', async () => {
+    const member = makeTestAgent({ llmProvider: 'claude' });
+    addAgent(member);
+
+    mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 5 });
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: '', code: 0 }); // empty remote dir -> push everything
+    mockUploadContentToHome.mockResolvedValue({ success: ['planner.md', 'doer.md'], failed: [] });
+
+    const result = await updateMember({ member_id: member.id, category: 'doers' });
+
+    expect(result).toContain('Member "test-agent" updated.');
+    expect(mockUploadContentToHome).toHaveBeenCalled();
+    expect(result).toMatch(/Agents:\s+\d+ file\(s\) provisioned/);
+  });
+
+  it('appends a warning but still updates when the provisioning probe fails', async () => {
+    const member = makeTestAgent({ llmProvider: 'claude' });
+    addAgent(member);
+
+    mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 5 });
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: 'boom', code: 1 }); // probe fails
+
+    const result = await updateMember({ member_id: member.id, category: 'doers' });
+
+    expect(result).toContain('Member "test-agent" updated.');
+    expect(result).toContain('Could not verify remote agent files');
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+  });
+
+  it('re-provisions at the new provider path when llm_provider is switched', async () => {
+    const member = makeTestAgent({ llmProvider: 'claude' });
+    addAgent(member);
+
+    mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 5 });
+    // New provider's remote dir has never been provisioned -- empty probe -> push everything.
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: '', code: 0 });
+    mockUploadContentToHome.mockResolvedValue({ success: ['planner.md'], failed: [] });
+
+    const result = await updateMember({ member_id: member.id, llm_provider: 'gemini' });
+
+    expect(result).toContain('Provider: gemini');
+    expect(mockUploadContentToHome).toHaveBeenCalledTimes(1);
+    const [, , calledDir] = mockUploadContentToHome.mock.calls[0];
+    expect(calledDir).toBe('.gemini/agents');
+  });
+
+  it('skips provisioning with a warning when unreachable, but still applies the update', async () => {
+    const member = makeTestAgent();
+    addAgent(member);
+
+    mockTestConnection.mockResolvedValue({ ok: false, error: 'connection timed out' });
+
+    const result = await updateMember({ member_id: member.id, category: 'doers' });
+
+    expect(result).toContain('Member "test-agent" updated.');
+    expect(result).toContain('Could not reach member -- agent files not re-provisioned: connection timed out');
+    expect(mockExecCommand).not.toHaveBeenCalled();
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+  });
+
+  it('does not attempt provisioning for local members', async () => {
+    const member = makeTestLocalAgent();
+    addAgent(member);
+
+    const result = await updateMember({ member_id: member.id, category: 'doers' });
+
+    expect(result).toContain('updated');
+    expect(mockTestConnection).not.toHaveBeenCalled();
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
   });
 });

--- a/tests/update-member.test.ts
+++ b/tests/update-member.test.ts
@@ -293,4 +293,31 @@ describe('updateMember -- agent re-provisioning (remote members)', () => {
     expect(mockTestConnection).not.toHaveBeenCalled();
     expect(mockUploadContentToHome).not.toHaveBeenCalled();
   });
+
+  it('does not attempt a connection or emit a provisioning warning for a codex remote member (no agents dir)', async () => {
+    const member = makeTestAgent({ llmProvider: 'codex' });
+    addAgent(member);
+
+    const result = await updateMember({ member_id: member.id, category: 'doers' });
+
+    expect(result).toContain('Member "test-agent" updated.');
+    expect(mockTestConnection).not.toHaveBeenCalled();
+    expect(mockExecCommand).not.toHaveBeenCalled();
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+    expect(result).not.toContain('Could not reach member');
+    expect(result).not.toContain('Agents:');
+  });
+
+  it('does not attempt a connection or emit a provisioning warning for a copilot remote member (no agents dir)', async () => {
+    const member = makeTestAgent({ llmProvider: 'copilot' });
+    addAgent(member);
+
+    const result = await updateMember({ member_id: member.id, category: 'doers' });
+
+    expect(result).toContain('Member "test-agent" updated.');
+    expect(mockTestConnection).not.toHaveBeenCalled();
+    expect(mockExecCommand).not.toHaveBeenCalled();
+    expect(mockUploadContentToHome).not.toHaveBeenCalled();
+    expect(result).not.toContain('Could not reach member');
+  });
 });


### PR DESCRIPTION
## Problem (bead apra-fleet-0ei, P1)

Remote fleet members never receive the role-agent definition files (planner.md, doer.md, reviewer.md, etc. plus _shared/ and schemas/). Local members share the operator's ~/.claude/agents/ transparently; a remote member has its own home and fails every agent dispatch with 'agent not found' -- making any remote member unusable as an auto-sprint role until a manual tarball workaround is applied.

## Fix

Hash-based detection + provider-aware provisioning at member register/update time:

- **src/services/agent-provisioner.ts** (new): builds the canonical agent set from the installed apra-fleet assets (dev / npm / SEA, via a new loadAgentAssets() export in install.ts), applies the existing transformAgentForOpenCode for opencode members BEFORE hashing, sha256s exact bytes; probes the member's provider-specific agents dir with ONE OS-aware exec round trip; diffs; pushes only missing/stale files via SFTP content writes (no temp files). Never throws -- all failures surface as warnings.
- **OS x provider matrix**: probe command syntax comes from the member OS (sha256sum / shasum -a 256 / PowerShell Get-FileHash via EncodedCommand); probed directory AND expected hashes come from the member provider (.claude/agents, .gemini/agents, .gemini/antigravity-cli/agents, .config/opencode/agents; codex/copilot skipped). The axes cannot mix; a failed/garbled probe means warn, never blind-push.
- **register_member**: provisions after connectivity is confirmed; warn-and-continue (registration still succeeds; stopped cloud members get a 'run update_member later' warning).
- **update_member**: doubles as the manual retry path -- testConnection pre-gate (no cloud auto-start), gated on the provider actually supporting agent files; a provider switch naturally re-provisions at the new provider's dir.

## Verification

- Full suite: 1693 passed / 0 failed (102 files); build green.
- Adversarial review (independent pass): verdict SHIP; its one SHOULD-FIX (skip the SSH connect for codex/copilot updates) and fixture NIT are addressed in the second commit.
- 12-case OS x provider matrix test plus explicit axis-mixing tests (Claude hashes never satisfy an OpenCode diff).

Closes apra-fleet-0ei.