### PR TITLE
summarise what was implemented across 1 cycle(s).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] -- per-member code-intelligence provider routing
+
+Sprint goal (P1/P2): route code-intelligence MCP tool calls through each member's configured provider instead of a single global backend. Implemented per-member resolution in `getProvider()` and wired the active in-flight member into the `code_query` / `code_references` / `code_definition` / `code_graph` / `code_impact` tool handlers. All 1749 tests pass (106 test files); build succeeds; working tree clean.
+
+Completed: `getProvider(memberId?)` now resolves a member's `codeIntelProvider` preference from the registry, falling back to the global default provider whenever the member has no preference, names an unregistered provider, or is not found -- this path never throws. The `code_*` MCP tool handlers resolve the active member from in-flight dispatch state (only when exactly one member is currently in flight, to avoid misattributing a call under concurrent dispatch) and forward that member id into provider resolution. Carried forward: end-to-end verification of per-member provider routing (registration through dispatch) remains open as backlog, and setting `codeIntelProvider` on a member is not yet exposed via the register/update member tool schemas.
+
+#### Sprint cost analysis
+Calibration: none   Cycles: estimated 1.5, actual 1
+
+| Role       | Est tokens | Act tokens |   D%   | Est USD  | Act USD  |
+|------------|------------|------------|-------|----------|----------|
+| doer       |          0 |     37,603 |   n/a |   $0.000 |   $0.819 |
+| reviewer   |          0 |     53,477 |   n/a |   $0.000 |   $0.991 |
+| overhead   |      7,150 |    101,779 | +1323% |   $0.121 |   $0.608 |
+| TOTAL      |      7,150 |    192,859 | +2597% |   $0.121 |   $2.417 |
+True-cost estimate (output x 4x): $0.483
+
+Outliers (>200% variance): overhead
+Calibration failures (>500%): overhead
+
 ## [v0.3.3] -- feat/install-default
 
 ### Breaking change -- MCP server start command changed

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Want to build your own skill on top of Fleet? See [docs/writing-skills.md](docs/
 | Git authentication | [docs/design-git-auth.md](docs/design-git-auth.md) |
 | Cloud compute | [docs/cloud-compute.md](docs/cloud-compute.md) |
 | Architecture | [docs/architecture.md](docs/architecture.md) |
+| Code intelligence tools (`code_query`, `code_impact`, etc.) and per-member providers | [docs/code-intelligence.md](docs/code-intelligence.md) |
 
 ## Community
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,6 +187,9 @@ One-time setup and maintenance. Provision auth (copy OAuth credentials or deploy
 **[Observability](tools-observability.md)**  -- `fleet_status`, `member_detail`
 Two-layer monitoring. `fleet_status` gives a quick summary table across all members with fleet-aware busy detection (distinguishes between Claude processes serving this member vs unrelated Claude activity). `member_detail` drills into one member with connectivity, CLI version, session state, and system resource metrics.
 
+**[Code Intelligence](code-intelligence.md)**  -- `code_query`, `code_references`, `code_definition`, `code_graph`, `code_impact`
+Symbol-level code queries backed by a pluggable, never-throwing provider abstraction. Each member can select its own backend (or opt out entirely); the active member for a call is inferred from in-flight dispatch state.
+
 ## Cross-Platform Support
 
 Members can run Windows, macOS, or Linux. The `platform.ts` utility generates the right shell commands for each OS  -- different commands for checking processes, reading memory, setting environment variables. The OS is auto-detected during registration (`uname -s` on Unix, `cmd /c ver` on Windows) and stored in the member record so subsequent tool calls don't need to re-detect.

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -1,0 +1,85 @@
+# Code Intelligence Tools
+
+Code-intelligence exposes symbol-level queries (`code_query`, `code_references`,
+`code_definition`, `code_graph`, `code_impact`) as MCP tools backed by a pluggable
+provider layer, so different fleet members can use different code-indexing backends
+(or none at all) without the orchestrator or dispatch code caring which one is active.
+
+## Provider abstraction
+
+`CodeIntelProvider` is the interface every backend implements:
+
+- `query(symbol, opts?)`
+- `getReferences(symbol)`
+- `getDefinition(symbol)`
+- `getCallGraph(symbol, depth?)`
+- `getImpact(symbol)`
+
+Every method returns a `CodeIntelResult` (`{ success, data?, error? }`) synchronously
+and **never throws**. A backend that can't answer a query (disabled, unconfigured,
+lookup failure) reports that as `{ success: false, error: "..." }` rather than raising
+an exception. This matters because these tools sit behind MCP tool-call dispatch: a
+thrown error there produces an opaque failure for the calling agent, whereas a
+structured `success: false` result lets the agent see *why* and decide what to do next
+(e.g. fall back to grep, or just note code-intel isn't available for this member).
+
+Two providers ship built in:
+
+- **`NullProvider`** (`name: 'none'`) -- explicit opt-out. Every method returns a
+  "disabled for this member" message. Selected when a member's `codeIntelProvider` is
+  set to `'none'`.
+- **`DefaultProvider`** (`name: 'default'`) -- the fallback when no specific backend is
+  configured. Every method returns a "not configured" message. This is intentionally a
+  placeholder, not a real indexer -- it exists so that calling any code-intel tool is
+  always safe (never a hard failure) even before a real backend is wired in for a
+  member.
+
+Additional real backends (an actual indexer/call-graph engine) register themselves in
+the `PROVIDERS` map under their own name; nothing else in the dispatch path needs to
+change to add one.
+
+## Per-member provider resolution
+
+Each `Agent` record carries an optional `codeIntelProvider: string` field. `getProvider`
+resolves which backend instance to use:
+
+1. No `memberId` given -> global `DefaultProvider` (this is what makes the tools
+   backward compatible with callers that don't know about per-member routing).
+2. `memberId` given but the agent has no `codeIntelProvider` set -> falls back to the
+   global default.
+3. `memberId` given and `codeIntelProvider` names a provider not present in `PROVIDERS`
+   -> falls back to the global default (never throws on an unknown/misconfigured name).
+4. `memberId` given and `codeIntelProvider` matches a registered provider -> that
+   provider instance is used, including `'none'` -> `NullProvider`.
+
+Resolution always degrades to "default" rather than failing outright. This is a
+deliberate trade-off: an unrecognized or missing provider name is treated as "not
+configured yet" rather than an error condition, since code-intel is an enhancement to
+agent capability, not something dispatch should ever block on.
+
+## Wiring into dispatch
+
+The MCP tool handlers for `code_query` / `code_references` / `code_definition` /
+`code_graph` / `code_impact` need to know *which* fleet member is asking, but the MCP
+tool-call surface itself carries no member identity parameter (it's not part of the
+tool's public schema -- callers just pass `symbol`, `opts`, etc.).
+
+The resolution strategy is a heuristic based on in-flight dispatch state: when exactly
+one member currently has a prompt in flight (`inFlightAgents.size === 1`), that member
+is assumed to be the caller and its `codeIntelProvider` is used. If zero or more than
+one member is in flight, the member is ambiguous and the tools fall back to the global
+default provider rather than guessing wrong.
+
+This is intentionally conservative -- it only attributes a code-intel call to a specific
+member when there's no ambiguity. Multi-member concurrent dispatch scenarios (more than
+one member in flight at once) fall back to shared/default behavior for code-intel calls
+until the tool-call surface carries explicit member identity end-to-end.
+
+## Known gap
+
+Setting a member's `codeIntelProvider` currently requires writing the field directly in
+the agent record -- it is not yet exposed as a parameter on the member
+registration/update tool schemas, so there's no end-to-end "register a member with a
+specific code-intel provider" path through the public API surface yet. End-to-end
+verification of per-member routing (registration through to tool dispatch) is tracked as
+follow-up backlog work.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -329,6 +329,7 @@ Want to build your own skill on top of Fleet? See [docs/writing-skills.md](docs/
 | Git authentication | [docs/design-git-auth.md](docs/design-git-auth.md) |
 | Cloud compute | [docs/cloud-compute.md](docs/cloud-compute.md) |
 | Architecture | [docs/architecture.md](docs/architecture.md) |
+| Code intelligence tools (`code_query`, `code_impact`, etc.) and per-member providers | [docs/code-intelligence.md](docs/code-intelligence.md) |
 
 ## Community
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -610,6 +610,9 @@ One-time setup and maintenance. Provision auth (copy OAuth credentials or deploy
 **[Observability](tools-observability.md)**  -- `fleet_status`, `member_detail`
 Two-layer monitoring. `fleet_status` gives a quick summary table across all members with fleet-aware busy detection (distinguishes between Claude processes serving this member vs unrelated Claude activity). `member_detail` drills into one member with connectivity, CLI version, session state, and system resource metrics.
 
+**[Code Intelligence](code-intelligence.md)**  -- `code_query`, `code_references`, `code_definition`, `code_graph`, `code_impact`
+Symbol-level code queries backed by a pluggable, never-throwing provider abstraction. Each member can select its own backend (or opt out entirely); the active member for a call is inferred from in-flight dispatch state.
+
 ## Cross-Platform Support
 
 Members can run Windows, macOS, or Linux. The `platform.ts` utility generates the right shell commands for each OS  -- different commands for checking processes, reading memory, setting environment variables. The OS is auto-detected during registration (`uname -s` on Unix, `cmd /c ver` on Windows) and stored in the member record so subsequent tool calls don't need to re-detect.

--- a/sprint-logs/calibration.json
+++ b/sprint-logs/calibration.json
@@ -78,42 +78,60 @@
     "standard": 80000,
     "premium": 150000
   },
+  "context_limits": {
+    "_doc": "Doer context-window budgeting. Used to predict whether a ready-task streak will fit in the model usable context before autocompact/session-limit truncation, and to split streaks proactively. Keyed by tier.",
+    "model_context_tokens": {
+      "_doc": "Total context window per tier (tokens).",
+      "cheap": 200000,
+      "standard": 200000,
+      "premium": 200000
+    },
+    "autocompact_headroom_fraction": 0.72,
+    "base_prompt_tokens": 9000,
+    "per_task_input_overhead_tokens": 3500,
+    "output_expansion_factor": 1
+  },
+  "parallelism": {
+    "_doc": "Doer concurrency (EXPERIMENTAL -- default 1 = proven serial path). When max_doers>1, independent bd-ready tasks are fanned out into isolated git worktrees, worked by one doer each in parallel, then merged back into the sprint branch sequentially with a conflict->re-queue fallback. This path is NOT yet default: on s10 (win32) it hit cross-platform worktree fragility (worktree \"already exists\" leak on re-create, and worktree-branch merges landing nothing -> 0 commits). Until that is hardened and validated on all runner OSes, max_doers stays 1 so sprints use the pre-parallelism serial path (which commits doers directly on the sprint branch, no worktree/merge machinery). Set >1 to opt into the experimental parallel path. Width is also capped by the harness concurrency limit and the number of ready tasks. Project-agnostic: no assumptions about language, layout, or task shape.",
+    "max_doers": 1,
+    "worktree_root": ".auto-sprint/wt"
+  },
   "historical": {
     "_doc": "Written by harvester after each sprint. Contains actual per-role output token averages from sprint-log JSONL files. Used by auto-sprint.js computeSprintQuote() to improve future estimates. Do not edit manually.",
     "max_sprints_in_sample": 5,
-    "sprints_sampled": 3,
-    "last_updated": "2026-06-30",
-    "cycle_avg": 2,
-    "reviewer_ratio_avg": 0.4157036813589812,
+    "sprints_sampled": 4,
+    "last_updated": "2026-07-25",
+    "cycle_avg": 1.75,
+    "reviewer_ratio_avg": 0.6673145532964478,
     "bucket_avg_tokens": {},
     "roles": {
       "setup": {
-        "avg_output_tokens": 4418,
-        "sample_n": 2
+        "avg_output_tokens": 4205.75,
+        "sample_n": 3
       },
       "sprint-meta": {
-        "avg_output_tokens": 794,
-        "sample_n": 2
+        "avg_output_tokens": 1065,
+        "sample_n": 3
       },
       "cycle-state": {
-        "avg_output_tokens": 4964,
-        "sample_n": 6
-      },
-      "ready-streaks": {
-        "avg_output_tokens": 2347,
-        "sample_n": 14
-      },
-      "doer": {
-        "avg_output_tokens": 9305.583333333334,
-        "sample_n": 8
-      },
-      "reviewer": {
-        "avg_output_tokens": 4125.111111111111,
+        "avg_output_tokens": 4468.75,
         "sample_n": 7
       },
+      "ready-streaks": {
+        "avg_output_tokens": 2363.8055555555557,
+        "sample_n": 23
+      },
+      "doer": {
+        "avg_output_tokens": 8859.3375,
+        "sample_n": 13
+      },
+      "reviewer": {
+        "avg_output_tokens": 5767.683333333333,
+        "sample_n": 12
+      },
       "log-append-iter": {
-        "avg_output_tokens": 2500.805555555555,
-        "sample_n": 8
+        "avg_output_tokens": 2838.2541666666666,
+        "sample_n": 13
       },
       "feedback-commit-reviewer": {
         "avg_output_tokens": 3396,
@@ -132,8 +150,8 @@
         "sample_n": 2
       },
       "log-append-end": {
-        "avg_output_tokens": 1924.8333333333333,
-        "sample_n": 6
+        "avg_output_tokens": 2102.375,
+        "sample_n": 7
       },
       "ci-watcher": {
         "avg_output_tokens": 1220,
@@ -144,23 +162,75 @@
         "sample_n": 1
       },
       "final-reviewer": {
-        "avg_output_tokens": 10054.666666666666,
-        "sample_n": 3
+        "avg_output_tokens": 8777.25,
+        "sample_n": 4
       },
       "cycle-meta": {
-        "avg_output_tokens": 969.3333333333334,
-        "sample_n": 4
+        "avg_output_tokens": 1154,
+        "sample_n": 5
       },
       "push-sha": {
-        "avg_output_tokens": 467.1666666666667,
-        "sample_n": 4
+        "avg_output_tokens": 491.375,
+        "sample_n": 5
       },
       "exit-check": {
-        "avg_output_tokens": 2458.5,
-        "sample_n": 4
+        "avg_output_tokens": 2975.125,
+        "sample_n": 5
       },
       "setup-shell": {
-        "avg_output_tokens": 1077,
+        "avg_output_tokens": 1169.75,
+        "sample_n": 2
+      },
+      "state-read": {
+        "avg_output_tokens": 604,
+        "sample_n": 1
+      },
+      "preflight-bd-schema": {
+        "avg_output_tokens": 438,
+        "sample_n": 1
+      },
+      "state-init": {
+        "avg_output_tokens": 1745,
+        "sample_n": 1
+      },
+      "stamp-setup": {
+        "avg_output_tokens": 277,
+        "sample_n": 1
+      },
+      "kb-primer": {
+        "avg_output_tokens": 933,
+        "sample_n": 1
+      },
+      "stamp-plan": {
+        "avg_output_tokens": 240,
+        "sample_n": 1
+      },
+      "state": {
+        "avg_output_tokens": 1459,
+        "sample_n": 2
+      },
+      "stamp-develop": {
+        "avg_output_tokens": 268,
+        "sample_n": 1
+      },
+      "heartbeat": {
+        "avg_output_tokens": 2425.1666666666665,
+        "sample_n": 6
+      },
+      "review-apply": {
+        "avg_output_tokens": 381.6666666666667,
+        "sample_n": 3
+      },
+      "feedback-write-reviewer": {
+        "avg_output_tokens": 4032.3333333333335,
+        "sample_n": 3
+      },
+      "stamp-harvest": {
+        "avg_output_tokens": 575,
+        "sample_n": 1
+      },
+      "harvest-clean-process-files": {
+        "avg_output_tokens": 752,
         "sample_n": 1
       }
     }

--- a/sprint-logs/test-kb-eval-a-20260725_104536.analysis.md
+++ b/sprint-logs/test-kb-eval-a-20260725_104536.analysis.md
@@ -1,0 +1,59 @@
+# Sprint summary: test/kb-eval-a
+
+**Started:** 20260725_104536  
+**Goal:** P1/P2  ->  MET  
+**Cycles:** estimated 1.5, actual 1  
+**Tasks:** 0 completed, 0 open/carried-forward
+
+---
+
+### Cost analysis
+
+#### Sprint cost analysis
+Calibration: none   Cycles: estimated 1.5, actual 1
+
+| Role       | Est tokens | Act tokens |   D%   | Est USD  | Act USD  |
+|------------|------------|------------|-------|----------|----------|
+| doer       |          0 |     37,603 |   n/a |   $0.000 |   $0.819 |
+| reviewer   |          0 |     53,477 |   n/a |   $0.000 |   $0.991 |
+| overhead   |      7,150 |    101,779 | +1323% |   $0.121 |   $0.608 |
+| TOTAL      |      7,150 |    192,859 | +2597% |   $0.121 |   $2.417 |
+True-cost estimate (output x 4x): $0.483
+
+Outliers (>200% variance): overhead
+Calibration failures (>500%): overhead
+
+---
+
+### Suggested calibration adjustments
+
+- `setup` actual 1685% over estimate -> consider bumping `fixed_overhead_tokens.setup` or bucket sizes
+
+## Sprint Execution Summary
+
+**Started:** 20260725_104536  
+**Cycles:** 1 (5 develop iteration(s), 3 reviewer CHANGES-NEEDED / feedback round(s))
+
+### Per-phase breakdown
+
+| Phase | Dispatches | Out tokens | Cost |
+| --- | --- | --- | --- |
+| Plan | 12 | 16854 | $0.0842 |
+| Develop | 41 | 169733 | $2.2029 |
+| Test | 0 | 0 | $0.0000 |
+| Harvest | 3 | 6272 | $0.1303 |
+
+### Per-phase timing (best-effort)
+
+- Plan: n/a (no timestamps)
+- Develop: n/a (no timestamps)
+- Test: n/a (no timestamps)
+- Harvest: n/a (no timestamps)
+
+### Failures / retries
+
+- c1: 5 develop iterations (retries)
+
+### Risks remaining
+
+_None -- goal met._

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,14 @@ async function startServer() {
   const { credentialStoreListSchema, credentialStoreList } = await import('./tools/credential-store-list.js');
   const { credentialStoreDeleteSchema, credentialStoreDelete } = await import('./tools/credential-store-delete.js');
   const { credentialStoreUpdateSchema, credentialStoreUpdate } = await import('./tools/credential-store-update.js');
+  const {
+    codeQuerySchema, codeQuery,
+    codeReferencesSchema, codeReferences,
+    codeDefinitionSchema, codeDefinition,
+    codeCallGraphSchema, codeCallGraph,
+    codeImpactSchema, codeImpact,
+  } = await import('./tools/code-intelligence.js');
+  const { inFlightAgents } = await import('./tools/execute-prompt.js');
   const { closeAllConnections } = await import('./services/ssh.js');
   const { idleManager } = await import('./services/cloud/idle-manager.js');
   const { cleanupStaleTasks } = await import('./services/task-cleanup.js');
@@ -288,6 +296,23 @@ async function startServer() {
 
   // --- Agent Lifecycle ---
   server.tool('stop_prompt', 'Kill the active LLM process on a member. Always call TaskStop on the dispatching background agent after calling this.', stopPromptSchema.shape, wrapTool('stop_prompt', (input) => stopPrompt(input as any)));
+  // --- Code Intelligence ---
+  // Resolve the active member from inFlightAgents so code-intel tools use the
+  // correct per-member provider. When exactly one member is being prompted, that
+  // member's codeIntelProvider is used; otherwise falls back to global default.
+  function resolveActiveMemberId(): string | undefined {
+    if (inFlightAgents.size === 1) {
+      return inFlightAgents.values().next().value as string;
+    }
+    return undefined;
+  }
+
+  server.tool('code_query', 'Query a code symbol for information. Resolves against the active member\'s code-intelligence provider.', codeQuerySchema.shape, wrapTool('code_query', (input) => codeQuery(input as any, resolveActiveMemberId())));
+  server.tool('code_references', 'Find all references to a symbol in the codebase.', codeReferencesSchema.shape, wrapTool('code_references', (input) => codeReferences(input as any, resolveActiveMemberId())));
+  server.tool('code_definition', 'Find the definition of a symbol.', codeDefinitionSchema.shape, wrapTool('code_definition', (input) => codeDefinition(input as any, resolveActiveMemberId())));
+  server.tool('code_graph', 'Trace the call graph for a symbol.', codeCallGraphSchema.shape, wrapTool('code_graph', (input) => codeCallGraph(input as any, resolveActiveMemberId())));
+  server.tool('code_impact', 'Analyze the change impact of a symbol.', codeImpactSchema.shape, wrapTool('code_impact', (input) => codeImpact(input as any, resolveActiveMemberId())));
+
   // --- Credential Store ---
   server.tool('credential_store_set', 'Collect a secret from the user out-of-band and store it. Returns a handle (sec://NAME) and scope. Use {{secure.NAME}} tokens in execute_command to inject the value.', credentialStoreSetSchema.shape, wrapTool('credential_store_set', (input) => credentialStoreSet(input as any)));
   server.tool('credential_store_list', 'List all stored credentials (names and metadata only — no values).', credentialStoreListSchema.shape, wrapTool('credential_store_list', () => credentialStoreList()));

--- a/src/tools/code-intelligence.ts
+++ b/src/tools/code-intelligence.ts
@@ -1,0 +1,133 @@
+import { getAgent } from '../services/registry.js';
+
+/**
+ * Result returned by every CodeIntelProvider method.
+ */
+export interface CodeIntelResult {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+/**
+ * Interface that all code-intelligence backends must implement.
+ */
+export interface CodeIntelProvider {
+  readonly name: string;
+  query(symbol: string, opts?: Record<string, unknown>): CodeIntelResult;
+  getReferences(symbol: string): CodeIntelResult;
+  getDefinition(symbol: string): CodeIntelResult;
+  getCallGraph(symbol: string, depth?: number): CodeIntelResult;
+  getImpact(symbol: string): CodeIntelResult;
+}
+
+/**
+ * A provider that returns structured "disabled" messages for every operation.
+ * Never throws -- all methods return { success: false, error: "..." }.
+ */
+export class NullProvider implements CodeIntelProvider {
+  readonly name = 'none';
+
+  private disabled(method: string): CodeIntelResult {
+    return {
+      success: false,
+      error: `code intelligence disabled for this member (${method})`,
+    };
+  }
+
+  query(_symbol: string, _opts?: Record<string, unknown>): CodeIntelResult {
+    return this.disabled('query');
+  }
+
+  getReferences(_symbol: string): CodeIntelResult {
+    return this.disabled('getReferences');
+  }
+
+  getDefinition(_symbol: string): CodeIntelResult {
+    return this.disabled('getDefinition');
+  }
+
+  getCallGraph(_symbol: string, _depth?: number): CodeIntelResult {
+    return this.disabled('getCallGraph');
+  }
+
+  getImpact(_symbol: string): CodeIntelResult {
+    return this.disabled('getImpact');
+  }
+}
+
+/**
+ * Default provider used when no specific code-intelligence backend is configured.
+ * Returns "not configured" results for all methods without throwing.
+ */
+class DefaultProvider implements CodeIntelProvider {
+  readonly name = 'default';
+
+  private notConfigured(method: string): CodeIntelResult {
+    return {
+      success: false,
+      error: `no code intelligence provider configured (${method})`,
+    };
+  }
+
+  query(_symbol: string, _opts?: Record<string, unknown>): CodeIntelResult {
+    return this.notConfigured('query');
+  }
+
+  getReferences(_symbol: string): CodeIntelResult {
+    return this.notConfigured('getReferences');
+  }
+
+  getDefinition(_symbol: string): CodeIntelResult {
+    return this.notConfigured('getDefinition');
+  }
+
+  getCallGraph(_symbol: string, _depth?: number): CodeIntelResult {
+    return this.notConfigured('getCallGraph');
+  }
+
+  getImpact(_symbol: string): CodeIntelResult {
+    return this.notConfigured('getImpact');
+  }
+}
+
+const nullProvider = new NullProvider();
+const defaultProvider = new DefaultProvider();
+
+/**
+ * Map of known code-intelligence provider names to their implementations.
+ * 'none' always maps to NullProvider; additional backends can be registered here.
+ */
+export const PROVIDERS: Record<string, CodeIntelProvider> = {
+  none: nullProvider,
+  default: defaultProvider,
+};
+
+/**
+ * Resolve a code-intelligence provider.
+ *
+ * - No args: returns the global default provider (backward compatible).
+ * - With memberId: looks up the agent's codeIntelProvider in the registry.
+ *   - If the agent has codeIntelProvider set, uses that provider from PROVIDERS.
+ *   - If codeIntelProvider is 'none', returns NullProvider.
+ *   - If the agent has no codeIntelProvider, falls back to the global default.
+ *   - If the agent is not found, returns the global default.
+ */
+export function getProvider(memberId?: string): CodeIntelProvider {
+  if (!memberId) {
+    return defaultProvider;
+  }
+
+  const agent = getAgent(memberId);
+  if (!agent || !agent.codeIntelProvider) {
+    return defaultProvider;
+  }
+
+  const providerName = agent.codeIntelProvider;
+  const provider = PROVIDERS[providerName];
+  if (!provider) {
+    return defaultProvider;
+  }
+
+  return provider;
+}

--- a/src/tools/code-intelligence.ts
+++ b/src/tools/code-intelligence.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { getAgent } from '../services/registry.js';
 
 /**
@@ -130,4 +131,80 @@ export function getProvider(memberId?: string): CodeIntelProvider {
   }
 
   return provider;
+}
+
+// ---------------------------------------------------------------------------
+// MCP tool schemas -- memberId is internal (not exposed in zod schemas)
+// ---------------------------------------------------------------------------
+
+export const codeQuerySchema = z.object({
+  symbol: z.string().describe('Symbol name to query'),
+  opts: z.record(z.unknown()).optional().describe('Additional query options'),
+});
+
+export const codeReferencesSchema = z.object({
+  symbol: z.string().describe('Symbol to find all references for'),
+});
+
+export const codeDefinitionSchema = z.object({
+  symbol: z.string().describe('Symbol to find definition for'),
+});
+
+export const codeCallGraphSchema = z.object({
+  symbol: z.string().describe('Symbol to trace call graph for'),
+  depth: z.number().optional().describe('Max depth of call graph traversal'),
+});
+
+export const codeImpactSchema = z.object({
+  symbol: z.string().describe('Symbol to analyze change impact for'),
+});
+
+// ---------------------------------------------------------------------------
+// Tool handler functions -- each accepts optional memberId to forward to
+// getProvider() for per-member provider resolution.
+// ---------------------------------------------------------------------------
+
+export async function codeQuery(
+  input: z.infer<typeof codeQuerySchema>,
+  memberId?: string,
+): Promise<string> {
+  const provider = getProvider(memberId);
+  const result = provider.query(input.symbol, input.opts);
+  return JSON.stringify(result);
+}
+
+export async function codeReferences(
+  input: z.infer<typeof codeReferencesSchema>,
+  memberId?: string,
+): Promise<string> {
+  const provider = getProvider(memberId);
+  const result = provider.getReferences(input.symbol);
+  return JSON.stringify(result);
+}
+
+export async function codeDefinition(
+  input: z.infer<typeof codeDefinitionSchema>,
+  memberId?: string,
+): Promise<string> {
+  const provider = getProvider(memberId);
+  const result = provider.getDefinition(input.symbol);
+  return JSON.stringify(result);
+}
+
+export async function codeCallGraph(
+  input: z.infer<typeof codeCallGraphSchema>,
+  memberId?: string,
+): Promise<string> {
+  const provider = getProvider(memberId);
+  const result = provider.getCallGraph(input.symbol, input.depth);
+  return JSON.stringify(result);
+}
+
+export async function codeImpact(
+  input: z.infer<typeof codeImpactSchema>,
+  memberId?: string,
+): Promise<string> {
+  const provider = getProvider(memberId);
+  const result = provider.getImpact(input.symbol);
+  return JSON.stringify(result);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface Agent {
   modelTiers?: { cheap?: string; standard?: string; premium?: string };
   category?: string;
   tags?: string[];
+  codeIntelProvider?: string;
 }
 
 export interface GitHubAppConfig {

--- a/tests/code-intelligence.test.ts
+++ b/tests/code-intelligence.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getProvider, NullProvider, PROVIDERS } from '../src/tools/code-intelligence.js';
+import {
+  getProvider, NullProvider, PROVIDERS,
+  codeQuery, codeReferences, codeDefinition, codeCallGraph, codeImpact,
+} from '../src/tools/code-intelligence.js';
 import type { CodeIntelProvider, CodeIntelResult } from '../src/tools/code-intelligence.js';
 
 // Mock the registry module
@@ -134,6 +137,120 @@ describe('code-intelligence', () => {
     it('contains "default" mapping', () => {
       expect(PROVIDERS['default']).toBeDefined();
       expect(PROVIDERS['default'].name).toBe('default');
+    });
+  });
+
+  describe('tool handler functions', () => {
+    describe('without memberId (global fallback)', () => {
+      it('codeQuery uses default provider', async () => {
+        const result = JSON.parse(await codeQuery({ symbol: 'foo' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('no code intelligence provider configured');
+      });
+
+      it('codeReferences uses default provider', async () => {
+        const result = JSON.parse(await codeReferences({ symbol: 'foo' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('no code intelligence provider configured');
+      });
+
+      it('codeDefinition uses default provider', async () => {
+        const result = JSON.parse(await codeDefinition({ symbol: 'foo' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('no code intelligence provider configured');
+      });
+
+      it('codeCallGraph uses default provider', async () => {
+        const result = JSON.parse(await codeCallGraph({ symbol: 'foo' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('no code intelligence provider configured');
+      });
+
+      it('codeImpact uses default provider', async () => {
+        const result = JSON.parse(await codeImpact({ symbol: 'foo' }));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('no code intelligence provider configured');
+      });
+    });
+
+    describe('with memberId (per-member provider)', () => {
+      it('codeQuery resolves member-specific provider', async () => {
+        mockGetAgent.mockReturnValue({
+          id: 'agent-ci',
+          friendlyName: 'CI Agent',
+          agentType: 'local',
+          workFolder: '/tmp/work',
+          createdAt: '2026-01-01',
+          codeIntelProvider: 'none',
+        });
+
+        const result = JSON.parse(await codeQuery({ symbol: 'bar' }, 'agent-ci'));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('code intelligence disabled');
+        expect(mockGetAgent).toHaveBeenCalledWith('agent-ci');
+      });
+
+      it('codeReferences resolves member-specific provider', async () => {
+        mockGetAgent.mockReturnValue({
+          id: 'agent-ci',
+          friendlyName: 'CI Agent',
+          agentType: 'local',
+          workFolder: '/tmp/work',
+          createdAt: '2026-01-01',
+          codeIntelProvider: 'none',
+        });
+
+        const result = JSON.parse(await codeReferences({ symbol: 'bar' }, 'agent-ci'));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('code intelligence disabled');
+      });
+
+      it('codeCallGraph forwards depth and resolves member provider', async () => {
+        mockGetAgent.mockReturnValue({
+          id: 'agent-ci',
+          friendlyName: 'CI Agent',
+          agentType: 'local',
+          workFolder: '/tmp/work',
+          createdAt: '2026-01-01',
+          codeIntelProvider: 'none',
+        });
+
+        const result = JSON.parse(await codeCallGraph({ symbol: 'baz', depth: 5 }, 'agent-ci'));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('code intelligence disabled');
+        expect(result.error).toContain('getCallGraph');
+      });
+
+      it('codeImpact resolves member-specific provider', async () => {
+        mockGetAgent.mockReturnValue({
+          id: 'agent-ci',
+          friendlyName: 'CI Agent',
+          agentType: 'local',
+          workFolder: '/tmp/work',
+          createdAt: '2026-01-01',
+          codeIntelProvider: 'none',
+        });
+
+        const result = JSON.parse(await codeImpact({ symbol: 'qux' }, 'agent-ci'));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('code intelligence disabled');
+      });
+    });
+
+    describe('with memberId falling back to default', () => {
+      it('falls back when agent has no codeIntelProvider', async () => {
+        mockGetAgent.mockReturnValue({
+          id: 'agent-noconfig',
+          friendlyName: 'No Config Agent',
+          agentType: 'local',
+          workFolder: '/tmp/work',
+          createdAt: '2026-01-01',
+        });
+
+        const result = JSON.parse(await codeQuery({ symbol: 'test' }, 'agent-noconfig'));
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('no code intelligence provider configured');
+      });
     });
   });
 });

--- a/tests/code-intelligence.test.ts
+++ b/tests/code-intelligence.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getProvider, NullProvider, PROVIDERS } from '../src/tools/code-intelligence.js';
+import type { CodeIntelProvider, CodeIntelResult } from '../src/tools/code-intelligence.js';
+
+// Mock the registry module
+vi.mock('../src/services/registry.js', () => ({
+  getAgent: vi.fn(),
+}));
+
+import { getAgent } from '../src/services/registry.js';
+const mockGetAgent = vi.mocked(getAgent);
+
+describe('code-intelligence', () => {
+  beforeEach(() => {
+    mockGetAgent.mockReset();
+  });
+
+  describe('getProvider() with no args', () => {
+    it('returns the global default provider', () => {
+      const provider = getProvider();
+      expect(provider.name).toBe('default');
+    });
+
+    it('returns the same provider on repeated calls (backward compat)', () => {
+      const a = getProvider();
+      const b = getProvider();
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('getProvider(memberId)', () => {
+    it('returns member-specific provider when codeIntelProvider is set', () => {
+      mockGetAgent.mockReturnValue({
+        id: 'agent-1',
+        friendlyName: 'Test Agent',
+        agentType: 'local',
+        workFolder: '/tmp/work',
+        createdAt: '2026-01-01',
+        codeIntelProvider: 'none',
+      });
+
+      const provider = getProvider('agent-1');
+      expect(provider.name).toBe('none');
+      expect(provider).toBeInstanceOf(NullProvider);
+    });
+
+    it('falls back to default when agent has no codeIntelProvider', () => {
+      mockGetAgent.mockReturnValue({
+        id: 'agent-2',
+        friendlyName: 'Test Agent 2',
+        agentType: 'local',
+        workFolder: '/tmp/work',
+        createdAt: '2026-01-01',
+      });
+
+      const provider = getProvider('agent-2');
+      expect(provider.name).toBe('default');
+    });
+
+    it('falls back to default when agent is not found', () => {
+      mockGetAgent.mockReturnValue(undefined);
+
+      const provider = getProvider('nonexistent');
+      expect(provider.name).toBe('default');
+    });
+
+    it('falls back to default for unknown provider name', () => {
+      mockGetAgent.mockReturnValue({
+        id: 'agent-3',
+        friendlyName: 'Test Agent 3',
+        agentType: 'local',
+        workFolder: '/tmp/work',
+        createdAt: '2026-01-01',
+        codeIntelProvider: 'unknown-provider',
+      });
+
+      const provider = getProvider('agent-3');
+      expect(provider.name).toBe('default');
+    });
+  });
+
+  describe('NullProvider', () => {
+    let nullProvider: NullProvider;
+
+    beforeEach(() => {
+      nullProvider = new NullProvider();
+    });
+
+    it('has name "none"', () => {
+      expect(nullProvider.name).toBe('none');
+    });
+
+    it('query() returns structured error, never throws', () => {
+      const result = nullProvider.query('someSymbol');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('code intelligence disabled');
+      expect(result.error).toContain('query');
+    });
+
+    it('getReferences() returns structured error, never throws', () => {
+      const result = nullProvider.getReferences('someSymbol');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('code intelligence disabled');
+      expect(result.error).toContain('getReferences');
+    });
+
+    it('getDefinition() returns structured error, never throws', () => {
+      const result = nullProvider.getDefinition('someSymbol');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('code intelligence disabled');
+      expect(result.error).toContain('getDefinition');
+    });
+
+    it('getCallGraph() returns structured error, never throws', () => {
+      const result = nullProvider.getCallGraph('someSymbol', 3);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('code intelligence disabled');
+      expect(result.error).toContain('getCallGraph');
+    });
+
+    it('getImpact() returns structured error, never throws', () => {
+      const result = nullProvider.getImpact('someSymbol');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('code intelligence disabled');
+      expect(result.error).toContain('getImpact');
+    });
+  });
+
+  describe('PROVIDERS map', () => {
+    it('contains "none" mapping to NullProvider', () => {
+      expect(PROVIDERS['none']).toBeInstanceOf(NullProvider);
+    });
+
+    it('contains "default" mapping', () => {
+      expect(PROVIDERS['default']).toBeDefined();
+      expect(PROVIDERS['default'].name).toBe('default');
+    });
+  });
+});


### PR DESCRIPTION
## What was built (per sprint goal)

This sprint adds a code-intelligence provider abstraction layer to apra-fleet, decoupling MCP tool handlers from a specific code-intelligence backend:

- `src/tools/code-intelligence.ts`: new provider abstraction with a `CodeIntelProvider` interface, `NullProvider`, `DefaultProvider`, a `PROVIDERS` registry, `getProvider()` with a 4-case fallback, 5 Zod schemas, and 5 async tool handlers. Never-throwing design.
- `src/index.ts`: registers the 5 new MCP tools and adds `resolveActiveMemberId()` using an `inFlightAgents.size === 1` heuristic to route per-member provider selection.
- `src/types.ts`: adds `codeIntelProvider?: string` to the `Agent` interface (minimal, non-breaking).
- `tests/code-intelligence.test.ts`: 24 tests covering provider resolution, `NullProvider` behavior, the `PROVIDERS` map, and all tool handlers with and without `memberId`.

- Sprint goal: P1/P2 -- MET
- Cycles run: 1

## Open items carried forward (if any)

`bd list --status=open` shows 30 open issues in the tracker overall (pre-existing backlog, not all attributable to this sprint). Notable ones adjacent to this work:

- `apra-fleet-0um.1` / `.2` / `.3` (P1/P2): evaluate codebase-memory-mcp vs Joern, implement and register `CodebaseMemoryProvider`
- `apra-fleet-151.1` / `.2` / `.3` (P1): audit KB tools and code-intelligence tools with both providers
- `apra-fleet-c6o.2.3` (P2): [test] verify per-member provider routing end-to-end
- `apra-fleet-le1` epic (P1) and children: optional per-repo code-intelligence enablement skip / upgrade-path handling
- `apra-fleet-t0d.3` and children (P1/P2): incremental re-indexing on code changes
- `apra-fleet-yeb` epic (P1) and children: SaaS bootstrap/sync integration
- Remaining P2 items: `apra-fleet-1az`, `apra-fleet-69r`, `apra-fleet-796`, `apra-fleet-9te`, `apra-fleet-t0d.2.1/.2`, `apra-fleet-ysl`

None of these block this PR; they are follow-on work.

## Final review notes

Sprint branch `test/kb-eval-a` adds a clean code-intelligence provider abstraction layer (2 commits, 4 files, +492 lines). All 1749 tests pass across 106 test files. Build succeeds. Working tree is clean.

Key files reviewed:
- `src/tools/code-intelligence.ts`: New provider abstraction with `CodeIntelProvider` interface, `NullProvider`, `DefaultProvider`, `PROVIDERS` registry, `getProvider()` with 4-case fallback, 5 Zod schemas, 5 async tool handlers. Clean, never-throwing design.
- `src/index.ts`: 5 MCP tool registrations with `resolveActiveMemberId()` using `inFlightAgents.size === 1` heuristic -- correct and conservative.
- `src/types.ts`: Added `codeIntelProvider?: string` to `Agent` interface -- minimal, non-breaking.
- `tests/code-intelligence.test.ts`: 24 tests covering provider resolution, `NullProvider` behavior, `PROVIDERS` map, and all tool handlers with and without `memberId`. Registry properly mocked.

Minor cosmetic note: `afterEach` is imported but unused in the test file (line 1). Not blocking.

No security issues, no regressions, no extraneous files. Code follows existing project patterns and conventions. Ready to harvest as a PR.

## Token cost summary

From: `bd memories auto-sprint`
