### PR TITLE
Fix e2e turn-budget, git-auth, and log-collection reliability issues

### DIFF
--- a/.github/e2e/fleet-setup.mjs
+++ b/.github/e2e/fleet-setup.mjs
@@ -8,12 +8,16 @@
 //
 // Usage:
 //   node fleet-setup.mjs setup --suite <id>
+//   node fleet-setup.mjs collect-logs
 //   node fleet-setup.mjs teardown
 //   node fleet-setup.mjs shutdown
 //
-// `setup` must be run with cwd set to the run directory ($RUN_DIR in the
-// workflow) -- checkpoints.json is written relative to cwd, matching the
-// convention sprint-script.md already uses for T3-* checkpoints.
+// `setup` and `collect-logs` must be run with cwd set to the run directory
+// ($RUN_DIR in the workflow) -- checkpoints.json / logs/<role>/ are written
+// relative to cwd, matching the convention sprint-script.md already uses for
+// T3-* checkpoints. `collect-logs` must run BEFORE `teardown` -- it needs
+// alice/bella still registered and reachable to pull their session
+// transcripts.
 //
 // `shutdown` stops the whole fleet server process (every member/session on
 // the runner, not just the ones this suite registered) and is deliberately
@@ -363,6 +367,162 @@ export function deleteFolderCommand(folderPath, os) {
     : `rm -rf "${folderPath}"`;
 }
 
+// ---- deterministic session-log collection --------------------------------
+//
+// Replaces sprint-script.md's old "## Collect Session Logs" section, which
+// had the orchestrator LLM itself work out each member's transcript path and
+// copy it over -- real turns spent on pure file-finding with no reasoning
+// involved, and it silently produced nothing if the orchestrator ran out of
+// turns or crashed before reaching that instruction. This runs unconditionally
+// as its own step (see fleet-e2e.yml, `if: always()`, before T6 teardown
+// removes the members) so logs are collected even on a total LLM failure.
+//
+// Path conventions below mirror src/services/stall/log-path-resolver.ts
+// (the stall detector's own, already-tested logic for finding a live
+// session's log file) rather than the old prompt's hand-written description,
+// which turned out to disagree with it in places (e.g. gemini's real
+// filename is the exact session ID, not an 8-char-prefix glob).
+
+export function claudeProjectSlug(workFolder) {
+  // Claude Code replaces EVERY non-alphanumeric character (slashes,
+  // backslashes, colons, dots...) with '-', not just path separators.
+  return workFolder.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+export function geminiProjectName(workFolder) {
+  return workFolder.split(/[\\/]/).filter(Boolean).pop() || 'project';
+}
+
+// Builds a cross-platform Node script (run via `node -e` through
+// execute_command) that locates a member's own session transcript and
+// copies it into the current directory -- avoids needing separate
+// bash/PowerShell variants per OS, matching the pattern the workflow already
+// uses for agy's own transcript lookup (fleet-e2e.yml's AGY_TRANSCRIPT_SCRIPT).
+// Returns null for providers with no known flat-file transcript (opencode
+// stores sessions in a SQLite db, not a per-session file -- unsupported here).
+export function collectTranscriptScript(provider, workFolder, sessionId) {
+  const idLit = JSON.stringify(sessionId);
+  const copyAndReport = (srcExpr) =>
+    `if(fs.existsSync(${srcExpr})){fs.copyFileSync(${srcExpr},path.join(process.cwd(),${idLit}+'.jsonl'));console.log('FLEET_LOG_COPIED');}else{console.log('FLEET_LOG_MISSING');}`;
+
+  if (provider === 'claude') {
+    const slug = claudeProjectSlug(workFolder);
+    return `const fs=require('fs'),path=require('path'),os=require('os');`
+      + `const src=path.join(os.homedir(),'.claude','projects',${JSON.stringify(slug)},${idLit}+'.jsonl');`
+      + copyAndReport('src');
+  }
+
+  if (provider === 'gemini') {
+    const projectName = geminiProjectName(workFolder);
+    return `const fs=require('fs'),path=require('path'),os=require('os');`
+      + `const src=path.join(os.homedir(),'.gemini','tmp',${JSON.stringify(projectName)},'chats',${idLit}+'.jsonl');`
+      + copyAndReport('src');
+  }
+
+  if (provider === 'agy') {
+    // agy (antigravity-cli) has no session-id-named file at all -- it keys a
+    // cache of conversations by the exact cwd they were started in, mapping
+    // to an internal conversation id whose transcript lives elsewhere. The
+    // fleet-tracked sessionId isn't used for lookup here at all; this only
+    // needs the member's own work folder.
+    const wfLit = JSON.stringify(workFolder);
+    return `const fs=require('fs'),path=require('path'),os=require('os');`
+      + `const home=os.homedir();`
+      + `const norm=p=>path.resolve(p).toLowerCase().split(path.sep).join('/');`
+      + `const target=norm(${wfLit});`
+      + `let id='';`
+      + `try{const cache=JSON.parse(fs.readFileSync(path.join(home,'.gemini','antigravity-cli','cache','last_conversations.json'),'utf8'));`
+      + `for(const k of Object.keys(cache)){if(norm(k)===target){id=cache[k];break;}}}catch{}`
+      + `if(!id){console.log('FLEET_LOG_MISSING');}else{`
+      + `const src=path.join(home,'.gemini','antigravity-cli','brain',id,'.system_generated','logs','transcript.jsonl');`
+      + `if(fs.existsSync(src)){fs.copyFileSync(src,path.join(process.cwd(),id+'.jsonl'));console.log('FLEET_LOG_COPIED');}else{console.log('FLEET_LOG_MISSING');}`
+      + `}`;
+  }
+
+  // codex, copilot, opencode: no known flat-file transcript to collect yet.
+  return null;
+}
+
+async function collectMemberLogs(fleetApi, roleName, runDir) {
+  let detail;
+  try {
+    const { text } = await call(fleetApi.memberDetail.bind(fleetApi), { member_name: roleName, format: 'json' }, `member_detail(${roleName})`);
+    detail = JSON.parse(text);
+  } catch (err) {
+    return `${roleName}: member_detail failed: ${err.message}`;
+  }
+
+  const sessionId = detail?.session?.id;
+  const workFolder = detail?.folder;
+  const provider = detail?.llmProvider ?? 'claude';
+
+  if (!sessionId) return `${roleName}: no session id recorded, nothing to collect`;
+  if (!workFolder) return `${roleName}: no work folder recorded, nothing to collect`;
+
+  const script = collectTranscriptScript(provider, workFolder, sessionId);
+  if (!script) return `${roleName}: provider "${provider}" has no known transcript format, skipped`;
+
+  const localDestDir = path.join(runDir, 'logs', roleName);
+  fs.mkdirSync(localDestDir, { recursive: true });
+  const remoteFileName = `${sessionId}.jsonl`;
+
+  let copyOutput;
+  try {
+    copyOutput = await execCommand(fleetApi, roleName, `node -e ${JSON.stringify(script)}`, 'locate + copy session transcript');
+  } catch (err) {
+    return `${roleName}: transcript lookup script failed: ${err.message}`;
+  }
+
+  if (!copyOutput.includes('FLEET_LOG_COPIED')) {
+    return `${roleName}: transcript not found on member (session ${sessionId}, provider ${provider})`;
+  }
+
+  try {
+    await call(
+      fleetApi.receiveFiles.bind(fleetApi),
+      { member_name: roleName, remote_paths: [remoteFileName], local_dest_dir: localDestDir },
+      `receive_files(${roleName})`,
+    );
+  } catch (err) {
+    return `${roleName}: receive_files failed: ${err.message}`;
+  } finally {
+    // Best-effort cleanup of the copy left in the member's work folder --
+    // receive_files only reaches files inside it, so the copy step above was
+    // just a hop, not something that should persist there afterward.
+    try {
+      await execCommand(
+        fleetApi,
+        roleName,
+        workFolder && workFolder.match(/^[A-Za-z]:\\/) // windows-style absolute path
+          ? `Remove-Item -Force -ErrorAction SilentlyContinue "${remoteFileName}"`
+          : `rm -f "${remoteFileName}"`,
+        'clean up transcript copy',
+      );
+    } catch { /* best-effort */ }
+  }
+
+  const downloadedPath = path.join(localDestDir, remoteFileName);
+  if (!fs.existsSync(downloadedPath)) return `${roleName}: receive_files did not write ${downloadedPath}`;
+  return `${roleName}: collected session ${sessionId} (${provider}) -> ${downloadedPath}`;
+}
+
+async function runCollectLogs(runDir) {
+  const { connectFleet } = await import('../../packages/apra-fleet-client/src/client/server-resolution.mjs');
+  const { fleetApi, transport } = await connectFleet();
+
+  try {
+    const results = [];
+    for (const { name } of ROLES) {
+      const note = await collectMemberLogs(fleetApi, name, runDir);
+      results.push(note);
+      process.stdout.write(`${note}\n`);
+    }
+    process.stdout.write('Log collection complete.\n');
+  } finally {
+    try { transport.stop(); } catch { /* best-effort cleanup */ }
+  }
+}
+
 async function runTeardown(suiteId) {
   const { connectFleet } = await import('../../packages/apra-fleet-client/src/client/server-resolution.mjs');
   const { fleetApi, transport } = await connectFleet();
@@ -471,6 +631,15 @@ if (process.argv[1] && (process.argv[1].endsWith('fleet-setup.mjs') || process.a
       process.stderr.write(`Setup failed: ${err.message}\n`);
       process.exit(1);
     });
+  } else if (subcommand === 'collect-logs') {
+    // Must run with cwd = $RUN_DIR (same convention as `setup`) -- logs are
+    // written to logs/<role>/ relative to cwd. Deliberately best-effort: a
+    // missing session or lookup failure on one member is logged and does not
+    // fail the process, since this is diagnostic collection, not a gate.
+    runCollectLogs(process.cwd()).catch((err) => {
+      process.stderr.write(`Log collection failed: ${err.message}\n`);
+      process.exit(1);
+    });
   } else if (subcommand === 'teardown') {
     const { suite } = parseArgs(rest);
     runTeardown(suite).catch((err) => {
@@ -483,7 +652,7 @@ if (process.argv[1] && (process.argv[1].endsWith('fleet-setup.mjs') || process.a
       process.exit(1);
     });
   } else {
-    process.stderr.write('Usage: fleet-setup.mjs <setup --suite <id>|teardown|shutdown>\n');
+    process.stderr.write('Usage: fleet-setup.mjs <setup --suite <id>|teardown|shutdown|collect-logs>\n');
     process.exit(1);
   }
 }

--- a/.github/e2e/fleet-setup.mjs
+++ b/.github/e2e/fleet-setup.mjs
@@ -295,9 +295,31 @@ async function runSetup(suiteId, runDir) {
   }
 }
 
-async function runTeardown() {
+// The toy repo is cloned to <work_folder>/fleet-e2e-toy (see verifyRoundtrip's
+// sibling setup steps and toy_projects in members.json) and is where the
+// doer/reviewer's beads/Dolt DB and git state accumulate across runs. Wiping
+// it here -- while the member is still registered and reachable via
+// execute_command -- means each run starts from a pristine clone instead of
+// patching over whatever state (corrupted Dolt DB, stale git identity) the
+// previous run left behind.
+export function toyFolderPath(folder, os) {
+  return os === 'windows' ? `${folder}\\fleet-e2e-toy` : `${folder}/fleet-e2e-toy`;
+}
+
+export function deleteFolderCommand(folderPath, os) {
+  return os === 'windows'
+    ? `Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "${folderPath}"`
+    : `rm -rf "${folderPath}"`;
+}
+
+async function runTeardown(suiteId) {
   const { connectFleet } = await import('../../packages/apra-fleet-client/src/client/server-resolution.mjs');
   const { fleetApi, transport } = await connectFleet();
+
+  // Resolving member configs requires a known suite -- older callers (or a
+  // manual `teardown` invocation) that don't pass one just skip the folder
+  // wipe and fall through to member removal, same as before this existed.
+  const members = suiteId ? resolveMemberConfigs(suiteId, loadConfig()) : null;
 
   // remove_member's text result has no single consistent failure marker
   // across its return paths (e.g. a "not found" member returns unmarked
@@ -306,7 +328,21 @@ async function runTeardown() {
   // the follow-up fleet_status check for whether alice/bella still remain.
   const removalNotes = [];
   try {
-    for (const { name } of ROLES) {
+    for (const { role, name } of ROLES) {
+      const member = members?.[role];
+      if (member) {
+        const toyPath = toyFolderPath(member.folder, member.os);
+        try {
+          await execCommand(fleetApi, name, deleteFolderCommand(toyPath, member.os), 'delete toy folder');
+          removalNotes.push(`${name}: wiped ${toyPath}`);
+        } catch (err) {
+          // Best-effort -- a member that's already unreachable (e.g. a prior
+          // step failed before it came online) shouldn't block teardown from
+          // still removing it from the registry.
+          removalNotes.push(`${name}: toy folder wipe failed: ${err.message}`);
+        }
+      }
+
       try {
         const result = await fleetApi.removeMember({ member_name: name, force: true });
         removalNotes.push(`${name}: ${textOf(result).split('\n')[0]}`);
@@ -385,7 +421,8 @@ if (process.argv[1] && (process.argv[1].endsWith('fleet-setup.mjs') || process.a
       process.exit(1);
     });
   } else if (subcommand === 'teardown') {
-    runTeardown().catch((err) => {
+    const { suite } = parseArgs(rest);
+    runTeardown(suite).catch((err) => {
       process.stdout.write(`T6: FAIL -- ${err.message}\n`);
       process.exit(1);
     });

--- a/.github/e2e/fleet-setup.mjs
+++ b/.github/e2e/fleet-setup.mjs
@@ -393,30 +393,66 @@ export function geminiProjectName(workFolder) {
   return workFolder.split(/[\\/]/).filter(Boolean).pop() || 'project';
 }
 
-// Builds a cross-platform Node script (run via `node -e` through
-// execute_command) that locates a member's own session transcript and
-// copies it into the current directory -- avoids needing separate
-// bash/PowerShell variants per OS, matching the pattern the workflow already
-// uses for agy's own transcript lookup (fleet-e2e.yml's AGY_TRANSCRIPT_SCRIPT).
-// Returns null for providers with no known flat-file transcript (opencode
-// stores sessions in a SQLite db, not a per-session file -- unsupported here).
+// Builds a cross-platform `node -e ...` SHELL COMMAND (not just JS source) that
+// locates a member's own session transcript and copies it into the current
+// directory -- avoids needing separate bash/PowerShell variants per OS,
+// matching the pattern the workflow already uses for agy's own transcript
+// lookup (fleet-e2e.yml's AGY_TRANSCRIPT_SCRIPT).
+//
+// Dynamic values (work-folder-derived slugs, session ids) are passed as
+// base64-encoded `process.argv` words instead of being interpolated as
+// quoted string literals into the -e source. This used to build the JS
+// source with `JSON.stringify(slug)`/`JSON.stringify(sessionId)` (producing
+// embedded double-quoted literals), then wrap the WHOLE script in another
+// `JSON.stringify()` for the `-e` argument (fleet-setup.mjs's execCommand
+// call) -- nesting one double-quoted string inside another, escaped as
+// `\"`. bash preserves that faithfully, but on a Windows local member the
+// PowerShell/CRT argv re-quoting the command passes through does not
+// round-trip nested `\"` correctly, corrupting exactly the interpolated
+// spans (observed live: quotes/commas mangled around the slug and session
+// id, while the surrounding single-quoted literal JS -- 'fs', 'path',
+// '.jsonl', etc -- survived intact every time). Base64 has no quote,
+// backslash, or comma characters at all, so there is nothing left for any
+// layer of re-quoting to corrupt, regardless of how many shells the command
+// string crosses (ssh, cmd.exe, powershell.exe).
+//
+// Returns a full command string (ready to hand straight to execute_command,
+// no further wrapping needed), or null for providers with no known flat-file
+// transcript (opencode stores sessions in a SQLite db, not a per-session
+// file -- unsupported here).
+function toBase64(value) {
+  return Buffer.from(value, 'utf8').toString('base64');
+}
+
+function buildNodeEvalCommand(scriptBody, argValues) {
+  // Prepended once: process.argv[2..] are base64-encoded UTF-8 strings,
+  // decoded into `A` before scriptBody runs.
+  const fullScript = `const A=process.argv.slice(2).map(x=>Buffer.from(x,'base64').toString('utf8'));${scriptBody}`;
+  const scriptB64 = toBase64(fullScript);
+  const argB64 = argValues.map(toBase64);
+  return `node -e "eval(Buffer.from('${scriptB64}','base64').toString('utf8'))" ${argB64.map((a) => `"${a}"`).join(' ')}`;
+}
+
 export function collectTranscriptScript(provider, workFolder, sessionId) {
-  const idLit = JSON.stringify(sessionId);
-  const copyAndReport = (srcExpr) =>
-    `if(fs.existsSync(${srcExpr})){fs.copyFileSync(${srcExpr},path.join(process.cwd(),${idLit}+'.jsonl'));console.log('FLEET_LOG_COPIED');}else{console.log('FLEET_LOG_MISSING');}`;
+  const copyAndReport = (srcExpr, idExpr) =>
+    `if(fs.existsSync(${srcExpr})){fs.copyFileSync(${srcExpr},path.join(process.cwd(),${idExpr}+'.jsonl'));console.log('FLEET_LOG_COPIED');}else{console.log('FLEET_LOG_MISSING');}`;
 
   if (provider === 'claude') {
     const slug = claudeProjectSlug(workFolder);
-    return `const fs=require('fs'),path=require('path'),os=require('os');`
-      + `const src=path.join(os.homedir(),'.claude','projects',${JSON.stringify(slug)},${idLit}+'.jsonl');`
-      + copyAndReport('src');
+    const scriptBody =
+      `const fs=require('fs'),path=require('path'),os=require('os');`
+      + `const src=path.join(os.homedir(),'.claude','projects',A[0],A[1]+'.jsonl');`
+      + copyAndReport('src', 'A[1]');
+    return buildNodeEvalCommand(scriptBody, [slug, sessionId]);
   }
 
   if (provider === 'gemini') {
     const projectName = geminiProjectName(workFolder);
-    return `const fs=require('fs'),path=require('path'),os=require('os');`
-      + `const src=path.join(os.homedir(),'.gemini','tmp',${JSON.stringify(projectName)},'chats',${idLit}+'.jsonl');`
-      + copyAndReport('src');
+    const scriptBody =
+      `const fs=require('fs'),path=require('path'),os=require('os');`
+      + `const src=path.join(os.homedir(),'.gemini','tmp',A[0],'chats',A[1]+'.jsonl');`
+      + copyAndReport('src', 'A[1]');
+    return buildNodeEvalCommand(scriptBody, [projectName, sessionId]);
   }
 
   if (provider === 'agy') {
@@ -424,12 +460,12 @@ export function collectTranscriptScript(provider, workFolder, sessionId) {
     // cache of conversations by the exact cwd they were started in, mapping
     // to an internal conversation id whose transcript lives elsewhere. The
     // fleet-tracked sessionId isn't used for lookup here at all; this only
-    // needs the member's own work folder.
-    const wfLit = JSON.stringify(workFolder);
-    return `const fs=require('fs'),path=require('path'),os=require('os');`
+    // needs the member's own work folder (A[0]).
+    const scriptBody =
+      `const fs=require('fs'),path=require('path'),os=require('os');`
       + `const home=os.homedir();`
       + `const norm=p=>path.resolve(p).toLowerCase().split(path.sep).join('/');`
-      + `const target=norm(${wfLit});`
+      + `const target=norm(A[0]);`
       + `let id='';`
       + `try{const cache=JSON.parse(fs.readFileSync(path.join(home,'.gemini','antigravity-cli','cache','last_conversations.json'),'utf8'));`
       + `for(const k of Object.keys(cache)){if(norm(k)===target){id=cache[k];break;}}}catch{}`
@@ -437,6 +473,7 @@ export function collectTranscriptScript(provider, workFolder, sessionId) {
       + `const src=path.join(home,'.gemini','antigravity-cli','brain',id,'.system_generated','logs','transcript.jsonl');`
       + `if(fs.existsSync(src)){fs.copyFileSync(src,path.join(process.cwd(),id+'.jsonl'));console.log('FLEET_LOG_COPIED');}else{console.log('FLEET_LOG_MISSING');}`
       + `}`;
+    return buildNodeEvalCommand(scriptBody, [workFolder]);
   }
 
   // codex, copilot, opencode: no known flat-file transcript to collect yet.
@@ -459,8 +496,8 @@ async function collectMemberLogs(fleetApi, roleName, runDir) {
   if (!sessionId) return `${roleName}: no session id recorded, nothing to collect`;
   if (!workFolder) return `${roleName}: no work folder recorded, nothing to collect`;
 
-  const script = collectTranscriptScript(provider, workFolder, sessionId);
-  if (!script) return `${roleName}: provider "${provider}" has no known transcript format, skipped`;
+  const command = collectTranscriptScript(provider, workFolder, sessionId);
+  if (!command) return `${roleName}: provider "${provider}" has no known transcript format, skipped`;
 
   const localDestDir = path.join(runDir, 'logs', roleName);
   fs.mkdirSync(localDestDir, { recursive: true });
@@ -468,7 +505,7 @@ async function collectMemberLogs(fleetApi, roleName, runDir) {
 
   let copyOutput;
   try {
-    copyOutput = await execCommand(fleetApi, roleName, `node -e ${JSON.stringify(script)}`, 'locate + copy session transcript');
+    copyOutput = await execCommand(fleetApi, roleName, command, 'locate + copy session transcript');
   } catch (err) {
     return `${roleName}: transcript lookup script failed: ${err.message}`;
   }

--- a/.github/e2e/fleet-setup.mjs
+++ b/.github/e2e/fleet-setup.mjs
@@ -427,7 +427,11 @@ function toBase64(value) {
 function buildNodeEvalCommand(scriptBody, argValues) {
   // Prepended once: process.argv[2..] are base64-encoded UTF-8 strings,
   // decoded into `A` before scriptBody runs.
-  const fullScript = `const A=process.argv.slice(2).map(x=>Buffer.from(x,'base64').toString('utf8'));${scriptBody}`;
+  // `node -e "<script>"` has no script-FILE slot in argv (unlike `node file.js`) --
+  // trailing positional args start at argv[1], not argv[2]. Verified live against
+  // fleet-win11: `node -e "console.log(process.argv)" "a" "b"` yields
+  // [execPath,"a","b"], not [execPath,undefined,"a","b"].
+  const fullScript = `const A=process.argv.slice(1).map(x=>Buffer.from(x,'base64').toString('utf8'));${scriptBody}`;
   const scriptB64 = toBase64(fullScript);
   const argB64 = argValues.map(toBase64);
   return `node -e "eval(Buffer.from('${scriptB64}','base64').toString('utf8'))" ${argB64.map((a) => `"${a}"`).join(' ')}`;

--- a/.github/e2e/fleet-setup.mjs
+++ b/.github/e2e/fleet-setup.mjs
@@ -229,6 +229,46 @@ async function verifyEcho(fleetApi, memberName) {
   }
 }
 
+// Clones the toy repo and runs `bd init` on a member, deterministically --
+// this used to be the orchestrator LLM's own T3-repo-setup work (real turns
+// spent on `git clone` + waiting out a slow `bd init`, once per member). Now
+// that the toy repo's Dolt history has been flattened (10 commits -> 1;
+// apra-fleet-eft P0 follow-up), `bd init` on a fresh clone takes ~25s instead
+// of downloading thousands of chunks -- cheap enough to just run
+// independently on BOTH members rather than initializing once and
+// replicating via send_files/receive_files, which was the original plan
+// before the flatten made that optimization unnecessary.
+//
+// `bd init` is NOT idempotent -- it errors ("this workspace is already
+// initialized") if a DB already exists, so each branch checks first and
+// skips if the toy folder / Dolt DB is already present (e.g. a re-run
+// against a work folder teardown didn't get to wipe).
+export function cloneAndInitCommand(toyUrl, toyPath, os) {
+  if (os === 'windows') {
+    return [
+      `if (Test-Path "${toyPath}\\.git") { Write-Output "already-cloned" } else { git clone ${toyUrl} "${toyPath}" }`,
+      `Set-Location "${toyPath}"`,
+      `if (Test-Path ".beads\\embeddeddolt") { Write-Output "already-initialized" } else { bd init 2>&1 }`,
+    ].join('; ');
+  }
+  return [
+    `if [ -d "${toyPath}/.git" ]; then echo already-cloned; else git clone ${toyUrl} "${toyPath}"; fi`,
+    `cd "${toyPath}"`,
+    `if [ -d ".beads/embeddeddolt" ]; then echo already-initialized; else bd init 2>&1; fi`,
+  ].join(' && ');
+}
+
+export function toyRepoUrlFor(vcs, members) {
+  const url = members.toy_projects?.[vcs];
+  if (!url) throw new Error(`members.json toy_projects has no entry for vcs "${vcs}"`);
+  return url;
+}
+
+async function bootstrapToyRepo(fleetApi, memberName, folder, os, toyUrl) {
+  const toyPath = toyFolderPath(folder, os);
+  await execCommand(fleetApi, memberName, cloneAndInitCommand(toyUrl, toyPath, os), 'toy repo clone + bd init');
+}
+
 async function verifyRoundtrip(fleetApi, memberName, runDir) {
   const content = 'fleet-e2e-roundtrip';
   const baseName = `roundtrip-${memberName}.txt`;
@@ -268,7 +308,8 @@ async function runSetup(suiteId, runDir) {
   const { fleetApi, transport } = await connectFleet();
 
   try {
-    const members = resolveMemberConfigs(suiteId, loadConfig());
+    const config = loadConfig();
+    const members = resolveMemberConfigs(suiteId, config);
     const memberList = [members.doer, members.reviewer];
 
     // T1: Member Registration
@@ -287,6 +328,16 @@ async function runSetup(suiteId, runDir) {
       await verifyRoundtrip(fleetApi, member.name, runDir);
     }
     writeCheckpoint('T2', 'PASS', 'echo + file roundtrip verified on both members');
+
+    // T2.5: Toy repo + beads bootstrap -- deterministic clone + `bd init` on
+    // BOTH members independently (see bootstrapToyRepo's comment for why this
+    // no longer needs an alice-initializes/bella-replicates approach).
+    const suite = config.suites.suites[suiteId];
+    const toyUrl = toyRepoUrlFor(suite.vcs, config.members);
+    for (const member of memberList) {
+      await bootstrapToyRepo(fleetApi, member.name, member.folder, member.os, toyUrl);
+    }
+    writeCheckpoint('T2-toy-bootstrap', 'PASS', 'toy repo cloned + beads DB initialized on both members');
     writeCheckpoint('T2-done', 'PASS', 'setup phase finished');
 
     process.stdout.write('Setup phase complete: T1, T2, T2-done all PASS.\n');

--- a/.github/e2e/sprint-script.md
+++ b/.github/e2e/sprint-script.md
@@ -34,7 +34,7 @@ Run a full sprint on the toy repo using the pm skill. Do all of it yourself in t
 
 ### T3.1 Set up the repo
 
-On alice: clone {{TOY_PROJECT_URL}} into its work folder if needed, then `git fetch origin && git checkout main && git pull`. Provision {{VCS}} auth.
+On alice: `git fetch origin && git checkout main && git pull`. Provision {{VCS}} auth.
 
 Record checkpoint:
 ```bash
@@ -96,42 +96,3 @@ Then record T3-done:
 ```bash
 node -e "const fs=require('fs');fs.appendFileSync('checkpoints.json',JSON.stringify({id:'T3-done',status:'PASS',notes:'sprint phase finished'})+'\n')"
 ```
-
----
-
-## Collect Session Logs
-
-During this phase you dispatched `execute_prompt` calls to members. Each response gives you the session ID it used. Collect every session ID per member, from this phase and the setup phase (setup-phase session IDs are in the run directory as `raw-setup.txt`).
-
-Each member's transcript file lives in the LLM's own log directory. How you find it depends on the member's provider.
-
-**Claude member -- the path is exact:**
-
-`~/.claude/projects/<slug>/<session-id>.jsonl`
-
-`<slug>` is the member's work_folder with every `/` (or `\` on Windows) replaced by `-` and any leading slash dropped. Example: `/home/user/fleet-work` becomes `home-user-fleet-work`.
-
-**Gemini member -- match on the session ID:**
-
-`~/.gemini/tmp/*/chats/session-*-<id8>.jsonl`
-
-`<id8>` is the first 8 characters of the session ID. Gemini does not name the file by work_folder or by the full ID, so list that glob -- the 8-character ID prefix identifies the file uniquely.
-
-Use the exact path (Claude) or the glob (Gemini). Do NOT run a recursive search (`find`, `locate`) -- a single fixed-depth glob in the directory above is all that is needed.
-
-Session files live outside the member's work_folder, so `receive_files` cannot reach them directly. For each file: copy it into the member's work_folder, `receive_files` it, then delete the copy.
-
-```bash
-# Unix
-cp <transcript-path> <work-folder>/<session-id>.jsonl
-```
-```powershell
-# Windows
-Copy-Item "<transcript-path>" "<work-folder>\<session-id>.jsonl"
-```
-
-Receive into:
-- alice's sessions -> `logs/alice/<session-id>.jsonl`
-- bella's sessions -> `logs/bella/<session-id>.jsonl`
-
-Skip any session whose file does not exist on the member.

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -371,6 +371,24 @@ jobs:
             exit "$NODE_EXIT"
           fi
 
+      - name: Re-assert PM MCP registration before sprint phase
+        if: steps.suite.outputs.pm_provider == 'claude'
+        shell: bash
+        run: |
+          # Live-verified (fleet-win11, apra-fleet-eft P0 investigation): the PM's own
+          # `claude mcp add --scope user` registration from the earlier install step can
+          # go missing by the time this job reaches the sprint-phase invocation (this
+          # machine also serves as a remote member for other suites, a plausible ~/.claude.json
+          # race) -- confirmed live via `claude mcp list` reporting "No MCP servers
+          # configured" moments before a sprint-phase run that came up with mcp_servers:[].
+          # Re-registering immediately before the sprint-phase step (the same command
+          # install.ts:933-935 already runs) is the reliable idempotent mitigation --
+          # NOT gated on whether it currently looks missing, since a stale/racy write can
+          # land after any check we'd do here too.
+          claude mcp remove apra-fleet --scope user > /dev/null 2>&1 || true
+          claude mcp add --scope user --transport http apra-fleet http://localhost:7523/mcp
+          claude mcp list | grep -qi "apra-fleet.*connected" || echo "::warning::apra-fleet MCP re-registration did not report connected -- sprint phase may still fail"
+
       - name: Run fleet e2e - sprint phase (${{ steps.suite.outputs.pm_provider }})
         id: e2e_sprint
         timeout-minutes: 120

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -497,6 +497,14 @@ jobs:
           fi
           cat "$LOG_DIR"/fleet-*.log > "$RUN_DIR/logs/fleet-pm.log" 2>/dev/null || true
 
+      - name: Collect member session logs (deterministic)
+        if: always()
+        shell: bash
+        run: |
+          cd "$RUN_DIR"
+          node "$GITHUB_WORKSPACE/.github/e2e/fleet-setup.mjs" collect-logs > "$RUN_DIR/collect-logs-output.txt" 2>&1 || true
+          cat "$RUN_DIR/collect-logs-output.txt"
+
       - name: Extract telemetry
         if: always()
         shell: bash

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -516,7 +516,7 @@ jobs:
         shell: bash
         run: |
           cd "$RUN_DIR"
-          node "$GITHUB_WORKSPACE/.github/e2e/fleet-setup.mjs" teardown > "$RUN_DIR/t6-output.txt" 2>&1 || true
+          node "$GITHUB_WORKSPACE/.github/e2e/fleet-setup.mjs" teardown --suite "${{ inputs.suite }}" > "$RUN_DIR/t6-output.txt" 2>&1 || true
           cat "$RUN_DIR/t6-output.txt"
 
       - name: Upload results

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -53,6 +53,29 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           jq --version || { echo "::error::jq is not installed on this runner"; exit 1; }
 
+      - name: Purge fleet daemon logs
+        shell: bash
+        run: |
+          # Must run BEFORE "Build and install fleet binary on PM" (install
+          # --force + start) -- self-hosted runners are long-lived boxes, and
+          # fleet-<pid>.log files (one per server process, never cleaned up on
+          # their own) accumulate across every job ever run here. Purging here,
+          # before this job's own server exists, guarantees this delete only
+          # ever touches leftovers from a PREVIOUS job (already archived via
+          # its own "Collect fleet daemon logs" step, so nothing of value is
+          # lost) -- never a file THIS job's own daemon has open. Member names
+          # (alice/bella) are reused on every run, so any per-member analysis
+          # keyed on the fleet log's "mem" field (e.g. wall/active time) would
+          # silently blend in a previous run's entries for those same names if
+          # this didn't run first.
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            LOG_DIR="$(cygpath "$USERPROFILE")/.apra-fleet/data/logs"
+          else
+            LOG_DIR="$HOME/.apra-fleet/data/logs"
+          fi
+          rm -f "$LOG_DIR"/fleet-*.log
+          echo "Fleet logs purged"
+
       # Must run AFTER "Check runner prerequisites": GITHUB_PATH entries are
       # prepended in the order steps add them, so a step run later wins.
       # $HOME/.local/bin (added above) contains a `node` symlink to an old
@@ -297,17 +320,6 @@ jobs:
             echo "PM opencode auth OK"
           fi
 
-      - name: Purge fleet daemon logs
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            LOG_DIR="$(cygpath "$USERPROFILE")/.apra-fleet/data/logs"
-          else
-            LOG_DIR="$HOME/.apra-fleet/data/logs"
-          fi
-          rm -f "$LOG_DIR"/fleet-*.log
-          echo "Fleet logs purged"
-
       - name: Pre-create local member work folders
         shell: bash
         run: |
@@ -513,11 +525,16 @@ jobs:
         if: always()
         shell: bash
         run: |
+          # Safe to just `cat` everything matching fleet-*.log here: the
+          # "Purge fleet daemon logs" step (top of this job, before install
+          # --force/start) already guarantees the only fleet-*.log file(s)
+          # present now are ones this job's own server created.
           if [ "$RUNNER_OS" = "Windows" ]; then
             LOG_DIR="$(cygpath "$USERPROFILE")/.apra-fleet/data/logs"
           else
             LOG_DIR="$HOME/.apra-fleet/data/logs"
           fi
+          mkdir -p "$RUN_DIR/logs"
           cat "$LOG_DIR"/fleet-*.log > "$RUN_DIR/logs/fleet-pm.log" 2>/dev/null || true
 
       - name: Collect member session logs (deterministic)

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -253,19 +253,23 @@ jobs:
             # Informational only below -- a fresh `-p` call can race the MCP
             # handshake and report "not installed" even when the deterministic
             # checks above just confirmed it is. Do not gate on this text.
-            output=$(claude -p "$PROMPT" --model haiku 2>&1)
+            # `|| true` is load-bearing: under `bash -e -o pipefail` (this
+            # step's shell), a nonzero exit from any of these bare commands
+            # kills the whole step despite this comment's intent -- capturing
+            # output into a variable does NOT suppress that.
+            output=$(claude -p "$PROMPT" --model haiku 2>&1) || true
             echo "$output"
             echo "PM claude auth OK"
           elif [ "$PROVIDER" = "gemini" ]; then
-            output=$(gemini -p "$PROMPT" --model auto --skip-trust 2>&1)
+            output=$(gemini -p "$PROMPT" --model auto --skip-trust 2>&1) || true
             echo "$output"
             echo "PM gemini auth OK"
           elif [ "$PROVIDER" = "agy" ]; then
-            output=$(agy -p "$PROMPT" --dangerously-skip-permissions 2>&1)
+            output=$(agy -p "$PROMPT" --dangerously-skip-permissions 2>&1) || true
             echo "$output"
             echo "PM agy auth OK"
           elif [ "$PROVIDER" = "opencode" ]; then
-            output=$(opencode run "$PROMPT" --format json --dangerously-skip-permissions 2>&1)
+            output=$(opencode run "$PROMPT" --format json --dangerously-skip-permissions 2>&1) || true
             echo "$output"
             echo "PM opencode auth OK"
           fi

--- a/.github/workflows/fleet-e2e.yml
+++ b/.github/workflows/fleet-e2e.yml
@@ -250,27 +250,50 @@ jobs:
             done
             [ "$FAIL" -eq 0 ] || exit 1
 
-            # Informational only below -- a fresh `-p` call can race the MCP
-            # handshake and report "not installed" even when the deterministic
-            # checks above just confirmed it is. Do not gate on this text.
-            # `|| true` is load-bearing: under `bash -e -o pipefail` (this
-            # step's shell), a nonzero exit from any of these bare commands
-            # kills the whole step despite this comment's intent -- capturing
-            # output into a variable does NOT suppress that.
+            # Below, only the "MCP tool not installed" text is informational --
+            # a fresh `-p` call can race the MCP handshake and report that
+            # even when the deterministic checks above just confirmed it's
+            # connected, so we don't gate on that specific text. Auth failure
+            # is NOT subject to that race (a logged-out CLI produces no real
+            # response at all) and DOES gate, via the AUTH_FAIL_RE check below.
+            # `|| true` on the capture is still required: under `bash -e
+            # -o pipefail` (this step's shell), a nonzero exit from the bare
+            # command kills the whole step regardless -- capturing output
+            # into a variable does not by itself suppress that.
+            AUTH_FAIL_RE='not logged in|unauthorized|\b401\b|authentication_error|expired.{0,20}token|permission_error|invalid.{0,20}(api.{0,20}key|token)'
             output=$(claude -p "$PROMPT" --model haiku 2>&1) || true
             echo "$output"
+            if echo "$output" | grep -qiE "$AUTH_FAIL_RE"; then
+              echo "::error::PM claude CLI is not authenticated (smoke-test prompt got no real response)"
+              exit 1
+            fi
             echo "PM claude auth OK"
           elif [ "$PROVIDER" = "gemini" ]; then
+            AUTH_FAIL_RE='not logged in|unauthorized|\b401\b|authentication_error|expired.{0,20}token|permission_error|invalid.{0,20}(api.{0,20}key|token)'
             output=$(gemini -p "$PROMPT" --model auto --skip-trust 2>&1) || true
             echo "$output"
+            if echo "$output" | grep -qiE "$AUTH_FAIL_RE"; then
+              echo "::error::PM gemini CLI is not authenticated (smoke-test prompt got no real response)"
+              exit 1
+            fi
             echo "PM gemini auth OK"
           elif [ "$PROVIDER" = "agy" ]; then
+            AUTH_FAIL_RE='not logged in|unauthorized|\b401\b|authentication_error|expired.{0,20}token|permission_error|invalid.{0,20}(api.{0,20}key|token)'
             output=$(agy -p "$PROMPT" --dangerously-skip-permissions 2>&1) || true
             echo "$output"
+            if echo "$output" | grep -qiE "$AUTH_FAIL_RE"; then
+              echo "::error::PM agy CLI is not authenticated (smoke-test prompt got no real response)"
+              exit 1
+            fi
             echo "PM agy auth OK"
           elif [ "$PROVIDER" = "opencode" ]; then
+            AUTH_FAIL_RE='not logged in|unauthorized|\b401\b|authentication_error|expired.{0,20}token|permission_error|invalid.{0,20}(api.{0,20}key|token)'
             output=$(opencode run "$PROMPT" --format json --dangerously-skip-permissions 2>&1) || true
             echo "$output"
+            if echo "$output" | grep -qiE "$AUTH_FAIL_RE"; then
+              echo "::error::PM opencode CLI is not authenticated (smoke-test prompt got no real response)"
+              exit 1
+            fi
             echo "PM opencode auth OK"
           fi
 

--- a/docs/eft-e2e-turn-budget-fixes.md
+++ b/docs/eft-e2e-turn-budget-fixes.md
@@ -1,0 +1,130 @@
+# E2E turn-budget fixes (apra-fleet-eft P0 follow-up)
+
+Context: after fixing the s1.1/s1.2 P0 blockers (MCP registration going missing
+before the sprint phase, an ungated smoke-test line, `fleet_status` ignoring
+`format=json` when empty), a passing s1.1 run still burned 81 of its 80
+allotted turns. Analyzing the orchestrator's and alice's real transcripts
+(not presumption -- see the run-30180827741 analysis) found three concrete,
+fixable turn sinks. This doc records the three fixes, their design, and status.
+
+## Background: what the transcripts showed
+
+- The orchestrator's own first ~9 turns are already-done work being *read*,
+  not performed -- `T1`/`T2` (member registration, echo/roundtrip) happen in
+  the deterministic `fleet-setup.mjs setup` step, a plain Node script with
+  zero LLM involvement, before the orchestrator's Claude session even starts.
+- The real orchestrator burn: `execute_prompt` to alice hit a transport drop
+  mid-call (right as alice's own session hung on `git push`), triggering
+  execute_prompt's own automatic retry-with-fresh-session behavior. That
+  spawned a **second full alice session** that had no idea the first one had
+  already finished the task -- it re-verified build/lint/test from scratch
+  and re-fought the same git-push problem independently. The orchestrator
+  *also* independently diagnosed the identical git-push/auth problem via its
+  own `execute_command` calls, in parallel with alice's second session doing
+  the same thing.
+- Both alice and bella hit "no beads database found" on their fresh toy-repo
+  clones, each independently running a full `bd init` that pulled the toy
+  repo's entire accumulated Dolt history from GitHub's `refs/dolt/data`
+  (7,006 chunks) -- twice, once per member, every single run.
+- The final straw: after all T3 checkpoints were already satisfied, the
+  orchestrator's own script instructions had it "collect session logs"
+  (alice/bella's session IDs) as a wrap-up step -- pure diagnostic
+  bookkeeping, unrelated to the acceptance criteria, and what actually tipped
+  the run from ~78 turns to 81 (`error_max_turns`).
+
+## Fix 1: deterministic toy-repo + beads bootstrap
+
+**Status: implemented** (`.github/e2e/fleet-setup.mjs`, new `T2-toy-bootstrap`
+checkpoint in `runSetup()`).
+
+Original plan was "initialize once on alice, replicate to bella via
+send_files/receive_files" -- avoiding a second slow `bd init`. That became
+unnecessary after a separate, bigger fix: the toy repo's Dolt history itself
+was flattened (`bd flatten`, 10 commits -> 1, plus `dolt gc`) and
+force-pushed to `refs/dolt/data` on `Apra-Labs/fleet-e2e-toy`. Verified with a
+fully fresh clone: `bd init` now completes in ~25s with **no chunk-download
+progress at all** (previously 7,006 chunks), and the issue data was diffed
+byte-identical before/after the flatten (no data loss).
+
+With `bd init` now cheap, the simpler fix is to just run it independently and
+deterministically on **both** members during the existing `fleet-setup.mjs
+setup` step (a plain Node script, provider/OS-agnostic via `execute_command`
+-- works identically for local members (s1.x) and remote members (s1/s2/etc,
+dispatched over SSH), which matters since other suites use remote devices):
+
+1. `cloneAndInitCommand(toyUrl, toyPath, os)` builds an OS-appropriate
+   (PowerShell / bash) command that clones the toy repo if not already
+   present, then runs `bd init` if the Dolt DB isn't already there (`bd init`
+   is **not** idempotent -- it errors "already initialized" on a second run,
+   so both steps guard first).
+2. `bootstrapToyRepo()` runs that command via `execute_command` against each
+   member's registered work folder.
+3. A new `T2-toy-bootstrap` checkpoint records the result.
+
+Net effect: the orchestrator's own T3-repo-setup work shrinks to "verify
+state already present" (a `bd show`/`git status` check that immediately
+succeeds) instead of doing the clone + slow init itself -- no prompt-template
+change was needed for that, since the orchestrator's existing instructions
+already check state before acting.
+
+## Fix 2: fix git push authentication on the 3 runners
+
+**Status: not yet implemented -- needs a decision.**
+
+Alice's session (and independently, the orchestrator) both hit
+`git push` hangs/failures against `origin` on fleet-win11, root-caused live:
+
+- `credential.helper` was configured as `manager` (Windows Git Credential
+  Manager, can't prompt headlessly) then `store` (plain-text
+  `~/.git-credentials`).
+- The PAT `provision_vcs_auth` deploys into `~/.git-credentials` (the
+  `e2e_gh_token` credential) was rejected by GitHub even when forced through
+  `store` alone: `remote: Invalid username or token. Password authentication
+  is not supported for Git operations.` -- the token itself looks bad, not
+  just a helper-priority conflict.
+- `gh auth setup-git` (delegating git's credential helper to the machine's
+  already-authenticated `gh` CLI OAuth session, a completely separate
+  identity) fixed it immediately.
+
+This is a real fork in the road, not yet resolved:
+
+- **(a) Standardize on `gh auth setup-git`** as the sole git-auth mechanism
+  on all 3 runners (fleet-win11, fleet-lin2404, the Mac box at
+  192.168.1.13/fleet-rev), and retire PAT-based `provision_vcs_auth` for
+  github mode entirely -- matches what we directly observed working.
+- **(b) Keep PAT as the mechanism**, which requires rotating `e2e_gh_token`
+  to an actually-valid token (needs a human to generate one -- an agent
+  can't create GitHub PATs) and then locking `credential.helper` down to
+  `store`-only so GCM never intercepts.
+
+Whichever is chosen, the fix needs to land on all 3 physical runner machines
+(not just fleet-win11, where it was diagnosed), since fleet-lin2404 and the
+Mac box are equally likely to hit the same class of problem.
+
+## Fix 3: make log collection deterministic, not LLM-driven
+
+**Status: not yet implemented.**
+
+The orchestrator's own sprint-script instructions currently have it fetch
+alice/bella's session IDs and transcripts as a wrap-up step, driven by the
+LLM. Two independent reasons to move this to a plain script instead:
+
+1. **It's pure mechanical file I/O** -- apra-fleet-client already exposes
+   everything needed (`member_detail` for session IDs/work folders,
+   `receive_files`/direct filesystem access for local members) with no
+   reasoning required. Spending LLM turns on it is waste, and in this run it
+   was literally the step that tipped the orchestrator over its turn budget.
+2. **Log collection needs to work even when the LLM fails completely** --
+   if the sprint-phase session crashes, hits max-turns early, or the
+   provider itself errors out, we still want the artifacts for post-mortem
+   analysis. Making it deterministic means it runs unconditionally as part
+   of an `if: always()` CI step, not contingent on the orchestrator getting
+   far enough in its own turn budget to reach that instruction.
+
+Planned implementation: extend the existing "Collect fleet daemon logs"
+workflow step (already `if: always()`, and runs *before* T6 teardown removes
+alice/bella, so they're still reachable) to also pull each member's most
+recent Claude Code session transcript file into the run's artifact directory,
+scoped to the `claude` provider for now (matching the suites currently
+exercising this P0 investigation; gemini/agy/opencode store sessions
+differently and would need separate handling if/when that's needed).

--- a/docs/tools-work.md
+++ b/docs/tools-work.md
@@ -68,7 +68,7 @@ Runs an LLM prompt on a member. This is the primary tool for doing actual work a
 7. **Handles stale sessions** -- if the command fails and a resume was attempted, retries with a fresh minted session ID.
 8. **Updates registry** -- stores the new `sessionId` (Claude and Gemini) and `lastUsed` timestamp.
 
-**Output:** The agent's response text, plus the session ID if one was returned.
+**Output:** `structuredContent.response` carries the agent's reply text; `structuredContent.usage` carries token counts when available; `structuredContent.sessionId` carries the session ID if one was returned. (The same text is also echoed in the tool result's display content, but MCP clients that surface `structuredContent` and drop `content` -- observed with Claude Code -- only see `structuredContent`, so `response` is the reliable field to read.)
 
 **Error handling:**
 - If the prompt fails due to an authentication issue, returns actionable guidance (`provision_llm_auth`) instead of raw error output.

--- a/packages/apra-fleet-client/docs/api-reference.md
+++ b/packages/apra-fleet-client/docs/api-reference.md
@@ -231,6 +231,18 @@ Calls `fleet_status` -- status of all fleet members.
 |---|---|---|
 | `format` | `"compact" \| "json"?` | Output format. |
 
+#### `memberDetail(options)`
+
+Calls `member_detail` -- detailed status for one member: connectivity,
+session (`session.id`, the current session ID or `null`), work folder
+(`folder`), and provider (`llmProvider`).
+
+| Field | Type | Notes |
+|---|---|---|
+| `member_id` | `string?` | UUID of the member. |
+| `member_name` | `string?` | Friendly name of the member. |
+| `format` | `"compact" \| "json"?` | Output format. |
+
 #### `sendFiles(options: SendFilesOptions)`
 
 Calls `send_files` -- uploads local files to a member.
@@ -290,6 +302,92 @@ Calls `remove_member` -- removes a member from the fleet.
 | `member_id` | `string?` | UUID of the member. |
 | `member_name` | `string?` | Friendly name of the member. |
 | `force` | `boolean?` | Remove even if the member is currently busy. |
+
+## `src/client/server-resolution.mjs`
+
+The single, shared implementation of "how does a client process reach the
+apra-fleet MCP server." Both `src/cli/workflow.ts` (the `apra-fleet
+workflow` launcher) and `packages/apra-fleet-se/bin/cli.mjs` (auto-sprint)
+depend on this module rather than duplicating the resolution logic.
+Binding design doc: `docs/adr-workflow-server-resolution.md`.
+
+Resolution order:
+
+1. **Forced transport / explicit stdio request.** `APRA_FLEET_TRANSPORT`
+   (`'http'` or `'stdio'`) overrides everything. `'stdio'` (or
+   `APRA_FLEET_SERVER_CMD`/`APRA_FLEET_SERVER_BIN` being set while transport
+   isn't forced to `'http'`) resolves a stdio command directly, no probe.
+   `'http'` probes only -- it never silently falls back to stdio.
+2. **HTTP singleton probe** (the product default when unset) --
+   `checkRunningInstance()` reads `~/.apra-fleet/data/server.json`
+   (`{pid, url}`), checks the pid is alive, then `GET`s a `/health`
+   endpoint derived from `url` (2s timeout). A stale/dead entry causes
+   `server.json` to be deleted (self-healing). On success, attaches over
+   `StreamableHttpTransport` and spawns nothing.
+3. **Stdio self-spawn fallback** -- `resolveFleetServerCommand()`'s four
+   tiers: `APRA_FLEET_SERVER_CMD` (a full `"<command> <args...>"` string),
+   `APRA_FLEET_SERVER_BIN` (resolved via `PATH`, run with `run --transport
+   stdio`), a bundled sibling `index.js` next to this module, or (dev
+   monorepo layout) `../../../dist/index.js` relative to it.
+
+The launcher/auto-sprint client and the MCP server are always separate
+processes; this module only decides the transport, it never merges them.
+Every branch takes an injectable `deps` bag (`env`, `readFile`, `unlink`,
+`pidAlive`, `health`, `dirname`, `exists`, `checkRunningInstance`) so each
+step is independently unit-testable without touching the real
+filesystem/network.
+
+#### `getFleetDataDir(env = process.env)`
+
+Returns `~/.apra-fleet/data`, honoring `APRA_FLEET_DATA_DIR` if set (mirrors
+`src/paths.ts`).
+
+#### `getServerInfoPath(env = process.env)`
+
+Returns `path.join(getFleetDataDir(env), 'server.json')`.
+
+#### `async checkRunningInstance(deps = {})`
+
+The HTTP-singleton probe (step 2 above). Reads and parses `server.json` via
+`deps.readFile`; on any parse failure, or a missing `pid`/`url`, returns
+`{ running: false }`. If `deps.pidAlive` (default: a `process.kill(pid, 0)`
+liveness check treating `EPERM` as alive) says the pid is dead, deletes
+`server.json` via `deps.unlink` and returns `{ running: false }`. If
+`deps.health` (default: `GET <url with /mcp replaced by /health>`, 2s
+timeout) fails, does the same. Otherwise returns
+`{ running: true, url, pid }`. Same semantics as
+`src/services/singleton.ts`'s `checkRunningInstance()`, so the client's
+probe and the server's own startup dedup never disagree.
+
+#### `resolveFleetServerCommand(deps = {})`
+
+Step 3's stdio command resolution, as a pure function (nothing is spawned).
+Returns `{ command: string, args: string[] }`. Throws if
+`APRA_FLEET_SERVER_CMD` is set but empty, or if none of the fallback
+entry-point tiers exist on disk (`deps.exists`, default `fs.existsSync`) and
+neither `APRA_FLEET_SERVER_CMD` nor `APRA_FLEET_SERVER_BIN` is set.
+
+#### `async resolveFleetServerConnection(deps = {})`
+
+The full resolution order above, as a pure descriptor -- nothing is spawned
+or connected. Returns either `{ mode: 'http', url, pid, reason }` or
+`{ mode: 'stdio', command, args, reason }`. Throws if `APRA_FLEET_TRANSPORT`
+is set to anything other than `'http'`/`'stdio'`, or if it's set to
+`'http'` and no healthy singleton is found (this case deliberately does not
+fall back to stdio).
+
+#### `async connectFleet(deps = {})`
+
+Resolves + connects in one call. Builds a `StreamableHttpTransport` or
+`StdioTransport` per `resolveFleetServerConnection`'s result, starts it,
+wraps it in `McpClient`, performs the `initialize`/`notifications/initialized`
+handshake for stdio connections (the HTTP transport already does its own
+`initialize` POST inside `start()`), and returns
+`{ transport, mcpClient, fleetApi, mode }` where `fleetApi` is a
+`new ApraFleet(mcpClient)`.
+
+`deps.options`, if given, is forwarded to the transport constructor (e.g.
+HTTP headers or child-process spawn options).
 
 ## `src/client/factory.mjs`
 

--- a/packages/apra-fleet-client/docs/getting-started.md
+++ b/packages/apra-fleet-client/docs/getting-started.md
@@ -18,6 +18,37 @@ Inside this monorepo, add it as a workspace dependency:
 }
 ```
 
+## Recommended: `connectFleet()` (auto-picks stdio vs. HTTP)
+
+For most callers, hand-picking a transport (the two sections below) is more
+than you need. `connectFleet()` from `@apralabs/apra-fleet-client/server-resolution`
+does it for you: it probes for a running HTTP singleton
+(`~/.apra-fleet/data/server.json` + a `/health` check), attaches to it if
+found, and otherwise self-spawns a stdio server -- performing whichever
+handshake the chosen transport needs.
+
+```js
+import { connectFleet } from '@apralabs/apra-fleet-client/server-resolution';
+
+const { transport, mcpClient, fleetApi, mode } = await connectFleet();
+console.log(`connected via ${mode}`);
+
+const status = await fleetApi.fleetStatus({ format: 'json' });
+console.log(status);
+
+transport.stop();
+```
+
+Set `APRA_FLEET_TRANSPORT=stdio` / `=http` to force a specific transport, or
+`APRA_FLEET_SERVER_CMD`/`APRA_FLEET_SERVER_BIN` to point at a specific
+server executable. See `api-reference.md`'s `server-resolution.mjs` section
+for the full resolution order.
+
+The manual, transport-specific setup below is what `connectFleet()` does
+internally -- reach for it directly only if you need to force a particular
+transport without using the env-var overrides, or want finer control over
+transport `options` (e.g. custom HTTP headers).
+
 ## Connecting over stdio (spawns the server as a child process)
 
 ```js
@@ -145,6 +176,17 @@ try {
   }
 }
 ```
+
+## Getting one member's detailed status
+
+```js
+const detail = await fleet.memberDetail({ member_name: 'build-server', format: 'json' });
+console.log(detail.session?.id, detail.folder, detail.llmProvider);
+```
+
+Unlike `fleetStatus` (all members) or `listMembers`, `memberDetail` returns
+one member's connectivity, current session ID (or `null`), work folder, and
+LLM provider.
 
 ## Registering, updating, and removing members
 

--- a/packages/apra-fleet-client/docs/overview.md
+++ b/packages/apra-fleet-client/docs/overview.md
@@ -11,10 +11,11 @@ knows how to:
 2. Speak the JSON-RPC 2.0 request/response protocol MCP uses, including
    request IDs, timeouts, and cancellation.
 3. Expose the fleet server's tool surface (`execute_prompt`,
-   `execute_command`, `list_members`, `fleet_status`, `send_files`,
-   `receive_files`, `register_member`, `update_member`, `remove_member`) as
-   a typed, promise-based JavaScript API instead of raw `tools/call`
-   payloads.
+   `execute_command`, `list_members`, `fleet_status`, `member_detail`,
+   `get_member_model_pricing`, `send_files`, `receive_files`,
+   `register_member`, `update_member`, `remove_member`, `provision_llm_auth`,
+   `compose_permissions`, `setup_ssh_key`, `shutdown_server`) as a typed,
+   promise-based JavaScript API instead of raw `tools/call` payloads.
 
 It is a **transport and protocol** layer. It does not implement any
 scheduling, retry, workflow, or orchestration logic of its own -- it hands
@@ -91,6 +92,7 @@ Declared in `package.json#exports`:
 | `@apralabs/apra-fleet-client/client` | `src/client/client.mjs` | `McpClient` class, `DEFAULT_REQUEST_TIMEOUT_MS` |
 | `@apralabs/apra-fleet-client/factory` | `src/client/factory.mjs` | `createWorkflowEngine()` |
 | `@apralabs/apra-fleet-client/transport` | `src/client/transport.mjs` | `StdioTransport`, `StreamableHttpTransport` |
+| `@apralabs/apra-fleet-client/server-resolution` | `src/client/server-resolution.mjs` | `connectFleet()`, `checkRunningInstance()`, `resolveFleetServerConnection()`, `resolveFleetServerCommand()`, `getFleetDataDir()`, `getServerInfoPath()` |
 
 `src/client/errors.mjs` (`ClientError`, `TimeoutError`, `AbortError`) is not
 listed in `exports` but its instances are the error/rejection values

--- a/packages/apra-fleet-client/src/client/api.mjs
+++ b/packages/apra-fleet-client/src/client/api.mjs
@@ -212,6 +212,14 @@ export class ApraFleet {
     }
 
     /**
+     * Get detailed status for one member: connectivity, session, work folder, provider.
+     * @param {{ member_id?: string, member_name?: string, format?: 'compact'|'json' }} options
+     */
+    async memberDetail(options) {
+        return this.mcpClient.callTool('member_detail', options);
+    }
+
+    /**
      * Get a member's cheap/standard/premium tier resolved to a concrete
      * model and its real per-1M-token price (apra-fleet-dv5.5/dv5.6).
      * @param {{ member_id?: string, member_name?: string }} options

--- a/packages/apra-fleet-client/test/fleet-client-api.test.mjs
+++ b/packages/apra-fleet-client/test/fleet-client-api.test.mjs
@@ -96,6 +96,25 @@ describe('ApraFleet', () => {
         assert.deepStrictEqual(result, { status: 'ok' });
     });
 
+    test('memberDetail', async () => {
+        let calledName, calledArgs;
+        const mockClient = {
+            async callTool(name, args) {
+                calledName = name;
+                calledArgs = args;
+                return { name: 'alice', folder: '/home/user/work', session: { id: 'sess-1' } };
+            }
+        };
+
+        const fleet = new ApraFleet(mockClient);
+        const options = { member_name: 'alice', format: 'json' };
+        const result = await fleet.memberDetail(options);
+
+        assert.strictEqual(calledName, 'member_detail');
+        assert.deepStrictEqual(calledArgs, options);
+        assert.deepStrictEqual(result, { name: 'alice', folder: '/home/user/work', session: { id: 'sess-1' } });
+    });
+
     test('sendFiles', async () => {
         let calledName, calledArgs;
         const mockClient = {

--- a/packages/apra-fleet-workflow/src/workflow/index.mjs
+++ b/packages/apra-fleet-workflow/src/workflow/index.mjs
@@ -903,12 +903,24 @@ export class FleetWorkflow extends EventEmitter {
                     // failure: surface it typed so callers' existing
                     // AgentDispatchError handling (retry / degrade the
                     // round) applies.
-                    const withoutWrapper = text
-                        .replace(/^\u{1F4CB} Response from [^\n:]+:\s*/u, '')
-                        .replace(/^Tokens: input=\d+ output=\d+\s*$/mu, '')
-                        .replace(/^---\s*$/mu, '')
-                        .replace(/^session: \S+\s*$/mu, '');
-                    if (withoutWrapper.trim() === '') {
+                    //
+                    // structuredContent.response (added alongside this text --
+                    // see src/tools/execute-prompt.ts) carries the exact reply
+                    // the server parsed, with no display wrapper to strip --
+                    // prefer it when present (upgraded server) as a direct,
+                    // reliable emptiness check and as the clean value to hand
+                    // back to callers, instead of text-scraping the wrapper.
+                    // Fall back to the wrapper-stripping regex for an
+                    // older/not-yet-rebuilt server that predates this field.
+                    const hasStructuredResponse = !!structured && typeof structured.response === 'string';
+                    const cleanText = hasStructuredResponse
+                        ? structured.response
+                        : text
+                            .replace(/^\u{1F4CB} Response from [^\n:]+:\s*/u, '')
+                            .replace(/^Tokens: input=\d+ output=\d+\s*$/mu, '')
+                            .replace(/^---\s*$/mu, '')
+                            .replace(/^session: \S+\s*$/mu, '');
+                    if (cleanText.trim() === '') {
                         const emptyMsg = `execute_prompt returned an empty response (display wrapper only, no LLM output) from member '${opts.member_name || opts.member_id}'.`;
                         console.error(`[Agent API Error]`, emptyMsg);
                         this.emit('activity:end', { ...activityMeta, error: emptyMsg, output: text, duration, usage: result.usage, cost, success: false });
@@ -917,10 +929,10 @@ export class FleetWorkflow extends EventEmitter {
 
                     if (!opts.schema) {
                         this.emit('activity:end', { ...activityMeta, duration, success: true, usage: result.usage, cost, output: text });
-                        return text;
+                        return hasStructuredResponse ? structured.response : text;
                     }
 
-                    const extraction = extractStructuredOutput(text, compiledSchema);
+                    const extraction = extractStructuredOutput(hasStructuredResponse ? structured.response : text, compiledSchema);
                     if (extraction.ok) {
                         this.emit('activity:end', { ...activityMeta, duration, success: true, usage: result.usage, cost, output: JSON.stringify(extraction.parsed, null, 2) });
                         return extraction.parsed;

--- a/src/os/linux.ts
+++ b/src/os/linux.ts
@@ -205,7 +205,17 @@ export class LinuxCommands implements OsCommands {
     const escapedHost = escapeDoubleQuoted(host);
     const escapedUser = escapeDoubleQuoted(username);
     const escapedToken = escapeDoubleQuoted(token);
-    const credFile = label ? `~/.fleet-git-credential-${escapeDoubleQuoted(label)}` : '~/.fleet-git-credential';
+    // $HOME (not `~`) -- `~` is only tilde-expanded by the shell in an UNQUOTED
+    // leading position; every use below is inside double quotes (needed for
+    // the other interpolated values), which suppresses that expansion. That
+    // silently stored the literal string "~/.fleet-git-credential-..." as the
+    // git config value -- git does not expand `~` itself when reading config,
+    // so it tried to exec a helper literally named
+    // `git-credential-~/.fleet-git-credential-...` ("not a git command").
+    // $HOME expands correctly even inside double quotes, so this actually
+    // resolves to an absolute path both when creating the file and when
+    // storing the git config value.
+    const credFile = label ? `$HOME/.fleet-git-credential-${escapeDoubleQuoted(label)}` : '$HOME/.fleet-git-credential';
     // scope_url is passed through escapeDoubleQuoted and embedded inside a double-quoted git config arg — safe against injection.
     const credUrl = scopeUrl ? escapeDoubleQuoted(scopeUrl) : `https://${escapedHost}`;
     return `printf '#!/bin/sh\\necho "protocol=https"\\necho "host=${escapedHost}"\\necho "username=${escapedUser}"\\necho "password=${escapedToken}"\\n' > "${credFile}" && chmod 600 "${credFile}" && chmod +x "${credFile}" && git config --global --replace-all "credential.${credUrl}.helper" "" && git config --global --add "credential.${credUrl}.helper" "${credFile}"`;
@@ -213,7 +223,7 @@ export class LinuxCommands implements OsCommands {
 
   gitCredentialHelperRemove(host: string, label?: string, scopeUrl?: string): string {
     const escapedHost = escapeDoubleQuoted(host);
-    const credFile = label ? `~/.fleet-git-credential-${escapeDoubleQuoted(label)}` : '~/.fleet-git-credential';
+    const credFile = label ? `$HOME/.fleet-git-credential-${escapeDoubleQuoted(label)}` : '$HOME/.fleet-git-credential';
     // scope_url is passed through escapeDoubleQuoted and embedded inside a double-quoted git config arg — safe against injection.
     const credUrl = scopeUrl ? escapeDoubleQuoted(scopeUrl) : `https://${escapedHost}`;
     return `rm -f "${credFile}" && git config --global --unset-all "credential.${credUrl}.helper" 2>/dev/null || true`;

--- a/src/services/tool-registry.ts
+++ b/src/services/tool-registry.ts
@@ -106,7 +106,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   server.tool('receive_files', 'Download files from a member to a local directory. Always batch multiple files into a single call — never invoke repeatedly for individual files.', receiveFilesSchema.shape, wrapTool('receive_files', (input, extra) => receiveFiles(input as any, extra)));
 
   // Prompt Execution
-  server.tool('execute_prompt', 'IMP: Never call this tool directly. Always wrap in a background subagent: Agent(run_in_background=true). Run an AI prompt on a member. Supports session resume for multi-turn conversations.', executePromptSchema.shape, wrapTool('execute_prompt', (input, extra) => executePrompt(input as any, extra)));
+  server.tool('execute_prompt', 'IMP: Never call this tool directly. Always wrap in a background subagent: Agent(run_in_background=true). Run an AI prompt on a member. Supports session resume for multi-turn conversations. On success, the reply text is returned in structuredContent.response (alongside usage and sessionId).', executePromptSchema.shape, wrapTool('execute_prompt', (input, extra) => executePrompt(input as any, extra)));
   server.tool('execute_command', 'IMP: Never call this tool directly. Always wrap in a background subagent: Agent(run_in_background=true). Run a shell command on a member. Use for quick tasks like installing packages, checking versions, or running scripts.', executeCommandSchema.shape, wrapTool('execute_command', (input, extra) => executeCommand(input as any, extra)));
 
   // Authentication & SSH

--- a/src/services/tool-registry.ts
+++ b/src/services/tool-registry.ts
@@ -106,8 +106,8 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   server.tool('receive_files', 'Download files from a member to a local directory. Always batch multiple files into a single call — never invoke repeatedly for individual files.', receiveFilesSchema.shape, wrapTool('receive_files', (input, extra) => receiveFiles(input as any, extra)));
 
   // Prompt Execution
-  server.tool('execute_prompt', 'IMP: Never call this tool directly. Always wrap in a background subagent: Agent(run_in_background=true). Run an AI prompt on a member. Supports session resume for multi-turn conversations. On success, the reply text is returned in structuredContent.response (alongside usage and sessionId).', executePromptSchema.shape, wrapTool('execute_prompt', (input, extra) => executePrompt(input as any, extra)));
-  server.tool('execute_command', 'IMP: Never call this tool directly. Always wrap in a background subagent: Agent(run_in_background=true). Run a shell command on a member. Use for quick tasks like installing packages, checking versions, or running scripts.', executeCommandSchema.shape, wrapTool('execute_command', (input, extra) => executeCommand(input as any, extra)));
+  server.tool('execute_prompt', 'Run an AI prompt on a member. Supports session resume for multi-turn conversations. On success, the reply text is returned in structuredContent.response (alongside usage and sessionId).', executePromptSchema.shape, wrapTool('execute_prompt', (input, extra) => executePrompt(input as any, extra)));
+  server.tool('execute_command', 'Run a shell command on a member. Use for quick tasks like installing packages, checking versions, or running scripts.', executeCommandSchema.shape, wrapTool('execute_command', (input, extra) => executeCommand(input as any, extra)));
 
   // Authentication & SSH
   server.tool('provision_llm_auth', "Authenticate a fleet member so it can run prompts. Copies your current login session to the member, or deploys an API key if provided. Run this before execute_prompt if the member reports no authentication.", provisionAuthSchema.shape, wrapTool('provision_llm_auth', (input) => provisionAuth(input as any)));

--- a/src/tools/check-status.ts
+++ b/src/tools/check-status.ts
@@ -202,6 +202,9 @@ export async function fleetStatus(input?: FleetStatusInput): Promise<string> {
   const agents = getAllAgents();
 
   if (agents.length === 0) {
+    if (format === 'json') {
+      return JSON.stringify({ version: serverVersion, summary: { total: 0, online: 0, offline: 0 }, members: [] });
+    }
     return 'No members registered. Use register_member to add one.';
   }
 

--- a/src/tools/execute-prompt.ts
+++ b/src/tools/execute-prompt.ts
@@ -35,6 +35,11 @@ import type { ParsedResponse } from '../providers/provider.js';
 export interface ExecutePromptStructured {
   isError?: boolean;
   reason?: 'busy' | 'reserved' | 'dispatch_failed' | 'nonzero_exit' | 'max_turns_exhausted' | 'empty_response' | 'workspace_not_trusted';
+  // The LLM's actual reply text on success. Callers that dispatch execute_prompt
+  // via an MCP client only ever see structuredContent (the content array is
+  // dropped when structuredContent is also present) -- this field exists so the
+  // reply reaches them at all, rather than being stranded in the display text.
+  response?: string;
   usage?: { input_tokens: number; output_tokens: number; total_tokens: number };
   sessionId?: string;
   [key: string]: unknown;
@@ -782,8 +787,6 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
     let output = `📋 Response from ${agent.friendlyName}:
 
 ${parsed.result}`;
-    if (parsed.usage) output += `
-Tokens: input=${parsed.usage.input_tokens} output=${parsed.usage.output_tokens}`;
     if (parsed.sessionId) output += `
 
 ---
@@ -792,6 +795,7 @@ session: ${parsed.sessionId}`;
     return {
       text: output,
       structuredContent: {
+        response: parsed.result,
         ...(_epUsage ? { usage: { input_tokens: _epUsage.input_tokens, output_tokens: _epUsage.output_tokens, total_tokens: _epUsage.input_tokens + _epUsage.output_tokens } } : {}),
         ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
       },

--- a/tests/execute-prompt.test.ts
+++ b/tests/execute-prompt.test.ts
@@ -294,7 +294,7 @@ describe('executePrompt', () => {
     expect(mockExecCommand.mock.calls[1][0]).not.toContain('"premium"');
   });
 
-  it('appends token line when usage is present in response', async () => {
+  it('reports usage via structuredContent when present in response', async () => {
     const member = makeTestAgent({ friendlyName: 'token-member' });
     addAgent(member);
     mockExecCommand.mockResolvedValue({
@@ -304,7 +304,13 @@ describe('executePrompt', () => {
     });
 
     const result = await executePrompt({ member_id: member.id, prompt: 'hi', resume: false, timeout_s: 5 });
-    expect(resultText(result)).toContain('Tokens: input=100 output=200');
+    expect(resultText(result)).not.toContain('Tokens:');
+    if (typeof result !== 'string') {
+      expect(result.structuredContent).toMatchObject({
+        response: 'done',
+        usage: { input_tokens: 100, output_tokens: 200, total_tokens: 300 },
+      });
+    }
   });
 
   it('does not append token line when usage is absent', async () => {

--- a/tests/fleet-setup-config.test.ts
+++ b/tests/fleet-setup-config.test.ts
@@ -10,6 +10,9 @@ import {
   deleteFolderCommand,
   cloneAndInitCommand,
   toyRepoUrlFor,
+  claudeProjectSlug,
+  geminiProjectName,
+  collectTranscriptScript,
 } from '../.github/e2e/fleet-setup.mjs';
 
 const REPO_ROOT = path.join(process.cwd());
@@ -156,6 +159,61 @@ describe('fleet-setup.mjs toy repo bootstrap (clone + bd init)', () => {
       expect(cmd).toContain('git clone https://github.com/x/y "/work/fleet-e2e-toy"');
       expect(cmd).not.toContain('Test-Path');
     }
+  });
+});
+
+describe('fleet-setup.mjs deterministic session-log collection', () => {
+  describe('claudeProjectSlug', () => {
+    it('replaces every non-alphanumeric character, not just path separators', () => {
+      expect(claudeProjectSlug('/home/user/fleet-work')).toBe('-home-user-fleet-work');
+      expect(claudeProjectSlug('C:\\Users\\test\\workspace')).toBe('C--Users-test-workspace');
+    });
+  });
+
+  describe('geminiProjectName', () => {
+    it('takes the final path segment across both separator styles', () => {
+      expect(geminiProjectName('/home/user/my-project')).toBe('my-project');
+      expect(geminiProjectName('C:\\Users\\test\\workspace')).toBe('workspace');
+    });
+
+    it('falls back to "project" for an empty/root path', () => {
+      expect(geminiProjectName('/')).toBe('project');
+    });
+  });
+
+  describe('collectTranscriptScript', () => {
+    it('claude: locates by exact project slug + session id under ~/.claude/projects', () => {
+      const script = collectTranscriptScript('claude', '/home/user/fleet-work', 'sess-123');
+      expect(script).toContain('.claude');
+      expect(script).toContain('projects');
+      expect(script).toContain('-home-user-fleet-work');
+      expect(script).toContain('sess-123');
+      expect(script).toContain('copyFileSync');
+    });
+
+    it('gemini: locates by project basename + exact session id under ~/.gemini/tmp/<project>/chats', () => {
+      const script = collectTranscriptScript('gemini', '/home/user/my-project', 'session-789-ghi');
+      expect(script).toContain('.gemini');
+      expect(script).toContain('tmp');
+      expect(script).toContain('chats');
+      expect(script).toContain('my-project');
+      expect(script).toContain('session-789-ghi');
+    });
+
+    it('agy: looks up by work folder via last_conversations.json, not by the fleet-tracked session id', () => {
+      const script = collectTranscriptScript('agy', '/home/user/fleet-work', 'sess-should-not-be-used-for-lookup');
+      expect(script).toContain('last_conversations.json');
+      expect(script).toContain('antigravity-cli');
+      expect(script).toContain('/home/user/fleet-work');
+      // the fleet-tracked session id plays no role in agy's own lookup
+      expect(script).not.toContain('sess-should-not-be-used-for-lookup');
+    });
+
+    it('returns null for providers with no known flat-file transcript', () => {
+      for (const provider of ['opencode', 'codex', 'copilot']) {
+        expect(collectTranscriptScript(provider, '/home/user/x', 'sess-1')).toBeNull();
+      }
+    });
   });
 });
 

--- a/tests/fleet-setup-config.test.ts
+++ b/tests/fleet-setup-config.test.ts
@@ -8,6 +8,8 @@ import {
   call,
   toyFolderPath,
   deleteFolderCommand,
+  cloneAndInitCommand,
+  toyRepoUrlFor,
 } from '../.github/e2e/fleet-setup.mjs';
 
 const REPO_ROOT = path.join(process.cwd());
@@ -124,6 +126,36 @@ describe('fleet-setup.mjs teardown toy-folder wipe', () => {
     expect(deleteFolderCommand('/home/akhil/fleet-e2e-toy', 'linux')).toBe(
       'rm -rf "/home/akhil/fleet-e2e-toy"',
     );
+  });
+});
+
+describe('fleet-setup.mjs toy repo bootstrap (clone + bd init)', () => {
+  it('resolves the toy repo URL for a known vcs', () => {
+    const { members } = loadConfig();
+    expect(toyRepoUrlFor('github', members)).toBe('https://github.com/Apra-Labs/fleet-e2e-toy');
+  });
+
+  it('throws a clear error for an unknown vcs', () => {
+    const { members } = loadConfig();
+    expect(() => toyRepoUrlFor('does-not-exist', members)).toThrow(/toy_projects has no entry/);
+  });
+
+  it('uses PowerShell Test-Path guards for windows', () => {
+    const cmd = cloneAndInitCommand('https://github.com/x/y', 'C:\\work\\fleet-e2e-toy', 'windows');
+    expect(cmd).toContain('Test-Path "C:\\work\\fleet-e2e-toy\\.git"');
+    expect(cmd).toContain('Test-Path ".beads\\embeddeddolt"');
+    expect(cmd).toContain('git clone https://github.com/x/y "C:\\work\\fleet-e2e-toy"');
+    expect(cmd).not.toContain('&&');
+  });
+
+  it('uses bash -d guards for linux/macos', () => {
+    for (const os of ['linux', 'macos']) {
+      const cmd = cloneAndInitCommand('https://github.com/x/y', '/work/fleet-e2e-toy', os);
+      expect(cmd).toContain('[ -d "/work/fleet-e2e-toy/.git" ]');
+      expect(cmd).toContain('[ -d ".beads/embeddeddolt" ]');
+      expect(cmd).toContain('git clone https://github.com/x/y "/work/fleet-e2e-toy"');
+      expect(cmd).not.toContain('Test-Path');
+    }
   });
 });
 

--- a/tests/fleet-setup-config.test.ts
+++ b/tests/fleet-setup-config.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import path from 'node:path';
-import { loadConfig, resolveMemberConfigs, bdCheckFor, doltCheckFor, call } from '../.github/e2e/fleet-setup.mjs';
+import {
+  loadConfig,
+  resolveMemberConfigs,
+  bdCheckFor,
+  doltCheckFor,
+  call,
+  toyFolderPath,
+  deleteFolderCommand,
+} from '../.github/e2e/fleet-setup.mjs';
 
 const REPO_ROOT = path.join(process.cwd());
 
@@ -93,6 +101,29 @@ describe('fleet-setup.mjs bd/dolt check command selection', () => {
     expect(doltCheckFor('windows')).toMatch(/^if \(Get-Command dolt/);
     expect(doltCheckFor('windows')).not.toContain('||');
     expect(doltCheckFor('windows')).not.toContain('$(');
+  });
+});
+
+describe('fleet-setup.mjs teardown toy-folder wipe', () => {
+  it('joins with a backslash for windows, forward slash otherwise', () => {
+    expect(toyFolderPath('C:\\Users\\akhil\\git\\apra-fleet-e2e-doer', 'windows')).toBe(
+      'C:\\Users\\akhil\\git\\apra-fleet-e2e-doer\\fleet-e2e-toy',
+    );
+    expect(toyFolderPath('/home/akhil/git/apra-fleet-e2e-doer', 'linux')).toBe(
+      '/home/akhil/git/apra-fleet-e2e-doer/fleet-e2e-toy',
+    );
+    expect(toyFolderPath('/Users/akhil/git/apra-fleet-e2e-rev', 'macos')).toBe(
+      '/Users/akhil/git/apra-fleet-e2e-rev/fleet-e2e-toy',
+    );
+  });
+
+  it('uses PowerShell Remove-Item for windows, rm -rf otherwise', () => {
+    expect(deleteFolderCommand('C:\\path\\fleet-e2e-toy', 'windows')).toBe(
+      'Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "C:\\path\\fleet-e2e-toy"',
+    );
+    expect(deleteFolderCommand('/home/akhil/fleet-e2e-toy', 'linux')).toBe(
+      'rm -rf "/home/akhil/fleet-e2e-toy"',
+    );
   });
 });
 

--- a/tests/fleet-setup-config.test.ts
+++ b/tests/fleet-setup-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
 import {
   loadConfig,
   resolveMemberConfigs,
@@ -239,6 +242,47 @@ describe('fleet-setup.mjs deterministic session-log collection', () => {
     it('returns null for providers with no known flat-file transcript', () => {
       for (const provider of ['opencode', 'codex', 'copilot']) {
         expect(collectTranscriptScript(provider, '/home/user/x', 'sess-1')).toBeNull();
+      }
+    });
+
+    it('actually executes end-to-end via `node -e` and copies the real file', () => {
+      // Regression test for a real bug found live: `node -e "<script>"` has NO
+      // script-file slot in argv (unlike `node file.js`) -- trailing args start
+      // at argv[1], not argv[2]. Using slice(2) silently dropped the first
+      // argument (the slug) every time, so `A[0]`/`A[1]` were off by one and
+      // fs.existsSync(src) always resolved to a bogus path -- the command ran
+      // cleanly (exit 0) and printed FLEET_LOG_MISSING even when the real
+      // transcript file existed right where expected. A pure string-inspection
+      // test can't catch this class of bug -- it has to actually run the
+      // generated command through a real child `node -e` invocation.
+      const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-collect-home-'));
+      const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-collect-cwd-'));
+      try {
+        const workFolder = 'C:\\Users\\test\\apra-fleet-e2e-doer';
+        const sessionId = 'sess-e2e-abc123';
+        const slug = claudeProjectSlug(workFolder);
+        const projectDir = path.join(fakeHome, '.claude', 'projects', slug);
+        fs.mkdirSync(projectDir, { recursive: true });
+        fs.writeFileSync(path.join(projectDir, `${sessionId}.jsonl`), '{"type":"assistant"}\n');
+
+        const command = collectTranscriptScript('claude', workFolder, sessionId);
+        // command is `node -e "..." "arg1" "arg2"` -- split into execFileSync's
+        // (file, args) form rather than re-parsing shell quoting ourselves.
+        const match = command.match(/^node -e "(.+)" "([^"]+)" "([^"]+)"$/);
+        expect(match).not.toBeNull();
+        const [, evalArg, arg1, arg2] = match as RegExpMatchArray;
+
+        const stdout = execFileSync('node', ['-e', evalArg, arg1, arg2], {
+          cwd,
+          env: { ...process.env, HOME: fakeHome, USERPROFILE: fakeHome },
+          encoding: 'utf8',
+        });
+
+        expect(stdout.trim()).toBe('FLEET_LOG_COPIED');
+        expect(fs.existsSync(path.join(cwd, `${sessionId}.jsonl`))).toBe(true);
+      } finally {
+        fs.rmSync(fakeHome, { recursive: true, force: true });
+        fs.rmSync(cwd, { recursive: true, force: true });
       }
     });
   });

--- a/tests/fleet-setup-config.test.ts
+++ b/tests/fleet-setup-config.test.ts
@@ -182,31 +182,58 @@ describe('fleet-setup.mjs deterministic session-log collection', () => {
   });
 
   describe('collectTranscriptScript', () => {
+    // Dynamic values (slugs, session ids, work folders) are passed as
+    // base64-encoded process.argv words, not interpolated as quoted string
+    // literals into the -e source -- see collectTranscriptScript's own
+    // comment in fleet-setup.mjs for why (nested-quote corruption observed
+    // on Windows local members). Decode both the script body and the argv
+    // args to assert on the real content, matching what the command
+    // actually does rather than raw substrings of the command line.
+    function decodeCommand(command: string) {
+      const scriptMatch = command.match(/eval\(Buffer\.from\('([^']+)','base64'\)/);
+      const decodedScript = scriptMatch ? Buffer.from(scriptMatch[1], 'base64').toString('utf8') : '';
+      const argMatches = [...command.matchAll(/"([A-Za-z0-9+/=]+)"/g)];
+      const decodedArgs = argMatches.map((m) => Buffer.from(m[1], 'base64').toString('utf8'));
+      return { decodedScript, decodedArgs };
+    }
+
     it('claude: locates by exact project slug + session id under ~/.claude/projects', () => {
-      const script = collectTranscriptScript('claude', '/home/user/fleet-work', 'sess-123');
-      expect(script).toContain('.claude');
-      expect(script).toContain('projects');
-      expect(script).toContain('-home-user-fleet-work');
-      expect(script).toContain('sess-123');
-      expect(script).toContain('copyFileSync');
+      const command = collectTranscriptScript('claude', '/home/user/fleet-work', 'sess-123');
+      expect(command).toMatch(/^node -e "eval\(Buffer\.from\(/);
+      const { decodedScript, decodedArgs } = decodeCommand(command);
+      expect(decodedScript).toContain('.claude');
+      expect(decodedScript).toContain('projects');
+      expect(decodedScript).toContain('copyFileSync');
+      expect(decodedArgs).toEqual(['-home-user-fleet-work', 'sess-123']);
     });
 
     it('gemini: locates by project basename + exact session id under ~/.gemini/tmp/<project>/chats', () => {
-      const script = collectTranscriptScript('gemini', '/home/user/my-project', 'session-789-ghi');
-      expect(script).toContain('.gemini');
-      expect(script).toContain('tmp');
-      expect(script).toContain('chats');
-      expect(script).toContain('my-project');
-      expect(script).toContain('session-789-ghi');
+      const command = collectTranscriptScript('gemini', '/home/user/my-project', 'session-789-ghi');
+      const { decodedScript, decodedArgs } = decodeCommand(command);
+      expect(decodedScript).toContain('.gemini');
+      expect(decodedScript).toContain('tmp');
+      expect(decodedScript).toContain('chats');
+      expect(decodedArgs).toEqual(['my-project', 'session-789-ghi']);
     });
 
     it('agy: looks up by work folder via last_conversations.json, not by the fleet-tracked session id', () => {
-      const script = collectTranscriptScript('agy', '/home/user/fleet-work', 'sess-should-not-be-used-for-lookup');
-      expect(script).toContain('last_conversations.json');
-      expect(script).toContain('antigravity-cli');
-      expect(script).toContain('/home/user/fleet-work');
+      const command = collectTranscriptScript('agy', '/home/user/fleet-work', 'sess-should-not-be-used-for-lookup');
+      const { decodedScript, decodedArgs } = decodeCommand(command);
+      expect(decodedScript).toContain('last_conversations.json');
+      expect(decodedScript).toContain('antigravity-cli');
+      expect(decodedArgs).toEqual(['/home/user/fleet-work']);
       // the fleet-tracked session id plays no role in agy's own lookup
-      expect(script).not.toContain('sess-should-not-be-used-for-lookup');
+      expect(decodedArgs).not.toContain('sess-should-not-be-used-for-lookup');
+    });
+
+    it('never interpolates dynamic values as raw literals into the command line', () => {
+      // The whole point of base64-encoding argv values: nothing left for a
+      // shell/CRT re-quoting pass to corrupt. Guard against a regression
+      // back to interpolating raw literals (e.g. via JSON.stringify) into
+      // the -e source itself.
+      const command = collectTranscriptScript('claude', 'C:\\Users\\test\\workspace', 'sess-1');
+      expect(command).not.toContain('workspace');
+      expect(command).not.toContain('sess-1');
     });
 
     it('returns null for providers with no known flat-file transcript', () => {

--- a/tests/fleet-status-branch.test.ts
+++ b/tests/fleet-status-branch.test.ts
@@ -24,6 +24,13 @@ describe('fleetStatus branch display', () => {
     restoreRegistry();
   });
 
+  it('returns valid JSON with zero members when format=json and no agents are registered', async () => {
+    const result = await fleetStatus({ format: 'json' });
+    const parsed = JSON.parse(result);
+    expect(parsed.summary).toEqual({ total: 0, online: 0, offline: 0 });
+    expect(parsed.members).toEqual([]);
+  });
+
   it('shows cached lastBranch in compact output when set', async () => {
     const member = makeTestAgent({ friendlyName: 'branch-member', lastBranch: 'feature/my-branch' });
     addAgent(member);

--- a/tests/platform.test.ts
+++ b/tests/platform.test.ts
@@ -349,6 +349,29 @@ describe('OsCommands via getOsCommands', () => {
       expect(cmd).toContain('chmod');
     });
 
+    // Regression: `~` is only tilde-expanded by the shell in an UNQUOTED
+    // leading position. Every use here is inside double quotes (needed for
+    // the other interpolated values), which suppresses that expansion --
+    // the literal string "~/.fleet-git-credential-..." then got stored as
+    // the git config value, and git does not expand `~` itself when reading
+    // config, so it tried to exec a helper literally named
+    // "git-credential-~/.fleet-git-credential-..." ("not a git command").
+    // $HOME expands correctly even inside double quotes. macOS inherits
+    // these methods from LinuxCommands unmodified, so it shares the fix.
+    for (const [name, cmds] of [['linux', linux], ['macos', macos]] as const) {
+      it(`${name}: gitCredentialHelperWrite uses $HOME, not a literal ~, for the credential file path`, () => {
+        const cmd = cmds.gitCredentialHelperWrite('github.com', 'x-access-token', 'ghs_abc');
+        expect(cmd).toContain('$HOME/.fleet-git-credential');
+        expect(cmd).not.toContain('"~/');
+      });
+
+      it(`${name}: gitCredentialHelperRemove uses $HOME, not a literal ~, for the credential file path`, () => {
+        const cmd = cmds.gitCredentialHelperRemove('github.com');
+        expect(cmd).toContain('$HOME/.fleet-git-credential');
+        expect(cmd).not.toContain('"~/');
+      });
+    }
+
     it('windows: writes a batch script credential helper', () => {
       const cmd = windows.gitCredentialHelperWrite('github.com', 'x-access-token', 'ghs_abc');
       expect(cmd).toContain('@echo off');


### PR DESCRIPTION
## Summary

A cluster of fixes found and verified through live, real CI runs against the Fleet E2E Test Suite (not from presumption) -- covering execute_prompt's reply visibility, git-push authentication on Linux/macOS members, several causes of wasted/exhausted turn budget, and multiple silent data-loss bugs in the e2e workflow's own log collection.

## Behavior changes

**`execute_prompt` now returns the reply text as structured data, not just as embedded text.** Previously, any caller that reads `structuredContent` directly (rather than parsing the free-text reply) only ever saw token usage and a session id -- the actual LLM answer was invisible to that path. It's now included as `structuredContent.response`, so structured-data consumers see the real reply. The redundant "Tokens: input=X output=Y" text line was also dropped since that data already exists in typed form.

**`execute_prompt`/`execute_command`'s tool descriptions no longer tell agents "this must be run in background."** That directive was duplicated (and stated less precisely) from `skills/fleet/SKILL.md`, which remains the authoritative source. Agents were burning turns re-deriving/second-guessing this instruction from the tool description itself; the descriptions now just describe what each tool does.

**Git push authentication on Linux/macOS members is now reliable.** The credential-helper path was written with a literal `~` inside a double-quoted shell string -- `~` only expands at an unquoted shell position, so git ended up trying to execute a credential helper literally named with a tilde in it, and push silently failed. Fixed to expand correctly. Verified live end-to-end (real clone/commit/push) on two different machines.

**Fleet status now returns valid JSON for an empty fleet when JSON output is requested.** Previously, if zero members were registered, the status tool ignored the requested output format and returned a plain English sentence -- any caller that parses its own JSON request crashed instead of getting a clean "no members" result.

**A smoke-test step no longer silently swallows a real authentication failure.** An early "is the PM's LLM CLI logged in / is the fleet tool available" check had, in one pass, both (a) a bug where any failure in it killed the whole run even though the check was meant to be advisory, and later (b) the opposite bug, where a genuine "not logged in" failure was caught and the step printed "auth OK" regardless. Both are now fixed: informational noise doesn't fail the run, but a real authentication failure does, immediately, before the run wastes a full attempt discovering it later.

**The sprint orchestrator's own MCP tool registration is now re-asserted immediately before the main run, rather than assumed to still be in place from setup.** That registration was intermittently going missing by the time the main run started (most likely a config-file race on a machine that also serves as a remote worker for other test suites), causing the whole run to proceed with no fleet tools available at all and fail every step. It's now unconditionally re-applied right before the run starts.

**Each test run now gets a clean, pristine copy of its working repository, including its issue-tracking database.** Previously only the record of *who* was registered got cleaned up between runs; the actual on-disk clone and its local database were left in whatever state the previous run left them in, so a corrupted or half-initialized state from one run could silently carry into the next and cause confusing, unrelated-looking failures. Both participating members now get their working copy fully wiped and freshly re-cloned/initialized at the start of every run.

**Session transcripts from the doer/reviewer are now collected deterministically, not by asking the orchestrating LLM to do it as one of its own tasks.** The old approach cost the orchestrator real turns on pure file-finding work, and -- worse -- produced nothing at all if the orchestrator crashed or ran out of turns before reaching that step. It's now a fixed, always-runs, provider-aware step that runs regardless of how the main phase ended.

**Fixed three bugs in that new deterministic log-collection step, each found by downloading and carefully validating a real (green, but not fully correct) run's artifacts rather than trusting the checkmark:**
- On Windows members specifically, the collection step was crashing with a syntax error and silently producing nothing, due to a subtle shell-quoting interaction when nesting quoted script content inside another layer of quoting for cross-machine command dispatch. Fixed by passing the dynamic parts of the lookup (paths, identifiers) in a form that has no quote characters left for any shell layer to corrupt, regardless of how many machines/shells the command crosses.
- Once that crash was fixed, a second, unrelated bug surfaced: the lookup still failed to find transcripts that demonstrably existed exactly where expected, because of an off-by-one in how positional arguments were being read back out on the remote side -- the first of two values was silently discarded every time, so the computed file location was always wrong. Verified live against a real machine: the exact expected file was confirmed present on disk, the buggy version reported "not found," and the corrected version successfully located and copied it.
- As a direct consequence of the first of those, per-member token-usage numbers in the run's final report were coming back as zero even on fully successful runs, since the reporting step reads from exactly the files the broken collection step failed to produce. No separate fix was needed there -- it resolves itself once collection works.

**A related but separate bug: the run's own daemon activity log was coming back completely empty in every artifact**, despite the daemon clearly having done real work for the full duration of the run. The cleanup step responsible for keeping old, unrelated log content out of each run's artifact was deleting the log file while the run's own daemon still had it open for writing, which discards everything written afterward with no error raised anywhere. Moved that cleanup to before the daemon for this run even starts, so it can only ever affect leftovers from an already-finished previous run, never the current one.

**A redundant instruction was trimmed from the main run's first step.** It was telling the orchestrator to clone the working repository "if needed" -- which is now always already guaranteed true by the time that instruction runs, since the deterministic setup phase handles it beforehand for every run.

## Verification

Every fix above was validated against real, triggered CI runs (not simulated), live command execution against the actual machines involved, and/or targeted unit tests added alongside the change (including one that actually executes the generated cross-machine command end-to-end rather than only inspecting it as a string, specifically because the off-by-one bug above was invisible to string-level inspection). The full local test suite passes (189 files / 2668 tests, only pre-existing Docker-dependent tests skipped).
