### PR TITLE
fix(bundle): make the packaged fleet-sprint binary actually run

### DIFF
--- a/scripts/bundle-se.mjs
+++ b/scripts/bundle-se.mjs
@@ -149,6 +149,25 @@ await build({
   minify: false, // keep readable for debugging
   // cli.mjs's own shebang (#!/usr/bin/env node) is preserved by esbuild
   // automatically when it is the first line of the entry point.
+  //
+  // ESM output + a bundled CJS dependency needs a real `require` in scope.
+  // esbuild rewrites CJS `require(...)` calls into its own `__require` shim,
+  // and that shim's fallback THROWS -- `Dynamic require of "node:assert" is
+  // not supported` -- for any call it could not resolve statically. undici
+  // (pulled in transitively by @apralabs/apra-fleet-client's HTTP transport)
+  // does exactly that at runtime from lib/dispatcher/client.js, so every
+  // invocation of the bundled binary died on startup before parsing a single
+  // flag. The shim's first branch is `typeof require !== "undefined" ?
+  // require : <throwing fallback>`, so defining a genuine createRequire-backed
+  // `require` at module scope makes it take the working branch instead. This
+  // is the canonical esbuild ESM/CJS interop fix, not a workaround for undici
+  // specifically: any future CJS dep doing a dynamic require is covered.
+  banner: {
+    js: [
+      "import { createRequire as __apraCreateRequire } from 'node:module';",
+      'const require = __apraCreateRequire(import.meta.url);',
+    ].join('\n'),
+  },
   metafile: true,
 });
 

--- a/scripts/bundle-se.mjs
+++ b/scripts/bundle-se.mjs
@@ -79,7 +79,7 @@
 // the two @apralabs/* workspace packages below (apra-fleet-7pm.12).
 
 import { build } from 'esbuild';
-import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -178,8 +178,25 @@ copyFileSync(
 );
 console.log('Copied fleet-sprint/runner.js -> dist/fleet-sprint-runner.mjs');
 
-for (const name of ['contracts.mjs', 'errors.mjs', 'viewer-extensions.mjs']) {
-  copyFileSync(join(sePackageRoot, 'fleet-sprint', name), join(distDir, name));
+// Copy EVERY .mjs sibling of runner.js, not a hand-maintained subset.
+// runner.js is never bundled (it is read from disk as text by
+// engine.executeFile(), see above), so its relative './x.mjs' imports must be
+// satisfied by real files sitting next to dist/fleet-sprint-runner.mjs. This
+// list used to be the literal three ['contracts.mjs', 'errors.mjs',
+// 'viewer-extensions.mjs'], which silently went stale as siblings were added:
+// conflict-ladder.mjs and sprint-lock.mjs both became runner imports and
+// neither was copied, so the packaged binary died at startup with
+// ERR_MODULE_NOT_FOUND for dist/conflict-ladder.mjs on the very first sprint.
+// Nothing caught it because the dynamic-require crash masked it -- the binary
+// never got far enough to load the runner at all.
+//
+// Scanning the directory removes the failure mode rather than patching this
+// instance of it: a new sibling is copied automatically the moment it exists.
+// The cost of over-copying (a few KB for a sibling nothing imports yet) is
+// trivial next to shipping a binary that cannot start.
+const siblingDir = join(sePackageRoot, 'fleet-sprint');
+for (const name of readdirSync(siblingDir).filter((f) => f.endsWith('.mjs')).sort()) {
+  copyFileSync(join(siblingDir, name), join(distDir, name));
   console.log(`Copied fleet-sprint/${name} -> dist/${name}`);
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -224,7 +224,10 @@ function collectPackageTree(
   return results;
 }
 
-function buildDevManifest(root: string): AssetManifest {
+// Exported for tests: the dev-mode manifest is what gates the entire workflow
+// subsystem install, and its inputs are filesystem paths that can silently go
+// stale when directories move (see agentSchemasDir below).
+export function buildDevManifest(root: string): AssetManifest {
   const hooks: Record<string, string> = {};
   for (const entry of fs.readdirSync(path.join(root, 'hooks'))) {
     hooks[entry] = `hooks/${entry}`;

--- a/tests/fleet-sprint-bundle-smoke.test.ts
+++ b/tests/fleet-sprint-bundle-smoke.test.ts
@@ -53,4 +53,43 @@ describe.skipIf(!bundleExists)('dist/fleet-sprint.mjs -- packaged binary smoke',
     const firstLine = readFileSync(bundlePath, 'utf-8').split('\n')[0];
     expect(firstLine).toBe('#!/usr/bin/env node');
   });
+
+  // Second regression guard, for a bug the --help smoke above cannot reach:
+  // runner.js is NOT bundled (engine.executeFile() reads it from disk as
+  // text), so its relative './x.mjs' imports resolve against dist/ at
+  // sprint-run time -- long after --help has exited 0. bundle-se.mjs used to
+  // copy a hardcoded three siblings; conflict-ladder.mjs and sprint-lock.mjs
+  // were added as runner imports later and never got copied, so the packaged
+  // binary died with ERR_MODULE_NOT_FOUND for dist/conflict-ladder.mjs on the
+  // first real sprint. Resolve the imports statically here so a missing
+  // sibling fails the build instead of a user's sprint.
+  it('ships every sibling module the unbundled runner imports', async () => {
+    const { readFileSync, existsSync: exists } = await import('node:fs');
+    const distDir = path.join(root, 'dist');
+    const runnerPath = path.join(distDir, 'fleet-sprint-runner.mjs');
+    expect(exists(runnerPath)).toBe(true);
+
+    // Walk transitively: a copied sibling may import further siblings.
+    const seen = new Set<string>();
+    const queue = [runnerPath];
+    const missing: string[] = [];
+
+    while (queue.length > 0) {
+      const filePath = queue.pop()!;
+      if (seen.has(filePath)) continue;
+      seen.add(filePath);
+
+      const src = readFileSync(filePath, 'utf-8');
+      for (const match of src.matchAll(/from\s+'(\.\/[A-Za-z0-9._-]+\.mjs)'/g)) {
+        const resolved = path.join(distDir, match[1]);
+        if (!exists(resolved)) {
+          missing.push(`${path.basename(filePath)} -> ${match[1]}`);
+        } else {
+          queue.push(resolved);
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
 });

--- a/tests/fleet-sprint-bundle-smoke.test.ts
+++ b/tests/fleet-sprint-bundle-smoke.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Smoke test for the packaged fleet-sprint binary (dist/fleet-sprint.mjs,
+ * produced by scripts/bundle-se.mjs and exposed as the root package's
+ * `fleet-sprint` bin).
+ *
+ * Regression guard: the bundle is ESM (format: 'esm') but pulls in CJS
+ * dependencies -- notably undici, via @apralabs/apra-fleet-client's HTTP
+ * transport. esbuild rewrites CJS `require(...)` into its own `__require`
+ * shim whose fallback THROWS `Dynamic require of "node:assert" is not
+ * supported`. undici hits that at runtime from lib/dispatcher/client.js, so
+ * the shipped binary died on startup before parsing a single flag -- every
+ * `fleet-sprint ...` invocation, and `apra-fleet workflow fleet-sprint` with
+ * it. Nothing caught it: cli-server-resolution.test.mjs only ever writes a
+ * fake `// bundled cli` placeholder, so no test had ever EXECUTED the real
+ * artifact.
+ *
+ * The check is deliberately end-to-end and dumb: actually spawn the bundle
+ * and require it to reach flag parsing. A unit test of the bundler's config
+ * would not have caught this, because the config was syntactically fine --
+ * only running the output reveals it.
+ *
+ * Skipped (not failed) when dist/fleet-sprint.mjs is absent: it is built by
+ * `npm run build:se` (part of prepublishOnly), not by a plain `npm run
+ * build`, so a normal dev checkout legitimately may not have it yet.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(__dirname, '..');
+const bundlePath = path.join(root, 'dist', 'fleet-sprint.mjs');
+const bundleExists = existsSync(bundlePath);
+
+describe.skipIf(!bundleExists)('dist/fleet-sprint.mjs -- packaged binary smoke', () => {
+  it('starts and reaches flag parsing instead of dying on a dynamic require', () => {
+    const result = spawnSync(process.execPath, [bundlePath, '--help'], {
+      encoding: 'utf-8',
+      timeout: 60_000,
+    });
+
+    const combined = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+    // Assert on the specific failure first so a regression reports the real
+    // cause rather than a bare exit-code mismatch.
+    expect(combined).not.toMatch(/Dynamic require of/);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: fleet-se sprint');
+  });
+
+  it('keeps its shebang on line 1 so the bin entry stays executable', async () => {
+    const { readFileSync } = await import('node:fs');
+    const firstLine = readFileSync(bundlePath, 'utf-8').split('\n')[0];
+    expect(firstLine).toBe('#!/usr/bin/env node');
+  });
+});

--- a/tests/install-dev-manifest.test.ts
+++ b/tests/install-dev-manifest.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Guards the dev-mode asset manifest that gates the workflow subsystem
+ * install (`apra-fleet install` -> extractWorkflowSubsystemAssets).
+ *
+ * This is a GUARD, not a fix: the paths are already correct on main. It exists
+ * because this class of breakage was observed for real on a pre-bd01665 tree,
+ * where buildDevManifest() still located agent schemas at
+ * vendor/apra-pm/agents/schemas -- a submodule retired when apra-pm moved to
+ * packages/apra-fleet-se/apra-pm/. That path has no fallback, so agentSchemas
+ * silently stayed undefined; hasWorkflowSubsystemAssets() requires ALL THREE
+ * sections, so the install warned and returned before creating
+ * ~/.apra-fleet/workflows/ at all. The install still printed success and
+ * recorded workflowsMode:"all", leaving `apra-fleet workflow fleet-sprint`
+ * dead with "No workflows installed" -- a total failure with no failing exit
+ * code anywhere. Nothing prevents the next directory move from doing it again,
+ * which is what these assertions are for.
+ *
+ * These assertions run against the real checkout rather than a fixture,
+ * because the bug is precisely that a real directory moved and a hardcoded
+ * path did not follow. A mocked filesystem would have happily passed.
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { buildDevManifest } from '../src/cli/install.js';
+import { hasWorkflowSubsystemAssets } from '../src/cli/workflow-assets.js';
+
+const root = path.resolve(__dirname, '..');
+
+describe('buildDevManifest -- workflow subsystem sections', () => {
+  it('carries all three sections, so the workflow install is not skipped', () => {
+    const manifest = buildDevManifest(root);
+
+    // Report which section is missing rather than a bare false.
+    const present = {
+      workflowRuntime: !!manifest.workflowRuntime,
+      agentSchemas: !!manifest.agentSchemas,
+      builtinWorkflows: !!manifest.builtinWorkflows,
+    };
+    expect(present).toEqual({
+      workflowRuntime: true,
+      agentSchemas: true,
+      builtinWorkflows: true,
+    });
+
+    expect(hasWorkflowSubsystemAssets(manifest)).toBe(true);
+  });
+
+  it('resolves agent schemas to real files at apra-pm\'s current location', () => {
+    const manifest = buildDevManifest(root);
+    const entries = Object.entries(manifest.agentSchemas ?? {});
+    expect(entries.length).toBeGreaterThan(0);
+
+    // Every manifest value is a repo-relative path; a stale directory would
+    // yield entries pointing at files that do not exist.
+    const missing = entries
+      .filter(([, relPath]) => !existsSync(path.join(root, relPath)))
+      .map(([key]) => key);
+    expect(missing).toEqual([]);
+  });
+
+  it('references no retired vendor/apra-pm paths', () => {
+    // The submodule is gone; any manifest entry still rooted there is stale
+    // by construction.
+    const manifest = buildDevManifest(root);
+    const allPaths = [
+      ...Object.values(manifest.agentSchemas ?? {}),
+      ...Object.values(manifest.builtinWorkflows ?? {}),
+      ...Object.values(manifest.workflowRuntime ?? {}),
+    ];
+    expect(allPaths.filter((p) => p.includes('vendor/apra-pm'))).toEqual([]);
+    expect(existsSync(path.join(root, 'vendor', 'apra-pm'))).toBe(false);
+  });
+});


### PR DESCRIPTION
The `fleet-sprint` binary declared in this package's `bin` map
(`dist/fleet-sprint.mjs`, installed onto PATH by
`npm install -g @apralabs/apra-fleet`) cannot start on `main` today. Two
independent breakages, one masking the other:

1. **Dies on startup.** The bundle is `format: 'esm'` but pulls in CJS deps --
   undici, via `@apralabs/apra-fleet-client`'s HTTP transport. esbuild rewrites
   CJS `require(...)` into a `__require` shim whose fallback throws, and undici
   hits it at runtime from `lib/dispatcher/client.js`:
   `Dynamic require of "node:assert" is not supported`. Every invocation of that
   binary died before parsing a flag.

   Fixed with a `createRequire` banner. The shim's own first branch is
   `typeof require !== "undefined" ? require : <throwing fallback>`, so putting
   a genuine `require` in module scope makes it take the working branch. This
   is the canonical esbuild ESM/CJS interop fix, not an undici-specific patch --
   any future CJS dep doing a dynamic require is covered. esbuild keeps the
   entry's shebang on line 1 ahead of the banner, so the bin stays executable.

2. **Ships an incomplete runner.** `runner.js` is deliberately never bundled
   (`engine.executeFile()` reads it from disk as text), so its relative
   `./x.mjs` imports must resolve against real files next to
   `dist/fleet-sprint-runner.mjs`. `bundle-se.mjs` copied a hardcoded three;
   `conflict-ladder.mjs` and `sprint-lock.mjs` became runner imports later and
   never shipped, so the binary died with `ERR_MODULE_NOT_FOUND` for
   `dist/conflict-ladder.mjs` on the first real sprint.

   Fixed by scanning the directory instead of naming files, so a new sibling
   ships the moment it exists. This is already earning its keep: #362 added
   `full-db-fetch-guard.mjs`, which the hardcoded list would also have dropped.

## Scope: which entry point this affects

`packages/apra-fleet-se/fleet-sprint/docs/README.md` documents two ways to run
a sprint, and **neither goes through this bundle**:

1. `apra-fleet workflow fleet-sprint` -- resolves from
   `~/.apra-fleet/workflows/fleet-sprint`, which `install.ts` populates from
   `collectPackageTree(packages/apra-fleet-se)`, i.e. the SE *source tree*.
2. `node packages/apra-fleet-se/bin/cli.mjs` -- the unbundled dev entry point.

This PR fixes the third, undocumented-but-shipped path: the `fleet-sprint` bin
itself, which `bundle-se.mjs`'s own header states is there so
`npm install -g @apralabs/apra-fleet` "also gets a working `fleet-sprint`
binary". It currently does not. So the blast radius is `npm i -g` users
invoking `fleet-sprint` directly, not the documented workflows.

## Why nothing caught this

No test had ever executed the packaged artifact.
`cli-server-resolution.test.mjs` only writes a fake `// bundled cli`
placeholder, so both breakages sat in the shipped binary while the documented
paths (which bypass it) kept working. Bug 1 also masked bug 2 -- the binary
never got far enough to load the runner, so the missing modules could not
surface; fixing the first exposed the second on the very next launch.

`tests/fleet-sprint-bundle-smoke.test.ts` closes that gap: it spawns the built
bundle and requires it to reach flag parsing, asserts the shebang stays on line
1, and walks the runner's relative `.mjs` imports transitively so a missing
sibling fails the build rather than a user's sprint. The `--help` smoke alone
cannot catch bug 2 -- the runner loads at sprint-run time, long after `--help`
exits 0. Skipped (not failed) when `dist/fleet-sprint.mjs` is absent, since it
is built by `build:se`/`prepublishOnly`, not a plain `npm run build`.

Both fixes were verified as real regression tests: reverting each makes its
test fail with the exact original error.

## Also included

`tests/install-dev-manifest.test.ts` is a guard, not a fix -- the paths are
already correct on `main`. `buildDevManifest()`'s workflow-subsystem inputs are
hardcoded filesystem paths, and `hasWorkflowSubsystemAssets()` requires all
three sections, so one stale path silently disables the whole workflow install:
no `~/.apra-fleet/workflows/`, no non-zero exit, and an install that still
prints success and records `workflowsMode:"all"` -- which breaks documented
invocation form 1 above. That was observed for real on a pre-`bd01665` tree
where `agentSchemasDir` still pointed at the retired `vendor/apra-pm`
submodule. Nothing stops the next directory move from repeating it.

## Testing

- Root: 2740 passed / 10 skipped. One unrelated pre-existing flake --
  `tests/hub-service/relay-queue.test.ts` times out at 20s under parallel load
  and passes on retry in isolation; this branch touches no hub-service file.
- `packages/apra-fleet-se`: 1065 passed, 0 failed.

## Not included

An earlier revision of this branch also carried an `Ensure Sprint Branch` fix
for a local-only branch being force-reset to base (real data loss: it destroyed
three unpushed commits). `bd01665`'s `decideEnsureBranchAction()` supersedes it
and is strictly better -- it also handles the local-ahead-of-origin ancestry
case that fix left open -- so it was dropped rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
