### PR TITLE
Auto-sprint [ABORTED]: feat/lhf-batch-a

### DIFF
--- a/scripts/check-toy-doer-credentials.mjs
+++ b/scripts/check-toy-doer-credentials.mjs
@@ -52,6 +52,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
 
 export const CREDENTIAL_ENV_VAR = 'CLAUDE_CODE_OAUTH_TOKEN';
@@ -70,6 +71,21 @@ export function defaultRegistryPath(fleetHome = defaultFleetHome()) {
 /** Path LocalStrategy's clean-env dispatch (and the claude CLI) reads OAuth credentials from. */
 export function defaultCredentialsPath(fleetHome = defaultFleetHome()) {
   return path.join(fleetHome, '.claude', '.credentials.json');
+}
+
+/**
+ * Path to the per-install AES-256-GCM key file (matches src/utils/crypto.ts's
+ * SALT_PATH: `<FLEET_DIR>/salt`, respecting APRA_FLEET_DATA_DIR the same way
+ * defaultRegistryPath does).
+ *
+ * apra-fleet-vak.2: deliberately a separate, read-only lookup -- never calls
+ * into src/utils/crypto.ts#getOrCreateKey, which WRITES a fresh salt file
+ * when one is missing. That write side effect is fine for the real server
+ * process but wrong for a read-only sandbox probe script.
+ */
+export function defaultSaltPath(fleetHome = defaultFleetHome()) {
+  const dataDir = process.env.APRA_FLEET_DATA_DIR ?? path.join(fleetHome, '.apra-fleet', 'data');
+  return path.join(dataDir, 'salt');
 }
 
 /**
@@ -134,11 +150,127 @@ export function checkMemberEnvVarProvisioned(registryPath, memberName) {
     return {
       ok: true,
       message: `OK (env-var path): member '${memberName}' has encryptedEnvVars.${CREDENTIAL_ENV_VAR} populated.`,
+      // apra-fleet-vak.2: additive field only -- the raw ciphertext, so a caller
+      // (checkToyDoerCredentialsProvisioned) can run the JSON-blob shape check
+      // against it without this function's own pass/fail semantics changing.
+      // Pre-existing callers that only read .ok/.message are unaffected.
+      ciphertext: /** @type {Record<string, unknown>} */ (agent.encryptedEnvVars)[CREDENTIAL_ENV_VAR],
     };
   }
   return {
     ok: false,
     message: `NOT-PROVISIONED (env-var path): member '${memberName}' has no encryptedEnvVars.${CREDENTIAL_ENV_VAR} in '${registryPath}'.`,
+  };
+}
+
+/**
+ * Read-only counterpart to src/utils/crypto.ts#decryptPassword: decrypts an
+ * 'ivHex:authTagHex:cipherHex' AES-256-GCM ciphertext using the per-install
+ * key at saltPath. Returns null (never throws) when the salt file is
+ * missing/unreadable, the ciphertext isn't the expected 3-part hex shape, or
+ * decryption otherwise fails (wrong key, corrupt data) -- callers treat null
+ * as "plaintext unavailable", not a crash.
+ *
+ * apra-fleet-vak.2 STEP ONE: this is a deliberate inline reimplementation
+ * (option (b) from the task), NOT a `dist/utils/crypto.js` import (option
+ * (a)). Reasons: (1) this script must keep working with no build present
+ * (`node scripts/check-toy-doer-credentials.mjs` standalone, no `npm run
+ * build` prerequisite); (2) more importantly, src/utils/crypto.ts's own
+ * `getOrCreateKey()` WRITES a brand-new salt file to disk when one is
+ * missing -- unacceptable side-effect for a read-only sandbox probe (see the
+ * "Sandbox-only / read-only" header comment above: this script never
+ * writes/mutates anything). Mirrors src/utils/crypto.ts's exact format/
+ * algorithm ground truth (aes-256-gcm, IV_LENGTH 16, 'iv:authTag:cipher' hex).
+ *
+ * @param {string} ciphertext
+ * @param {string} [saltPath]
+ * @returns {string | null}
+ */
+export function decryptEnvVarValue(ciphertext, saltPath = defaultSaltPath()) {
+  if (!ciphertext || typeof ciphertext !== 'string') return null;
+  if (!fs.existsSync(saltPath)) return null;
+  const parts = ciphertext.split(':');
+  if (parts.length !== 3) return null;
+  const [ivHex, authTagHex, encryptedHex] = parts;
+  try {
+    const key = Buffer.from(fs.readFileSync(saltPath, 'utf-8').trim(), 'hex');
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    let decrypted = decipher.update(encryptedHex, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is this decrypted plaintext JSON-shaped (a full object -- e.g. the
+ * claudeAiOauth blob provisionEnvVarForMember must never store verbatim, see
+ * apra-fleet-vak) rather than a bare OAuth access-token string?
+ *
+ * @param {string} plaintext
+ * @returns {boolean}
+ */
+export function isJsonShapedToken(plaintext) {
+  if (typeof plaintext !== 'string') return false;
+  const trimmed = plaintext.trim();
+  if (!trimmed || trimmed[0] !== '{') return false;
+  try {
+    JSON.parse(trimmed);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * apra-fleet-vak.2: does a member's encryptedEnvVars.CLAUDE_CODE_OAUTH_TOKEN
+ * ciphertext decrypt to a JSON-shaped blob (the apra-fleet-vak bug: a full
+ * claudeAiOauth object stored verbatim instead of being unwrapped to its bare
+ * accessToken by provisionEnvVarForMember)?
+ *
+ * Three distinct outcomes, never a thrown error and never a silent pass over
+ * a real problem:
+ *   - 'skipped': no ciphertext was supplied (nothing to check).
+ *   - 'indeterminate': plaintext could not be obtained (no salt file, e.g. no
+ *     server has ever run on this host yet -- or a format mismatch) -- this
+ *     check is inconclusive here, NOT a pass.
+ *   - 'hard-fail': plaintext is JSON-shaped -- the apra-fleet-vak regression.
+ *   - 'ok': plaintext is a bare (non-JSON) token string.
+ *
+ * Never includes the plaintext (or any prefix of it) in its message.
+ *
+ * @param {string | undefined | null} ciphertext
+ * @param {{saltPath?: string, fleetHome?: string}} [opts]
+ * @returns {{status: 'skipped' | 'indeterminate' | 'hard-fail' | 'ok', message: string}}
+ */
+export function checkEnvVarNotJsonBlob(ciphertext, opts = {}) {
+  if (!ciphertext) {
+    return {
+      status: 'skipped',
+      message: `SKIPPED (JSON-blob shape check): no encryptedEnvVars.${CREDENTIAL_ENV_VAR} ciphertext to examine.`,
+    };
+  }
+  const saltPath = opts.saltPath ?? defaultSaltPath(opts.fleetHome ?? defaultFleetHome());
+  const plaintext = decryptEnvVarValue(ciphertext, saltPath);
+  if (plaintext === null) {
+    return {
+      status: 'indeterminate',
+      message: `INDETERMINATE (JSON-blob shape check): could not decrypt encryptedEnvVars.${CREDENTIAL_ENV_VAR} to verify its shape -- no readable per-install salt at '${saltPath}' (or a ciphertext/key format mismatch). This result is inconclusive, NOT a pass; build the project and/or run once against a real fleet home with an existing salt file to get a definitive result.`,
+    };
+  }
+  if (isJsonShapedToken(plaintext)) {
+    return {
+      status: 'hard-fail',
+      message: `FAIL (apra-fleet-vak): encryptedEnvVars.${CREDENTIAL_ENV_VAR} decrypts to a JSON-shaped blob, not a bare OAuth access token -- this is the apra-fleet-vak regression (a full claudeAiOauth object stored verbatim). Check provisionEnvVarForMember (src/cli/auth.ts, apra-fleet-vak.1) actually extracted accessToken before writing encryptedEnvVars.`,
+    };
+  }
+  return {
+    status: 'ok',
+    message: `OK (JSON-blob shape check): encryptedEnvVars.${CREDENTIAL_ENV_VAR} decrypts to a bare token string, not a JSON blob.`,
   };
 }
 
@@ -580,18 +712,30 @@ export function checkToyDoerCredentialsProvisioned(opts = {}) {
   const fleetHome = opts.fleetHome ?? defaultFleetHome();
   const registryPath = opts.registryPath ?? defaultRegistryPath(fleetHome);
   const deps = opts.deps ?? {};
+  const saltPath = opts.saltPath ?? defaultSaltPath(fleetHome);
 
   const envVarCheck = checkMemberEnvVarProvisioned(registryPath, memberName);
   const cleanEnvCheck = checkCleanEnvCredentialsFile(fleetHome, deps);
-  const ok = envVarCheck.ok || cleanEnvCheck.ok;
+  // apra-fleet-vak.2: independent of the two checks above -- only examines
+  // the ciphertext WHEN checkMemberEnvVarProvisioned found one (envVarCheck.ok
+  // already required a non-empty string for that). A 'hard-fail' here is the
+  // ONLY thing that can turn an otherwise-passing result into a failure;
+  // 'indeterminate'/'skipped' never do (see checkEnvVarNotJsonBlob's doc).
+  const jsonBlobCheck = checkEnvVarNotJsonBlob(envVarCheck.ciphertext, { saltPath });
+  const hardFail = jsonBlobCheck.status === 'hard-fail';
+
+  const ok = (envVarCheck.ok || cleanEnvCheck.ok) && !hardFail;
 
   return {
     ok,
-    message: ok
-      ? (envVarCheck.ok ? envVarCheck.message : cleanEnvCheck.message)
-      : `FAIL: member '${memberName}' has no provisioned LLM credential -- neither encryptedEnvVars.${CREDENTIAL_ENV_VAR} nor a clean-env-resolvable '.claude/.credentials.json' was found. Run integ-test-playbook.md's '## Test scenario' step 3 (apra-fleet-eft.48.1's credential-provisioning step) before dispatching -- an unprovisioned member fails every real Planner dispatch with 'Authentication failed' (AGENT_DISPATCH_FAILED, apra-fleet-eft.48).`,
+    message: hardFail
+      ? jsonBlobCheck.message
+      : ok
+        ? (envVarCheck.ok ? envVarCheck.message : cleanEnvCheck.message)
+        : `FAIL: member '${memberName}' has no provisioned LLM credential -- neither encryptedEnvVars.${CREDENTIAL_ENV_VAR} nor a clean-env-resolvable '.claude/.credentials.json' was found. Run integ-test-playbook.md's '## Test scenario' step 3 (apra-fleet-eft.48.1's credential-provisioning step) before dispatching -- an unprovisioned member fails every real Planner dispatch with 'Authentication failed' (AGENT_DISPATCH_FAILED, apra-fleet-eft.48).`,
     envVarCheck,
     cleanEnvCheck,
+    jsonBlobCheck,
   };
 }
 
@@ -603,6 +747,7 @@ function main() {
   const result = checkToyDoerCredentialsProvisioned({ memberName, fleetHome });
   console.log(`[check-toy-doer-credentials] ${result.envVarCheck.message}`);
   console.log(`[check-toy-doer-credentials] ${result.cleanEnvCheck.message}`);
+  console.log(`[check-toy-doer-credentials] ${result.jsonBlobCheck.message}`);
 
   if (!result.ok) {
     console.error(`[check-toy-doer-credentials] ${result.message}`);

--- a/scripts/package-sea.mjs
+++ b/scripts/package-sea.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * package-sea.mjs — Generate SEA blob and inject into Node binary
+ * package-sea.mjs -- Generate SEA blob and inject into Node binary
  *
  * Steps:
  * 1. Run `node --experimental-sea-config` to generate blob
@@ -54,7 +54,7 @@ export function runPostjectFiltered(command, options = {}, deps = {}) {
   return { status: result.status, error: result.error, filteredStderr };
 }
 
-function reportAndCheckPostjectResult(result) {
+export function reportAndCheckPostjectResult(result) {
   if (result.filteredStderr) {
     process.stderr.write(result.filteredStderr.endsWith('\n') ? result.filteredStderr : `${result.filteredStderr}\n`);
   }
@@ -127,7 +127,7 @@ function main() {
         execSync(`"${rcedit}" "${outputBinary}" --set-icon "${icoPath}"`, { stdio: 'inherit', shell: true });
         console.log('  Icon injection succeeded');
       } else {
-        console.error('WARNING: rcedit not found — icon not replaced. Install with: npm install -g rcedit');
+        console.error('WARNING: rcedit not found -- icon not replaced. Install with: npm install -g rcedit');
       }
     }
   }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -252,6 +252,34 @@ async function handleOAuth(args: string[]): Promise<void> {
 // (apra-fleet-eft.48.8), instead of writing a provider credential file.
 // ---------------------------------------------------------------------------
 
+// apra-fleet-vak.1: unlike parseClaudeOAuthSecret (used for the
+// credentials-FILE path), the env-var path must store ONLY the bare access
+// token string -- it must never synthesize expiresAt/scopes fields, since
+// those belong to the credentials-file session shape, not an env var value.
+// If the resolved secret is a full claudeAiOauth JSON object (or the nested
+// { claudeAiOauth: { accessToken } } wrapper matching the on-disk
+// credentials-file shape), extract just its accessToken. Otherwise pass the
+// secret through unchanged (a bare token, or a non-JSON/invalid-JSON string
+// that merely starts with '{').
+export function extractBearerTokenFromSecret(secret: string): string {
+  const trimmed = secret.trim();
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object') {
+        if (typeof parsed.accessToken === 'string') {
+          return parsed.accessToken;
+        }
+        const nested = (parsed as Record<string, unknown>).claudeAiOauth;
+        if (nested && typeof nested === 'object' && typeof (nested as Record<string, unknown>).accessToken === 'string') {
+          return (nested as Record<string, unknown>).accessToken as string;
+        }
+      }
+    } catch { /* fall through to verbatim pass-through */ }
+  }
+  return secret;
+}
+
 async function provisionEnvVarForMember(provider: string, token: string, memberName: string): Promise<void> {
   if (provider !== 'claude') {
     console.error(`✗ --member provisioning currently only supports provider "claude" (CLAUDE_CODE_OAUTH_TOKEN). Got "${provider}".`);
@@ -271,8 +299,9 @@ async function provisionEnvVarForMember(provider: string, token: string, memberN
   try {
     const { encryptPassword } = await import('../utils/crypto.js');
     const { updateAgent } = await import('../services/registry.js');
+    const bearerToken = extractBearerTokenFromSecret(token);
     const updated = updateAgent(agentOrError.id, {
-      encryptedEnvVars: { ...agentOrError.encryptedEnvVars, [envVarName]: encryptPassword(token) },
+      encryptedEnvVars: { ...agentOrError.encryptedEnvVars, [envVarName]: encryptPassword(bearerToken) },
     });
     if (!updated) {
       console.error(`✗ Failed to update member "${memberName}" -- not found in registry.`);

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -313,18 +313,47 @@ export class ClaudeProvider implements ProviderAdapter {
     const homeFile = isWindows ? '$env:USERPROFILE\\.claude.json' : '$HOME/.claude.json';
     const tmpFile = isWindows ? '$env:USERPROFILE\\.claude.json.fleet-trust-tmp' : '$HOME/.claude.json.fleet-trust-tmp';
 
+    // apra-fleet-9oo: the project's .mcp.json lives in the MEMBER's work folder, not on
+    // the orchestrator host, so it must be read through the same execCommand channel --
+    // never local node:fs. It rides along in the SAME read command as ~/.claude.json:
+    // one round-trip, and (crucially) the already-satisfied case still costs exactly one
+    // exec, so the "no write when nothing to do" contract is observable as before.
+    const mcpFile = `${key}/.mcp.json`;
+    const SPLIT = '---FLEET_MCP_SPLIT---';
+
     const readCmd = isWindows
-      ? `Get-Content -Raw "${homeFile}" -ErrorAction SilentlyContinue`
-      : `cat "${homeFile}" 2>/dev/null || true`;
+      ? `Get-Content -Raw "${homeFile}" -ErrorAction SilentlyContinue; Write-Output "${SPLIT}"; Get-Content -Raw "${mcpFile}" -ErrorAction SilentlyContinue`
+      : `cat "${homeFile}" 2>/dev/null || true; echo "${SPLIT}"; cat "${mcpFile}" 2>/dev/null || true`;
     const readResult = await execCommand(readCmd, 10000);
+
+    // Substring split (not line-split): if ~/.claude.json has no trailing newline the
+    // marker glues onto its closing brace, and only a substring split separates cleanly.
+    // No marker at all -> treat the whole payload as ~/.claude.json with no .mcp.json.
+    const rawStdout = readResult.stdout;
+    const splitIdx = rawStdout.indexOf(SPLIT);
+    const homeRaw = (splitIdx === -1 ? rawStdout : rawStdout.slice(0, splitIdx)).trim();
+    const mcpRaw = (splitIdx === -1 ? '' : rawStdout.slice(splitIdx + SPLIT.length)).trim();
 
     let existing: Record<string, unknown> = {};
     try {
-      const parsed = JSON.parse(readResult.stdout.trim());
+      const parsed = JSON.parse(homeRaw);
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) existing = parsed;
     } catch {
       // File missing, empty, or not JSON -- a member that has never run Claude
       // interactively has no ~/.claude.json at all yet. Start from an empty object.
+    }
+
+    // A missing / unparseable / server-less .mcp.json is NOT an error: seed nothing
+    // extra and fall through to the pre-existing trust-only behaviour.
+    let declaredServers: string[] = [];
+    try {
+      const mcpParsed = JSON.parse(mcpRaw);
+      const servers = mcpParsed?.mcpServers;
+      if (servers && typeof servers === 'object' && !Array.isArray(servers)) {
+        declaredServers = Object.keys(servers);
+      }
+    } catch {
+      // no .mcp.json (or garbage in it) -- trust-only path.
     }
 
     const rawProjects = existing.projects;
@@ -336,15 +365,36 @@ export class ClaudeProvider implements ProviderAdapter {
       ? rawEntry as Record<string, unknown>
       : {};
 
-    if (existingEntry.hasTrustDialogAccepted === true) {
+    // apra-fleet-9oo: trust and MCP-server enablement are computed INDEPENDENTLY, because
+    // an already-trusted member (hasTrustDialogAccepted true) can still be missing its
+    // enabledMcpjsonServers entries -- the old unconditional early return here is exactly
+    // why members never got project MCP servers auto-approved. Short-circuit only when
+    // BOTH are already satisfied.
+    const trustNeeded = existingEntry.hasTrustDialogAccepted !== true;
+
+    const enabled = Array.isArray(existingEntry.enabledMcpjsonServers)
+      ? (existingEntry.enabledMcpjsonServers as unknown[]).filter((n): n is string => typeof n === 'string')
+      : [];
+    const disabled = Array.isArray(existingEntry.disabledMcpjsonServers)
+      ? (existingEntry.disabledMcpjsonServers as unknown[]).filter((n): n is string => typeof n === 'string')
+      : [];
+    // Union-merge, deny wins: keep every existing entry in its existing order, append
+    // only names that are missing (in .mcp.json declaration order, so re-runs are
+    // byte-identical), and NEVER add a name a human explicitly disabled.
+    const serversToAdd = declaredServers.filter(n => !enabled.includes(n) && !disabled.includes(n));
+
+    if (!trustNeeded && serversToAdd.length === 0) {
       console.error(`[claude] workspace trust: already present for "${key}"`);
-      return { seeded: false, detail: `already trusted: ${key}` };
+      return { seeded: false, detail: `already trusted: ${key}`, mcpServersSeeded: [] };
     }
 
     // MERGE: preserve every sibling field already on the project entry (history,
     // allowedTools, etc.) and every other project's entry in the file -- never replace
-    // the entry, or the file, wholesale.
-    const mergedProjects = { ...projects, [key]: { ...existingEntry, hasTrustDialogAccepted: true } };
+    // the entry, or the file, wholesale. Note enabledMcpjsonServers is only written when
+    // something is actually being added -- an absent array is never "tidied" into [].
+    const mergedEntry: Record<string, unknown> = { ...existingEntry, hasTrustDialogAccepted: true };
+    if (serversToAdd.length > 0) mergedEntry.enabledMcpjsonServers = [...enabled, ...serversToAdd];
+    const mergedProjects = { ...projects, [key]: mergedEntry };
     const merged = { ...existing, projects: mergedProjects };
     const contentStr = JSON.stringify(merged, null, 2);
 
@@ -356,8 +406,12 @@ export class ClaudeProvider implements ProviderAdapter {
       : `cat > "${tmpFile}" << 'FLEET_TRUST_EOF'\n${contentStr}\nFLEET_TRUST_EOF\nmv "${tmpFile}" "${homeFile}"`;
     await execCommand(writeCmd, 10000);
 
-    console.error(`[claude] workspace trust: seeded for "${key}"`);
-    return { seeded: true, detail: `seeded trust: ${key}` };
+    const mcpNote = serversToAdd.length > 0 ? `; enabled MCP servers: ${serversToAdd.join(', ')}` : '';
+    console.error(`[claude] workspace trust: seeded for "${key}"${mcpNote}`);
+    const detail = trustNeeded
+      ? `seeded trust: ${key}${mcpNote}`
+      : `already trusted: ${key}${mcpNote}`;
+    return { seeded: trustNeeded, detail, mcpServersSeeded: serversToAdd };
   }
 }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -407,10 +407,13 @@ export class ClaudeProvider implements ProviderAdapter {
     await execCommand(writeCmd, 10000);
 
     const mcpNote = serversToAdd.length > 0 ? `; enabled MCP servers: ${serversToAdd.join(', ')}` : '';
-    console.error(`[claude] workspace trust: seeded for "${key}"${mcpNote}`);
+    // eft.40.1 requires logging distinctly when trust is SEEDED vs already present --
+    // `detail` already encodes that distinction, so log it verbatim rather than
+    // hard-coding "seeded" for the already-trusted/servers-only case.
     const detail = trustNeeded
       ? `seeded trust: ${key}${mcpNote}`
       : `already trusted: ${key}${mcpNote}`;
+    console.error(`[claude] workspace trust: ${detail}`);
     return { seeded: trustNeeded, detail, mcpServersSeeded: serversToAdd };
   }
 }

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -81,6 +81,10 @@ export interface EnsureWorkspaceTrustedResult {
   /** Human-readable detail for logging/audit (apra-fleet-eft.40.1: "log distinctly
    *  when it SEEDS trust vs finds it already present"). */
   detail: string;
+  /** apra-fleet-9oo: names from the project's .mcp.json that this call just ADDED to
+   *  projects[<key>].enabledMcpjsonServers (empty/absent when nothing was added).
+   *  Optional so the non-Claude no-op adapters need no change. */
+  mcpServersSeeded?: string[];
 }
 
 export interface ProviderAdapter {

--- a/src/tools/execute-prompt.ts
+++ b/src/tools/execute-prompt.ts
@@ -137,12 +137,12 @@ function buildFailureMessage(agentName: string, result: SSHExecResult, provider:
   // message, etc.) that would otherwise misclassify it as an auth failure.
   const category: PromptErrorCategory = parsed?.terminalReason === 'max_turns' ? 'max_turns' : provider.classifyError(output);
   if (category === 'max_turns') {
-    return `❌ Prompt on "${agentName}" was stopped after exhausting its turn limit (max_turns), not a genuine failure -- the model ran out of turns before finishing:
+    return `[FAIL] Prompt on "${agentName}" was stopped after exhausting its turn limit (max_turns), not a genuine failure -- the model ran out of turns before finishing:
 ${output}`;
   }
   return category === 'auth'
     ? authErrorAdvice(agentName)
-    : `❌ Prompt failed on "${agentName}":
+    : `[FAIL] Prompt failed on "${agentName}":
 ${output}`;
 }
 
@@ -352,13 +352,13 @@ async function executePromptInteractive(
   const parsed = JSON.parse(sendResult);
   if (parsed.error) {
     scope.abort(`send failed: ${parsed.error}`);
-    return `❌ Failed to deliver prompt to "${agent.friendlyName}" (interactive session): ${parsed.error}`;
+    return `[FAIL] Failed to deliver prompt to "${agent.friendlyName}" (interactive session): ${parsed.error}`;
   }
 
   try {
     const response = await waitForInteractiveResponse(agent, workspaceId, parsed.msgid, timeoutS * 1000, scope);
     scope.ok('interactive response received');
-    let output = `📋 Response from ${agent.friendlyName}:\n\n${response}`;
+    let output = `[RESULT] Response from ${agent.friendlyName}:\n\n${response}`;
     if (heuristicWarningSuffix) output += heuristicWarningSuffix;
     return output;
   } catch (err: any) {
@@ -382,7 +382,7 @@ async function executePromptInteractive(
       sessionRegistry.unregister(workspaceId, agent.id);
       scope.info(`[interactive] timed-out session for "${agent.friendlyName}" has no verifiable live pid (pid=${timedOutPid ?? 'none'}) -- evicting so the next dispatch falls back to subprocess`);
     }
-    return `❌ Timed out waiting for "${agent.friendlyName}" to respond (interactive session, ${timeoutS}s). The prompt was delivered; the member may still respond late, but this call has given up waiting.`;
+    return `[FAIL] Timed out waiting for "${agent.friendlyName}" to respond (interactive session, ${timeoutS}s). The prompt was delivered; the member may still respond late, but this call has given up waiting.`;
   }
 }
 
@@ -420,7 +420,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
   try {
     agent = await ensureCloudReady(agentOrError as Agent); // auto-start if stopped
   } catch (err: any) {
-    return `❌ Failed to execute prompt on "${(agentOrError as Agent).friendlyName}": ${err.message}`;
+    return `[FAIL] Failed to execute prompt on "${(agentOrError as Agent).friendlyName}": ${err.message}`;
   }
 
   // Server-side member reservation enforcement (apra-fleet-eft.10.3): a member
@@ -455,7 +455,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
 
   if (inFlightAgents.has(agent.id)) {
     return {
-      text: `❌ execute_prompt is already running for "${agent.friendlyName}". Wait for the current call to finish before sending another.`,
+      text: `[FAIL] execute_prompt is already running for "${agent.friendlyName}". Wait for the current call to finish before sending another.`,
       structuredContent: { isError: true, reason: 'busy' },
     };
   }
@@ -466,7 +466,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
   // state is entered, rather than relying on NoneProvider's methods to throw
   // deeper in either dispatch path.
   if (agent.llmProvider === 'none') {
-    return `❌ "${agent.friendlyName}" has no LLM provider (llm_provider: "none") -- it is a plain command executor. Use execute_command instead.`;
+    return `[FAIL] "${agent.friendlyName}" has no LLM provider (llm_provider: "none") -- it is a plain command executor. Use execute_command instead.`;
   }
 
   // Interactive routing (apra-fleet-2xs.8/us9.8, docs/cloud-fleet-architecture.md
@@ -677,7 +677,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
       stallDetector.remove(agent.id);
       writeStatusline(new Map([[agent.id, 'idle']]));
       return {
-        text: `❌ execute_prompt on "${agent.friendlyName}" rejected -- session "${explicitResumeId}" cannot be resumed (unknown or expired). No LLM call was made. Rebuild the context and re-dispatch with a full, self-contained prompt (resume=false), or resume=true for best-effort recovery.`,
+        text: `[FAIL] execute_prompt on "${agent.friendlyName}" rejected -- session "${explicitResumeId}" cannot be resumed (unknown or expired). No LLM call was made. Rebuild the context and re-dispatch with a full, self-contained prompt (resume=false), or resume=true for best-effort recovery.`,
         structuredContent: { isError: true, reason: 'session_not_found', sessionId: explicitResumeId },
       };
     }
@@ -784,7 +784,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
       stallDetector.remove(agent.id);
       writeStatusline(new Map([[agent.id, 'idle']]));
       return {
-        text: `❌ execute_prompt on "${agent.friendlyName}" rejected -- insufficient context headroom (demand=${admission.detail.demand}, headroom=${admission.detail.headroom}, window=${admission.detail.window}). Start a fresh session, shrink the task, or split it.`,
+        text: `[FAIL] execute_prompt on "${agent.friendlyName}" rejected -- insufficient context headroom (demand=${admission.detail.demand}, headroom=${admission.detail.headroom}, window=${admission.detail.window}). Start a fresh session, shrink the task, or split it.`,
         structuredContent: { isError: true, reason: 'insufficient_context_headroom', detail: admission.detail },
       };
     }
@@ -807,7 +807,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
       stallDetector.remove(agent.id);
       writeStatusline(new Map([[agent.id, 'idle']]));
       return {
-        text: `❌ execute_prompt on "${agent.friendlyName}" rejected -- budget exhausted (scope=${budgetScope}, spent=${preBudget.block.spent}, budget=${preBudget.block.budget} ${preBudget.block.unit}, source=${preBudget.block.source}). No LLM call was made; raise or reset the budget to resume.`,
+        text: `[FAIL] execute_prompt on "${agent.friendlyName}" rejected -- budget exhausted (scope=${budgetScope}, spent=${preBudget.block.spent}, budget=${preBudget.block.budget} ${preBudget.block.unit}, source=${preBudget.block.source}). No LLM call was made; raise or reset the budget to resume.`,
         structuredContent: { isError: true, reason: 'budget_exhausted', budgetUsage: preBudget.block },
       };
     }
@@ -890,7 +890,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
     // ensureWorkspaceTrusted (apra-fleet-eft.40.1/40.2) as the remediation.
     if (result.code !== 0 && provider.classifyError(result.stderr || result.stdout) === 'workspace_not_trusted') {
       return {
-        text: `❌ ${workspaceNotTrustedAdvice(agent.friendlyName)}\n${result.stderr || result.stdout}`,
+        text: `[FAIL] ${workspaceNotTrustedAdvice(agent.friendlyName)}\n${result.stderr || result.stdout}`,
         structuredContent: { isError: true, reason: 'workspace_not_trusted' },
       };
     }
@@ -980,7 +980,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
       if (recovery.status === 'timeout') {
         scope.info(`orphan recovery timed out after ${Math.round((recovery.waitedMs ?? 0) / 1000)}s -- pid killed`);
         return {
-          text: `❌ execute_prompt on "${agent.friendlyName}" lost its SSH channel while the member CLI (pid ${capturedPid}) was still running, and that process was still alive after the recovery window (${Math.round((recovery.waitedMs ?? 0) / 1000)}s). The process has been killed; no result was recovered. This is NOT an empty response -- do not treat it as a failed turn without checking the member's session transcript first.`,
+          text: `[FAIL] execute_prompt on "${agent.friendlyName}" lost its SSH channel while the member CLI (pid ${capturedPid}) was still running, and that process was still alive after the recovery window (${Math.round((recovery.waitedMs ?? 0) / 1000)}s). The process has been killed; no result was recovered. This is NOT an empty response -- do not treat it as a failed turn without checking the member's session transcript first.`,
           structuredContent: { isError: true, reason: 'orphan_recovery_timeout' },
         };
       }
@@ -999,7 +999,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
       if (!parsed.result || parsed.result.trim() === '') {
         const stderrTail = (result.stderr || '').trim().slice(-500);
         return {
-          text: `❌ execute_prompt on "${agent.friendlyName}" exited 0 but produced no parseable output (empty result -- the member CLI likely died mid-turn without printing its result envelope).${stderrTail ? `\n[stderr tail]\n${stderrTail}` : ''}`,
+          text: `[FAIL] execute_prompt on "${agent.friendlyName}" exited 0 but produced no parseable output (empty result -- the member CLI likely died mid-turn without printing its result envelope).${stderrTail ? `\n[stderr tail]\n${stderrTail}` : ''}`,
           structuredContent: { isError: true, reason: 'empty_response' },
         };
       }
@@ -1056,7 +1056,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
       if (postBudget?.warned) budgetUsage = postBudget.block;
     }
 
-    let output = `📋 Response from ${agent.friendlyName}:
+    let output = `[RESULT] Response from ${agent.friendlyName}:
 
 ${parsed.result}`;
     if (parsed.sessionId) output += `
@@ -1079,7 +1079,7 @@ session: ${parsed.sessionId}`;
     _epOffline = !!(err.message && /ssh|network|econnrefused|ehostunreach|connection timed out/i.test(err.message));
     _epError = err.message;
     return {
-      text: `❌ Failed to execute prompt on "${agent.friendlyName}": ${err.message}`,
+      text: `[FAIL] Failed to execute prompt on "${agent.friendlyName}": ${err.message}`,
       structuredContent: { isError: true, reason: 'dispatch_failed' },
     };
   } finally {

--- a/tests/auth-oauth-secret.test.ts
+++ b/tests/auth-oauth-secret.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { parseClaudeOAuthSecret, runAuth } from '../src/cli/auth.js';
+import { parseClaudeOAuthSecret, extractBearerTokenFromSecret, runAuth } from '../src/cli/auth.js';
 import { checkCleanEnvCredentialsFile, checkMemberEnvVarProvisioned, defaultRegistryPath } from '../scripts/check-toy-doer-credentials.mjs';
 import { addAgent, getAllAgents } from '../src/services/registry.js';
 import { decryptPassword } from '../src/utils/crypto.js';
@@ -220,6 +220,40 @@ describe('handleOAuth / getOAuthCredentialPatch write path (apra-fleet-eft.48.5)
   });
 });
 
+// apra-fleet-vak.1: unlike parseClaudeOAuthSecret (credentials-FILE path,
+// which SYNTHESIZES expiresAt/scopes for bare tokens), the env-var path must
+// extract ONLY the bare accessToken from a JSON-object secret and otherwise
+// pass bare tokens/malformed-JSON-looking strings through byte-identical.
+describe('extractBearerTokenFromSecret', () => {
+  it('extracts accessToken from a full claudeAiOauth JSON object', () => {
+    const full = { accessToken: 'sk-test-access', refreshToken: 'sk-test-refresh', expiresAt: 123, scopes: ['user:inference'] };
+    expect(extractBearerTokenFromSecret(JSON.stringify(full))).toBe('sk-test-access');
+  });
+
+  it('extracts accessToken from a nested { claudeAiOauth: { accessToken } } wrapper', () => {
+    const wrapped = { claudeAiOauth: { accessToken: 'sk-test-nested', expiresAt: 123 } };
+    expect(extractBearerTokenFromSecret(JSON.stringify(wrapped))).toBe('sk-test-nested');
+  });
+
+  it('tolerates surrounding whitespace on a JSON secret', () => {
+    const full = { accessToken: 'sk-a', expiresAt: 123 };
+    expect(extractBearerTokenFromSecret(`  ${JSON.stringify(full)}\n`)).toBe('sk-a');
+  });
+
+  it('passes a bare token through unchanged', () => {
+    expect(extractBearerTokenFromSecret('sk-bare-token')).toBe('sk-bare-token');
+  });
+
+  it('falls back to verbatim pass-through for malformed JSON starting with a brace', () => {
+    expect(extractBearerTokenFromSecret('{not json')).toBe('{not json');
+  });
+
+  it('falls back to verbatim pass-through for valid JSON with no accessToken string', () => {
+    const noToken = JSON.stringify({ expiresAt: 123 });
+    expect(extractBearerTokenFromSecret(noToken)).toBe(noToken);
+  });
+});
+
 // apra-fleet-eft.48.8 (ORCHESTRATOR STEER, post-Integ-C4): `auth --oauth
 // --member <name>` provisions the member's registry.json
 // encryptedEnvVars.CLAUDE_CODE_OAUTH_TOKEN directly instead of writing a
@@ -250,6 +284,25 @@ describe('handleOAuth --member env-var provisioning (apra-fleet-eft.48.8)', () =
     expect(stored).toBeTruthy();
     expect(stored).not.toBe('sk-test-member-envvar-token'); // never plaintext
     expect(decryptPassword(stored!)).toBe('sk-test-member-envvar-token');
+  });
+
+  it('extracts only the bare accessToken when the resolved secret is a full claudeAiOauth JSON object (apra-fleet-vak.1)', async () => {
+    const member = makeTestLocalAgent({ friendlyName: 'toy-doer-json' });
+    addAgent(member);
+    const full = {
+      accessToken: 'sk-test-json-access',
+      refreshToken: 'sk-test-json-refresh',
+      expiresAt: 1999999999999,
+      scopes: ['user:inference'],
+      subscriptionType: 'max',
+    };
+
+    await runAuth(['--oauth', '--member', 'toy-doer-json', JSON.stringify(full)]);
+
+    const updated = getAllAgents().find(a => a.friendlyName === 'toy-doer-json');
+    const stored = updated!.encryptedEnvVars?.CLAUDE_CODE_OAUTH_TOKEN;
+    expect(stored).toBeTruthy();
+    expect(decryptPassword(stored!)).toBe('sk-test-json-access');
   });
 
   it('resolves a secure.<name> credential-store reference rather than accepting plaintext on the command line', async () => {

--- a/tests/check-toy-doer-credentials.test.ts
+++ b/tests/check-toy-doer-credentials.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import crypto from 'node:crypto';
 import {
   CREDENTIAL_ENV_VAR,
   defaultRegistryPath,
@@ -13,6 +14,7 @@ import {
   hasSufficientSessionShape,
   checkMemberEnvVarProvisioned,
   checkCleanEnvCredentialsFile,
+  checkEnvVarNotJsonBlob,
   checkToyDoerCredentialsProvisioned,
 } from '../scripts/check-toy-doer-credentials.mjs';
 
@@ -317,6 +319,80 @@ describe('checkCleanEnvCredentialsFile', () => {
     const result = checkCleanEnvCredentialsFile(tmpDir, { execSync: throwingExecSync });
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/probe failed to run/);
+  });
+});
+
+// apra-fleet-vak.3: verification for apra-fleet-vak.2's checkEnvVarNotJsonBlob
+// (the hard-fail guard that catches a full claudeAiOauth JSON blob stored
+// verbatim in encryptedEnvVars.CLAUDE_CODE_OAUTH_TOKEN instead of the bare
+// accessToken apra-fleet-vak.1's provisionEnvVarForMember is supposed to
+// extract). Ciphertexts here are built with a self-contained AES-256-GCM
+// helper that mirrors decryptEnvVarValue's own 'ivHex:authTagHex:cipherHex'
+// format -- this stubs/injects the decrypt path via a fixture salt file
+// under a fresh temp dir, rather than depending on a real
+// ~/.apra-fleet/data/salt or requiring `npm run build` first.
+describe('checkEnvVarNotJsonBlob (apra-fleet-vak.2, regression for apra-fleet-vak.1)', () => {
+  let tmpDir: string;
+  let saltPath: string;
+  let key: Buffer;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'apra-fleet-toy-doer-creds-jsonblob-test-'));
+    saltPath = path.join(tmpDir, 'salt');
+    key = crypto.randomBytes(32);
+    fs.writeFileSync(saltPath, key.toString('hex'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function encryptForFixture(plaintext: string): string {
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    const authTag = cipher.getAuthTag();
+    return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+  }
+
+  it('plaintext-available + JSON-shaped value -> hard-fails, message mentions apra-fleet-vak', () => {
+    const ciphertext = encryptForFixture(JSON.stringify({ accessToken: 'sk-leaked', expiresAt: 123 }));
+    const result = checkEnvVarNotJsonBlob(ciphertext, { saltPath });
+    expect(result.status).toBe('hard-fail');
+    expect(result.message).toMatch(/apra-fleet-vak/);
+  });
+
+  it('plaintext-available + bare token -> ok', () => {
+    const ciphertext = encryptForFixture('sk-bare-token-value');
+    const result = checkEnvVarNotJsonBlob(ciphertext, { saltPath });
+    expect(result.status).toBe('ok');
+  });
+
+  it('plaintext unavailable (no readable salt) -> indeterminate, not ok-by-default, does not throw', () => {
+    const ciphertext = encryptForFixture('sk-bare-token-value');
+    const missingSaltPath = path.join(tmpDir, 'no-such-salt');
+    expect(() => {
+      const result = checkEnvVarNotJsonBlob(ciphertext, { saltPath: missingSaltPath });
+      expect(result.status).toBe('indeterminate');
+      expect(result.status).not.toBe('ok');
+      expect(result.message).toMatch(/INDETERMINATE/);
+    }).not.toThrow();
+  });
+
+  it('end-to-end via checkMemberEnvVarProvisioned\'s ciphertext field: a JSON-shaped provisioned token is caught from a real registry.json fixture', () => {
+    const registryPath = path.join(tmpDir, 'registry.json');
+    const ciphertext = encryptForFixture(JSON.stringify({ accessToken: 'sk-leaked-e2e', expiresAt: 123 }));
+    fs.writeFileSync(
+      registryPath,
+      JSON.stringify({
+        version: '1.0',
+        agents: [{ friendlyName: 'toy-doer', encryptedEnvVars: { CLAUDE_CODE_OAUTH_TOKEN: ciphertext } }],
+      }),
+    );
+    const envVarCheck = checkMemberEnvVarProvisioned(registryPath, 'toy-doer');
+    expect(envVarCheck.ok).toBe(true);
+    const jsonBlobCheck = checkEnvVarNotJsonBlob(envVarCheck.ciphertext, { saltPath });
+    expect(jsonBlobCheck.status).toBe('hard-fail');
   });
 });
 

--- a/tests/ensure-workspace-trusted.test.ts
+++ b/tests/ensure-workspace-trusted.test.ts
@@ -25,8 +25,17 @@ import type { SSHExecResult } from '../src/types.js';
 
 /** A fake delivery channel standing in for AgentStrategy.execCommand -- tracks a
  *  single virtual remote file (~/.claude.json) across read/write commands, the same
- *  way the real member-side file would evolve across calls. */
-function makeFakeExec(initialFileContent: string | null) {
+ *  way the real member-side file would evolve across calls.
+ *
+ *  apra-fleet-9oo.2: the impl's read command fetches ~/.claude.json AND the project's
+ *  .mcp.json in one round-trip, joined by a literal split marker embedded in the
+ *  command text itself (`echo "${SPLIT}"` / `Write-Output "${SPLIT}"`). Rather than
+ *  hard-coding that marker string here (and drifting if it ever changes), extract it
+ *  straight out of the command being executed -- that's what makes this fake robust to
+ *  the exact marker value while still exercising the impl's real split-on-substring
+ *  parsing. `mcpFileContent` stands in for the project's .mcp.json; pass null/undefined
+ *  to simulate no .mcp.json existing at all. */
+function makeFakeExec(initialFileContent: string | null, mcpFileContent?: string | null) {
   let fileContent: string | null = initialFileContent;
   const calls: string[] = [];
 
@@ -34,7 +43,9 @@ function makeFakeExec(initialFileContent: string | null) {
     calls.push(cmd);
 
     if (cmd.includes('cat "') || cmd.includes('Get-Content')) {
-      return { stdout: fileContent ?? '', stderr: '', code: 0 };
+      const markerMatch = cmd.match(/(?:echo|Write-Output) "([^"]+)"/);
+      const marker = markerMatch ? markerMatch[1] : '---FLEET_MCP_SPLIT---';
+      return { stdout: `${fileContent ?? ''}\n${marker}\n${mcpFileContent ?? ''}`, stderr: '', code: 0 };
     }
 
     const heredocMatch = cmd.match(/<< 'FLEET_TRUST_EOF'\n([\s\S]*?)\nFLEET_TRUST_EOF/);
@@ -170,6 +181,112 @@ describe('ClaudeProvider.ensureWorkspaceTrusted (apra-fleet-eft.40.1)', () => {
 
     expect(result.seeded).toBe(true);
     expect(JSON.parse(getFileContent()!).projects['/home/member/work/project-a'].hasTrustDialogAccepted).toBe(true);
+  });
+});
+
+describe('ClaudeProvider.ensureWorkspaceTrusted -- enabledMcpjsonServers seeding (apra-fleet-9oo.2, regression for apra-fleet-9oo.1)', () => {
+  const mcpJson = JSON.stringify({ mcpServers: { serverA: {}, serverB: {} } });
+
+  it('fresh member: seeds every server name declared in .mcp.json into enabledMcpjsonServers', async () => {
+    const provider = new ClaudeProvider();
+    const { exec, getFileContent } = makeFakeExec(null, mcpJson);
+
+    const result = await provider.ensureWorkspaceTrusted('/home/member/work/project-a', exec, 'linux');
+
+    expect(result.seeded).toBe(true);
+    expect(result.mcpServersSeeded).toEqual(['serverA', 'serverB']);
+    const written = JSON.parse(getFileContent()!);
+    expect(written.projects['/home/member/work/project-a'].enabledMcpjsonServers).toEqual(['serverA', 'serverB']);
+  });
+
+  it('already-trusted member missing servers still gets them seeded (guards against the old early return)', async () => {
+    const provider = new ClaudeProvider();
+    const existing = {
+      projects: {
+        '/home/member/work/project-a': { hasTrustDialogAccepted: true },
+      },
+    };
+    const { exec, getFileContent } = makeFakeExec(JSON.stringify(existing), mcpJson);
+
+    const result = await provider.ensureWorkspaceTrusted('/home/member/work/project-a', exec, 'linux');
+
+    // Trust was already present, so `seeded` (trust-seeded) stays false, but the
+    // servers must still be added -- this is exactly the bug apra-fleet-9oo.1 fixed.
+    expect(result.seeded).toBe(false);
+    expect(result.mcpServersSeeded).toEqual(['serverA', 'serverB']);
+    const written = JSON.parse(getFileContent()!);
+    expect(written.projects['/home/member/work/project-a'].hasTrustDialogAccepted).toBe(true);
+    expect(written.projects['/home/member/work/project-a'].enabledMcpjsonServers).toEqual(['serverA', 'serverB']);
+  });
+
+  it('deny wins: a server listed in disabledMcpjsonServers is never added', async () => {
+    const provider = new ClaudeProvider();
+    const existing = {
+      projects: {
+        '/home/member/work/project-a': { hasTrustDialogAccepted: true, disabledMcpjsonServers: ['serverB'] },
+      },
+    };
+    const { exec, getFileContent } = makeFakeExec(JSON.stringify(existing), mcpJson);
+
+    const result = await provider.ensureWorkspaceTrusted('/home/member/work/project-a', exec, 'linux');
+
+    expect(result.mcpServersSeeded).toEqual(['serverA']);
+    const written = JSON.parse(getFileContent()!);
+    expect(written.projects['/home/member/work/project-a'].enabledMcpjsonServers).toEqual(['serverA']);
+    // The deny list itself is untouched -- still exactly what the human set.
+    expect(written.projects['/home/member/work/project-a'].disabledMcpjsonServers).toEqual(['serverB']);
+  });
+
+  it('idempotent re-run over the post-write state: no duplicates, no clobbering of sibling/other-project fields', async () => {
+    const provider = new ClaudeProvider();
+    const existing = {
+      projects: {
+        '/home/member/work/project-a': { hasTrustDialogAccepted: true, history: ['unrelated'] },
+        '/home/member/work/other-project': { hasTrustDialogAccepted: true, allowedTools: ['Bash'] },
+      },
+    };
+    const { exec, getFileContent } = makeFakeExec(JSON.stringify(existing), mcpJson);
+
+    const first = await provider.ensureWorkspaceTrusted('/home/member/work/project-a', exec, 'linux');
+    expect(first.mcpServersSeeded).toEqual(['serverA', 'serverB']);
+
+    const second = await provider.ensureWorkspaceTrusted('/home/member/work/project-a', exec, 'linux');
+    expect(second.seeded).toBe(false);
+    expect(second.mcpServersSeeded).toEqual([]);
+
+    const written = JSON.parse(getFileContent()!);
+    // No duplicates from the second pass.
+    expect(written.projects['/home/member/work/project-a'].enabledMcpjsonServers).toEqual(['serverA', 'serverB']);
+    // Sibling field on the SAME entry untouched.
+    expect(written.projects['/home/member/work/project-a'].history).toEqual(['unrelated']);
+    // Other project's entry untouched.
+    expect(written.projects['/home/member/work/other-project']).toEqual({ hasTrustDialogAccepted: true, allowedTools: ['Bash'] });
+  });
+
+  it('missing .mcp.json degrades to trust-only behaviour without throwing', async () => {
+    const provider = new ClaudeProvider();
+    const { exec, getFileContent } = makeFakeExec(null, null);
+
+    const result = await provider.ensureWorkspaceTrusted('/home/member/work/project-a', exec, 'linux');
+
+    expect(result.seeded).toBe(true);
+    expect(result.mcpServersSeeded).toEqual([]);
+    const written = JSON.parse(getFileContent()!);
+    expect(written.projects['/home/member/work/project-a'].hasTrustDialogAccepted).toBe(true);
+    expect(written.projects['/home/member/work/project-a'].enabledMcpjsonServers).toBeUndefined();
+  });
+
+  it('unparseable .mcp.json degrades to trust-only behaviour without throwing', async () => {
+    const provider = new ClaudeProvider();
+    const { exec, getFileContent } = makeFakeExec(null, 'not-json-at-all{{{');
+
+    const result = await provider.ensureWorkspaceTrusted('/home/member/work/project-a', exec, 'linux');
+
+    expect(result.seeded).toBe(true);
+    expect(result.mcpServersSeeded).toEqual([]);
+    const written = JSON.parse(getFileContent()!);
+    expect(written.projects['/home/member/work/project-a'].hasTrustDialogAccepted).toBe(true);
+    expect(written.projects['/home/member/work/project-a'].enabledMcpjsonServers).toBeUndefined();
   });
 });
 

--- a/tests/ensure-workspace-trusted.test.ts
+++ b/tests/ensure-workspace-trusted.test.ts
@@ -237,6 +237,24 @@ describe('ClaudeProvider.ensureWorkspaceTrusted -- enabledMcpjsonServers seeding
     expect(written.projects['/home/member/work/project-a'].disabledMcpjsonServers).toEqual(['serverB']);
   });
 
+  it('union-merges into a pre-existing enabledMcpjsonServers list instead of clobbering it', async () => {
+    const provider = new ClaudeProvider();
+    const existing = {
+      projects: {
+        '/home/member/work/project-a': { hasTrustDialogAccepted: true, enabledMcpjsonServers: ['humanAdded'] },
+      },
+    };
+    const { exec, getFileContent } = makeFakeExec(JSON.stringify(existing), mcpJson);
+
+    const result = await provider.ensureWorkspaceTrusted('/home/member/work/project-a', exec, 'linux');
+
+    expect(result.mcpServersSeeded).toEqual(['serverA', 'serverB']);
+    const written = JSON.parse(getFileContent()!);
+    // The human's pre-existing entry is preserved (union), not replaced, and new
+    // servers are appended in declaration order after it.
+    expect(written.projects['/home/member/work/project-a'].enabledMcpjsonServers).toEqual(['humanAdded', 'serverA', 'serverB']);
+  });
+
   it('idempotent re-run over the post-write state: no duplicates, no clobbering of sibling/other-project fields', async () => {
     const provider = new ClaudeProvider();
     const existing = {

--- a/tests/execute-prompt.test.ts
+++ b/tests/execute-prompt.test.ts
@@ -8,6 +8,7 @@ import { writeStatusline } from '../src/services/statusline.js';
 import { getOsCommands } from '../src/os/index.js';
 import type { SSHExecResult } from '../src/types.js';
 import { setBudget, _resetBudgetState } from '../src/services/budget-awareness.js';
+import { recordSessionUsage, _resetSessionUsage, DEFAULT_SIZE_BUCKET_TOKENS } from '../src/services/context-admission.js';
 
 vi.mock('../src/services/statusline.js', () => ({
   writeStatusline: vi.fn(),
@@ -1522,6 +1523,141 @@ describe('budget_exhausted admission gate (apra-fleet-eft.80.3)', () => {
 
     expect(result.structuredContent).not.toMatchObject({ reason: 'budget_exhausted' });
     expect(mockExecCommand).toHaveBeenCalled();
+  });
+});
+
+// apra-fleet-eft.81.2: context-headroom admission control (apra-fleet-eft.81.1)
+// pins the same 3-band decision at the execute_prompt tool boundary: a demand
+// that doesn't fit a resumed session's remaining window rejects BEFORE any
+// spawn; the identical demand against a fresh session passes; a demand that
+// fits the raw window but eats into the reserved safety margin passes with a
+// structured contextWarning attached; and declaring no demand at all (both
+// expected_context_tokens and context_size omitted) is a total no-op --
+// back-compat with every pre-eft.81.1 caller. The "engine supplies bucket"
+// case pins that context_size ('S'/'M'/'L') alone -- with no explicit
+// expected_context_tokens -- is enough to derive the numeric demand used in
+// the admission decision (DEFAULT_SIZE_BUCKET_TOKENS), i.e. a caller (an
+// orchestrating "engine") that only knows a task's S/M/L size metadata still
+// gets a real admission check.
+describe('context-headroom admission gate at the execute_prompt boundary (apra-fleet-eft.81.2)', () => {
+  beforeEach(() => {
+    backupAndResetRegistry();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    _resetSessionUsage();
+  });
+
+  afterEach(() => {
+    restoreRegistry();
+    vi.useRealTimers();
+    _resetSessionUsage();
+  });
+
+  it('rejects with insufficient_context_headroom and makes no LLM call when a resumed session with high cumulative usage cannot fit an L-size demand', async () => {
+    const member = makeTestAgent({ friendlyName: 'context-reject-resumed', sessionId: 'sess-high-cumulative' });
+    addAgent(member);
+    // claude (non-opus) window = 200_000. Cumulative usage of 150_000 leaves
+    // only 50_000 raw remaining -- less than the L bucket's 60_000 demand, so
+    // this does not fit at all (band 3: REJECT), regardless of the 20_000
+    // safety margin.
+    recordSessionUsage('sess-high-cumulative', { input_tokens: 100_000, output_tokens: 50_000 });
+
+    const result = await executePrompt({ member_id: member.id, prompt: 'hi', resume: true, context_size: 'L', timeout_s: 5 });
+
+    expect(result.structuredContent).toMatchObject({
+      isError: true,
+      reason: 'insufficient_context_headroom',
+      detail: { demand: DEFAULT_SIZE_BUCKET_TOKENS.L, window: 200_000 },
+    });
+    expect(resultText(result)).toContain('insufficient context headroom');
+    // The gate sits ahead of writePromptFile/the main exec/deletePromptFile:
+    // the spawn-spy sees zero calls, exactly like the budget_exhausted gate.
+    expect(mockExecCommand).not.toHaveBeenCalled();
+  });
+
+  it('the identical L-size demand against a fresh session (no prior cumulative usage) passes and dispatches normally', async () => {
+    const member = makeTestAgent({ friendlyName: 'context-pass-fresh' });
+    addAgent(member);
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'ok', session_id: 'sess-fresh-ok' }),
+      stderr: '',
+      code: 0,
+    });
+
+    const result = await executePrompt({ member_id: member.id, prompt: 'hi', resume: false, context_size: 'L', timeout_s: 5 });
+
+    expect(result.structuredContent).not.toMatchObject({ isError: true, reason: 'insufficient_context_headroom' });
+    expect((result.structuredContent as any)?.contextWarning).toBeUndefined();
+    expect(mockExecCommand).toHaveBeenCalled();
+  });
+
+  it('a near-margin demand (fits the raw window but eats into the safety margin) still dispatches, with a structured contextWarning attached', async () => {
+    const member = makeTestAgent({ friendlyName: 'context-near-margin', sessionId: 'sess-near-margin' });
+    addAgent(member);
+    // window=200_000, cumulative=145_000 -> rawRemaining=55_000, margin=20_000
+    // -> headroom=35_000. A 40_000-token demand fits the raw remaining window
+    // (55_000) but lands inside the 20_000 safety margin (band 2: ALLOW +
+    // structured warning), not a band-1 comfortable fit and not a band-3 reject.
+    recordSessionUsage('sess-near-margin', { input_tokens: 100_000, output_tokens: 45_000 });
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'ok', session_id: 'sess-near-margin' }),
+      stderr: '',
+      code: 0,
+    });
+
+    const result = await executePrompt({ member_id: member.id, prompt: 'hi', resume: true, expected_context_tokens: 40_000, timeout_s: 5 });
+
+    expect(mockExecCommand).toHaveBeenCalled();
+    expect((result.structuredContent as any)?.contextWarning).toMatchObject({
+      detail: { demand: 40_000, window: 200_000 },
+    });
+    expect((result.structuredContent as any)?.contextWarning?.message).toContain('safety margin');
+  });
+
+  it('back-compat: omitting both expected_context_tokens and context_size skips the admission check entirely -- no rejection, no warning', async () => {
+    const member = makeTestAgent({ friendlyName: 'context-omitted-backcompat', sessionId: 'sess-omitted' });
+    addAgent(member);
+    // Seed a cumulative total that WOULD reject any declared L/M/S demand, to
+    // prove the gate is skipped altogether (not merely "always passes") when
+    // the caller declares no demand at all.
+    recordSessionUsage('sess-omitted', { input_tokens: 190_000, output_tokens: 5_000 });
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'ok', session_id: 'sess-omitted' }),
+      stderr: '',
+      code: 0,
+    });
+
+    const result = await executePrompt({ member_id: member.id, prompt: 'hi', resume: true, timeout_s: 5 });
+
+    expect(result.structuredContent).not.toMatchObject({ isError: true, reason: 'insufficient_context_headroom' });
+    expect((result.structuredContent as any)?.contextWarning).toBeUndefined();
+    expect(mockExecCommand).toHaveBeenCalled();
+  });
+
+  it('engine supplies bucket: context_size alone (no explicit expected_context_tokens) derives the numeric demand from S/M/L size metadata', async () => {
+    const member = makeTestAgent({ friendlyName: 'context-engine-bucket', sessionId: 'sess-engine-bucket' });
+    addAgent(member);
+    // Cumulative usage chosen so the S bucket (4_000) fits comfortably but the
+    // M bucket (20_000) does not fit at all -- this proves the actual bucket
+    // token VALUE (not just "some declared demand") reaches the admission
+    // decision, i.e. the size metadata was really translated into a token
+    // count rather than being ignored.
+    recordSessionUsage('sess-engine-bucket', { input_tokens: 190_000, output_tokens: 0 });
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'ok', session_id: 'sess-engine-bucket' }),
+      stderr: '',
+      code: 0,
+    });
+
+    const passing = await executePrompt({ member_id: member.id, prompt: 'hi', resume: true, context_size: 'S', timeout_s: 5 });
+    expect(passing.structuredContent).not.toMatchObject({ isError: true, reason: 'insufficient_context_headroom' });
+
+    const rejecting = await executePrompt({ member_id: member.id, prompt: 'hi', resume: true, context_size: 'M', timeout_s: 5 });
+    expect(rejecting.structuredContent).toMatchObject({
+      isError: true,
+      reason: 'insufficient_context_headroom',
+      detail: { demand: DEFAULT_SIZE_BUCKET_TOKENS.M },
+    });
   });
 });
 

--- a/tests/package-sea-postject.test.ts
+++ b/tests/package-sea-postject.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  isBenignPostjectStderrLine,
+  filterPostjectStderr,
+  runPostjectFiltered,
+  reportAndCheckPostjectResult,
+} from '../scripts/package-sea.mjs';
+
+// apra-fleet-eft.57.2: postject repeats a KNOWN-BENIGN warning per Linux
+// build against Node 22's ELF sections (see package-sea.mjs's
+// POSTJECT_BENIGN_STDERR_PATTERNS / apra-fleet-eft.57.1). This must be an
+// explicit allowlist of exact benign patterns only -- everything else must
+// pass through verbatim, and a nonzero postject exit must still fail the
+// build. These tests pin: (1) a non-allowlisted stderr line passes through
+// verbatim, (2) a benign allowlisted line is dropped, (3) a nonzero postject
+// exit still fails the build.
+describe('isBenignPostjectStderrLine / filterPostjectStderr', () => {
+  it('recognizes the exact known-benign ELF section warning as benign', () => {
+    expect(isBenignPostjectStderrLine("warning: Can't find string offset for section name '.note'")).toBe(true);
+    expect(isBenignPostjectStderrLine("warning: Can't find string offset for section name '.note.1'")).toBe(true);
+  });
+
+  it('does NOT treat an unrelated stderr line as benign', () => {
+    expect(isBenignPostjectStderrLine('Error: something went wrong')).toBe(false);
+    expect(isBenignPostjectStderrLine("warning: Can't find string offset for section name '.text'")).toBe(false);
+  });
+
+  it('drops only the benign allowlisted line, passing a non-allowlisted line through verbatim', () => {
+    const stderrText = [
+      "warning: Can't find string offset for section name '.note'",
+      'Error: unexpected failure while injecting blob',
+      "warning: Can't find string offset for section name '.note.2'",
+    ].join('\n');
+
+    const filtered = filterPostjectStderr(stderrText);
+
+    expect(filtered).toBe('Error: unexpected failure while injecting blob');
+  });
+
+  it('passes a fully non-allowlisted stderr blob through verbatim, unmodified', () => {
+    const stderrText = 'Error: postject could not locate NODE_SEA_BLOB fuse\nAborting.';
+    expect(filterPostjectStderr(stderrText)).toBe(stderrText);
+  });
+});
+
+describe('runPostjectFiltered', () => {
+  it('filters benign lines out of the captured stderr while preserving status/error', () => {
+    const spawnSyncSpy = vi.fn().mockReturnValue({
+      status: 0,
+      error: undefined,
+      stderr: "warning: Can't find string offset for section name '.note'\n",
+    });
+
+    const result = runPostjectFiltered('npx --yes postject foo', {}, { spawnSync: spawnSyncSpy });
+
+    expect(spawnSyncSpy).toHaveBeenCalled();
+    expect(result.status).toBe(0);
+    expect(result.filteredStderr).toBe('');
+  });
+
+  it('preserves a non-allowlisted stderr line verbatim alongside a nonzero exit status', () => {
+    const spawnSyncSpy = vi.fn().mockReturnValue({
+      status: 1,
+      error: undefined,
+      stderr: 'Error: postject injection failed\n',
+    });
+
+    const result = runPostjectFiltered('npx --yes postject foo', {}, { spawnSync: spawnSyncSpy });
+
+    expect(result.status).toBe(1);
+    expect(result.filteredStderr).toBe('Error: postject injection failed');
+  });
+});
+
+describe('reportAndCheckPostjectResult', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not exit and prints nothing extra when postject succeeds with no residual stderr', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as () => never);
+    const stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    reportAndCheckPostjectResult({ status: 0, error: undefined, filteredStderr: '' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes a non-allowlisted filtered stderr line verbatim even on a successful (zero) exit', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as () => never);
+    const stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    reportAndCheckPostjectResult({ status: 0, error: undefined, filteredStderr: 'Error: something odd but non-fatal' });
+
+    expect(stderrWriteSpy).toHaveBeenCalledWith('Error: something odd but non-fatal\n');
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails the build (non-zero process.exit) when postject exits nonzero, even with no stderr', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as () => never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => reportAndCheckPostjectResult({ status: 1, error: undefined, filteredStderr: '' })).toThrow('exit:1');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errorSpy.mockRestore();
+  });
+
+  it('throws the underlying spawn error (e.g. ENOENT) rather than swallowing it', () => {
+    const spawnError = new Error('spawnSync npx ENOENT');
+
+    expect(() => reportAndCheckPostjectResult({ status: null, error: spawnError, filteredStderr: '' })).toThrow('spawnSync npx ENOENT');
+  });
+});


### PR DESCRIPTION
Automated apra-fleet-se sprint ABORTED before reaching a final PASS/FAIL verdict.

Error code: REVIEWER_CONTRACT_VIOLATION
Error message: Reviewer returned CHANGES_NEEDED with empty reopenIds AND empty newTasks twice in a row (cycle 1) -- a self-contradictory verdict with nothing for the orchestrator to act on. Refusing to let this silently accumulate toward stall-abort.
Error details: cycle :1, notes : Missing required review input: base-branch was not supplied. The dispatch prompt (.fleet-task.md) contained only a schema-correction re-ask, with no base-branch, no branch, and no bead ids to review, so no diff could be taken and no acceptance criteria could be checked. Per the reviewer contract's missing-input rule, I am not guessing a branch name. Context for a correct re-dispatch: this session ran as a DOER on branch feat/lhf-batch-a and completed three beads -- apra-fleet-3e8 (commit 4cc4828: ASCII sweep of src/tools/execute-prompt.ts and scripts/package-sea.mjs), apra-fleet-eft.57.2 (commit 0701910: tests/package-sea-postject.test.ts, 10 tests for postject stderr filtering and nonzero-exit build failure), and apra-fleet-eft.81.2 (commit cc064dc: 5 context-headroom admission tests in tests/execute-prompt.test.ts). npm run build was clean, a full npm test run was green (196 files passed / 7 skipped; 2747 tests passed / 34 skipped; 0 failed), and the working tree is clean. Nothing has been pushed. Re-dispatch with base-branch, branch, and bead ids for a real review verdict; or re-dispatch with the doer output schema (status/closedIds/notes) if a doer report was intended.

Do NOT auto-merge -- see pm skill R12; a human must review and merge this PR.