### PR TITLE
fix: v0.4.0 release-gate fixes -- two CI flakes + graceful degrade for missing claude CLI

### DIFF
--- a/docs/release-notes-v0.4.0.md
+++ b/docs/release-notes-v0.4.0.md
@@ -197,6 +197,13 @@ sprints:
   `docs/missing-grant-recovery-and-playbook-evolution.md`. Until that lands,
   granting a role's permissions is still a manual `settings.json` /
   `settings.local.json` edit.
+- `apra-fleet install` (default `--llm claude`) registers its MCP server by
+  shelling out to `claude mcp add`. If the `claude` CLI is not yet on your
+  PATH when you run install, this fails hard instead of degrading
+  gracefully. Install Claude Code first, then run `apra-fleet install` (or
+  re-run it after installing Claude Code) -- or pass `--llm <provider>` /
+  `--transport http` for a setup that does not require the `claude` binary
+  at install time. A graceful-degrade fix is planned as a follow-up.
 
 ## Upgrade
 

--- a/packages/apra-fleet-se/test/supervisor-dashboard-integration.test.mjs
+++ b/packages/apra-fleet-se/test/supervisor-dashboard-integration.test.mjs
@@ -362,7 +362,15 @@ describe('dashboard integration (apra-fleet-eft.6.6) -- stack, backlog, launch, 
         assert.ok(htmlRes.headers['content-type'].includes('text/html'));
         const prefix = `/sprints/${sprintId}/live`;
         assert.ok(htmlRes.body.includes(`'${prefix}/events'`), htmlRes.body);
-        assert.ok(!htmlRes.body.includes(String(childPort)), 'the real child port must never leak into the served HTML');
+        // Boundary-aware, not a bare substring check: childPort is an
+        // OS-assigned ephemeral port (an arbitrary integer), and a raw
+        // .includes() can coincidentally match its digits inside an
+        // unrelated number already on the page (a PID, timestamp, byte
+        // count) -- a false-positive flake with zero real leak, since the
+        // rewrite (src/supervisor/proxy.mjs) never touches or embeds the
+        // port at all. Assert the port never appears as a standalone number.
+        const portLeakPattern = new RegExp(`(?<!\\d)${childPort}(?!\\d)`);
+        assert.ok(!portLeakPattern.test(htmlRes.body), 'the real child port must never leak into the served HTML');
 
         // SSE: the first event must arrive before the (never-ending) stream
         // closes -- proving incremental, non-buffered delivery through the

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -684,6 +684,19 @@ function run(cmd: string, opts?: Record<string, unknown>): void {
   execSync(cmd, { stdio: 'inherit', ...shellOpt, ...opts });
 }
 
+/** Is `cmd` resolvable on PATH? Used before shelling out to a provider's own
+ *  CLI (e.g. `claude`) so a missing binary degrades to a clear warning
+ *  instead of install crashing with a raw "Command failed" error. */
+function isCommandAvailable(cmd: string): boolean {
+  try {
+    const checkCmd = process.platform === 'win32' ? `where ${cmd}` : `command -v ${cmd}`;
+    execSync(checkCmd, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function isApraFleetRunning(): boolean {
   try {
     if (process.platform === 'win32') {
@@ -1077,10 +1090,19 @@ ${process.platform === 'win32' ? '    taskkill /F /IM apra-fleet.exe' : '    pki
 
   if (transport === 'http') {
     if (llm === 'claude') {
-      try {
-        run('claude mcp remove apra-fleet --scope user', { stdio: 'ignore' });
-      } catch { /* not registered */ }
-      run(`claude mcp add --scope user --transport http apra-fleet ${fleetUrl}`);
+      if (!isCommandAvailable('claude')) {
+        console.warn(
+          `  Warning: the 'claude' CLI was not found on PATH -- skipping MCP server registration.\n` +
+          `  Install Claude Code (https://claude.com/claude-code), then re-run 'apra-fleet install'\n` +
+          `  to register apra-fleet with it, or register manually with:\n` +
+          `    claude mcp add --scope user --transport http apra-fleet ${fleetUrl}`
+        );
+      } else {
+        try {
+          run('claude mcp remove apra-fleet --scope user', { stdio: 'ignore' });
+        } catch { /* not registered */ }
+        run(`claude mcp add --scope user --transport http apra-fleet ${fleetUrl}`);
+      }
     } else if (llm === 'gemini') {
       mergeGeminiConfig(paths, { httpUrl: fleetUrl });
     } else if (llm === 'codex') {
@@ -1103,15 +1125,23 @@ ${process.platform === 'win32' ? '    taskkill /F /IM apra-fleet.exe' : '    pki
       : { command: 'node', args: [path.join(findProjectRoot(), 'dist', 'index.js'), 'run', '--transport', 'stdio'] };
 
     if (llm === 'claude') {
-      try {
-        run('claude mcp remove apra-fleet --scope user', { stdio: 'ignore' });
-      } catch { /* not registered */ }
-
       // Build the claude MCP command from the actual mcpConfig structure.
       // All args are quoted and joined so paths with spaces (e.g. Windows "Program Files") work.
       const quotedArgs = mcpConfig.args.map((a: string) => `"${a.replace(/"/g, '\\"')}"`).join(' ');
       const cmd = `claude mcp add --scope user apra-fleet -- "${mcpConfig.command}" ${quotedArgs}`;
-      run(cmd);
+      if (!isCommandAvailable('claude')) {
+        console.warn(
+          `  Warning: the 'claude' CLI was not found on PATH -- skipping MCP server registration.\n` +
+          `  Install Claude Code (https://claude.com/claude-code), then re-run 'apra-fleet install'\n` +
+          `  to register apra-fleet with it, or register manually with:\n` +
+          `    ${cmd}`
+        );
+      } else {
+        try {
+          run('claude mcp remove apra-fleet --scope user', { stdio: 'ignore' });
+        } catch { /* not registered */ }
+        run(cmd);
+      }
     } else if (llm === 'gemini') {
       mergeGeminiConfig(paths, mcpConfig);
     } else if (llm === 'codex') {

--- a/tests/install-multi-provider.test.ts
+++ b/tests/install-multi-provider.test.ts
@@ -66,6 +66,40 @@ describe('runInstall multi-provider', () => {
     );
   });
 
+  it('degrades gracefully (warns, does not throw, does not run claude mcp add) when the claude CLI is not on PATH', async () => {
+    vi.mocked(execSync).mockImplementation((cmd: any) => {
+      const cmdStr = cmd.toString();
+      if (cmdStr.includes('where claude') || cmdStr === 'command -v claude') {
+        throw new Error('command not found');
+      }
+      return Buffer.from('');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(runInstall([])).resolves.not.toThrow();
+
+    // Never attempted to actually register or remove the MCP server
+    const claudeMcpCalls = vi.mocked(execSync).mock.calls.filter(c => c[0].toString().includes('claude mcp'));
+    expect(claudeMcpCalls).toHaveLength(0);
+
+    // Warned clearly instead of crashing silently or swallowing the gap
+    expect(warnSpy.mock.calls.some(c => c.join(' ').includes("'claude' CLI was not found on PATH"))).toBe(true);
+
+    // Install still completed the rest of its steps (e.g. Claude settings written)
+    const claudeSettings = path.join(mockHome, '.claude', 'settings.json');
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining(claudeSettings),
+      expect.any(String)
+    );
+
+    warnSpy.mockRestore();
+    // Restore the default no-throw implementation -- beforeEach only calls
+    // clearAllMocks() (clears call history), not resetAllMocks(), so a
+    // custom mockImplementation set here would otherwise leak into every
+    // later test in this file.
+    vi.mocked(execSync).mockImplementation(() => Buffer.from(''));
+  });
+
   it('installs for Gemini when --llm gemini is passed', async () => {
     await runInstall(['--llm', 'gemini']);
     

--- a/tests/undici-pack-install.test.ts
+++ b/tests/undici-pack-install.test.ts
@@ -29,9 +29,16 @@ describe('npm-packed install resolves undici 7.x (apra-fleet-0v0.6 regression)',
 
   let result: PackInstallResult | undefined;
 
+  // Explicit timeout: cleanup recursively deletes a full npm-installed
+  // node_modules tree via fs.rmSync, which can exceed vitest's default 10s
+  // hookTimeout on Windows CI runners (slower filesystem I/O, antivirus
+  // scanning) even though the test itself already passed -- observed live
+  // on windows-latest for commit de48e98c (the assertion passed in 83.5s;
+  // only this hook timed out). 30s matches the margin the test body itself
+  // is given (see the 5-minute test-level timeout below).
   afterAll(() => {
     result?.cleanup();
-  });
+  }, 30_000);
 
   it(
     'installs the packed tarball into a fresh consumer project and resolves undici to 7.x with no markAsUncloneable crash',


### PR DESCRIPTION
## Summary

Three fixes surfaced and root-caused while gating the v0.4.0 release tag, none of which were papered over with a rerun:

1. **`supervisor-dashboard-integration.test.mjs` (macOS flake)**: the "no port leak" assertion used a bare `String.includes(childPort)` against an OS-assigned ephemeral port -- an arbitrary integer whose digits can coincidentally collide with unrelated numbers already on the page (PIDs, timestamps, byte counts). The rewrite it guards (`src/supervisor/proxy.mjs`) never touches or embeds the port at all, so this was a false-positive by construction. Now a boundary-aware regex match.

2. **`tests/undici-pack-install.test.ts` (Windows flake)**: the undici-7.x assertion itself passed (confirmed in the failing run's own log, 83.5s). Only the `afterAll` cleanup hook (recursively deleting a full npm-installed `node_modules` tree) exceeded vitest's default 10s `hookTimeout` on Windows I/O. Explicit 30s timeout added.

3. **`apra-fleet install` crashes when the target LLM CLI isn't on PATH** (real bug, not a flake): default `--llm claude` shells out to `claude mcp add` unconditionally with no PATH check -- surfaced by the brand-new npm-publish smoke-test step (added this cycle) running a real install on a bare CI runner with no `claude` CLI present. Also a genuine end-user issue for anyone installing this package before installing Claude Code. Now checks `isCommandAvailable('claude')` first; when missing, warns with the manual registration command and continues the rest of install instead of crashing.

Also independently re-verified the undici pin is genuinely solid (not just re-reading logs): ran a clean `npm ci` on this Windows machine matching CI exactly, confirmed no lockfile-mismatch warnings, confirmed `require('undici')` doesn't crash, and both real regression test files pass fresh.

## Validation

- `npx tsc --noEmit -p .` -- clean
- Full root `npx vitest run` -- 2949 passed, 0 failed, 33 skipped
- All install-related suites (`install-multi-provider`, `install-force`, `install-npm`, `install-service`, `claude-provider-mcp-endpoint`, `uninstall`) -- 176 passed
- `supervisor-dashboard-integration.test.mjs` -- 8/8 passed locally with the fixed assertion
- Clean `npm ci` + fresh run of `tests/undici-pack-install.test.ts` + `tests/undici-node20-compat.test.ts` -- both pass

## Test plan

- [x] tsc clean
- [x] full root vitest suite green
- [x] all install-* suites green, including the new graceful-degrade regression test
- [ ] a real CI tag-push run confirms the npm-publish smoke test now completes past MCP registration