### PR TITLE
docs: relabel README top-nav link from Docs to Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ workforce -- on any machine, anywhere, using every LLM provider at once.
 [![MCP](https://img.shields.io/badge/MCP-compatible-8A2BE2.svg)](https://modelcontextprotocol.io)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Apra-Labs/apra-fleet)
 
-[Quick Start](#quick-start-5-minutes) - [Live Demo](#watch-a-fleet-work) - [How It Works](#how-it-works) - [fleet-sprint Getting Started Guide](docs/fleet-sprint-getting-started.md) - [Docs](https://apra-labs.github.io/apra-fleet)
+[Quick Start](#quick-start-5-minutes) - [Live Demo](#watch-a-fleet-work) - [How It Works](#how-it-works) - [fleet-sprint Getting Started Guide](docs/fleet-sprint-getting-started.md) - [Website](https://apra-labs.github.io/apra-fleet)
 
 </div>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22,7 +22,7 @@ workforce -- on any machine, anywhere, using every LLM provider at once.
 [![MCP](https://img.shields.io/badge/MCP-compatible-8A2BE2.svg)](https://modelcontextprotocol.io)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Apra-Labs/apra-fleet)
 
-[Quick Start](#quick-start-5-minutes) - [Live Demo](#watch-a-fleet-work) - [How It Works](#how-it-works) - [fleet-sprint Getting Started Guide](docs/fleet-sprint-getting-started.md) - [Docs](https://apra-labs.github.io/apra-fleet)
+[Quick Start](#quick-start-5-minutes) - [Live Demo](#watch-a-fleet-work) - [How It Works](#how-it-works) - [fleet-sprint Getting Started Guide](docs/fleet-sprint-getting-started.md) - [Website](https://apra-labs.github.io/apra-fleet)
 
 </div>
 


### PR DESCRIPTION
Relabels the top-nav link (pointing at https://apra-labs.github.io/apra-fleet) from "Docs" to "Website" -- it's the marketing landing page, not API/reference docs. Also includes the pre-commit-regenerated llms-full.txt.