### PR TITLE
docs: host fleet-sprint getting-started guide on GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ apra-fleet workflow fleet-sprint \
 Open the dashboard, watch your fleet PLAN->BUILD->REVIEW->TEST->SHIP in a loop till closure
 
 > **New to fleet-sprint?** Read the
-> [fleet-sprint Getting Started Guide](docs/fleet-sprint-getting-started.md)
-> ([HTML](docs/fleet-sprint-getting-started.html) -
-> [PDF](docs/fleet-sprint-getting-started.pdf)) -- a plain-English walkthrough
+> [fleet-sprint Getting Started Guide](https://apra-labs.github.io/apra-fleet/fleet-sprint-getting-started.html)
+> ([Markdown](docs/fleet-sprint-getting-started.md) if you're reading this on
+> GitHub -- [PDF](docs/fleet-sprint-getting-started.pdf)) -- a plain-English walkthrough
 > of what it does, what you need to prepare (beads backlog, `deploy.md`,
 > test playbooks, member registration), how to launch and monitor a sprint,
 > and what's automated versus what's still your call.
@@ -273,7 +273,7 @@ third-party verticals.
 
 | Topic | Link |
 |-------|------|
-| **fleet-sprint Getting Started Guide (start here, plain English)** | [Markdown](docs/fleet-sprint-getting-started.md) - [HTML](docs/fleet-sprint-getting-started.html) - [PDF](docs/fleet-sprint-getting-started.pdf) |
+| **fleet-sprint Getting Started Guide (start here, plain English)** | [Website](https://apra-labs.github.io/apra-fleet/fleet-sprint-getting-started.html) - [Markdown](docs/fleet-sprint-getting-started.md) - [PDF](docs/fleet-sprint-getting-started.pdf) |
 | Codebase wiki (architecture, internals, AI Q&A) | [DeepWiki](https://deepwiki.com/Apra-Labs/apra-fleet) |
 | Install, uninstall, the `--llm` flag | [docs/install.md](docs/install.md) |
 | Choosing a provider (roles, gotchas, mixing providers, OpenCode/local models) | [docs/provider-guide.md](docs/provider-guide.md) |

--- a/docs/site/fleet-sprint-getting-started.html
+++ b/docs/site/fleet-sprint-getting-started.html
@@ -1506,8 +1506,8 @@
 
   <figure>
     <div class="frame">
-      <img class="art-light" src="../assets/marketing/fleet-topology-light.svg" alt="apra-fleet topology: a control plane dispatching agent work to registered members across machines and providers." loading="lazy">
-      <img class="art-dark" src="../assets/marketing/fleet-topology-dark.svg" alt="apra-fleet topology: a control plane dispatching agent work to registered members across machines and providers." loading="lazy">
+      <img class="art-light" src="../../assets/marketing/fleet-topology-light.svg" alt="apra-fleet topology: a control plane dispatching agent work to registered members across machines and providers." loading="lazy">
+      <img class="art-dark" src="../../assets/marketing/fleet-topology-dark.svg" alt="apra-fleet topology: a control plane dispatching agent work to registered members across machines and providers." loading="lazy">
     </div>
     <figcaption>assets/marketing/fleet-topology-{light,dark}.svg</figcaption>
   </figure>
@@ -1573,28 +1573,28 @@ dist/apra-fleet-installer-win-x64.exe install --force
 
   <figure>
     <div class="frame">
-      <img src="../assets/marketing/supervisor-sprints.png" alt="Supervisor index, Sprints tab: the running sprint with its health badge, branch, goal, claimed bead scope and members, plus per-sprint Open live view, Raw log, Stop and Restart controls." loading="lazy">
+      <img src="../../assets/marketing/supervisor-sprints.png" alt="Supervisor index, Sprints tab: the running sprint with its health badge, branch, goal, claimed bead scope and members, plus per-sprint Open live view, Raw log, Stop and Restart controls." loading="lazy">
     </div>
     <figcaption>assets/marketing/supervisor-sprints.png &mdash; supervisor index, Sprints tab (http://localhost:8787)</figcaption>
   </figure>
 
   <figure>
     <div class="frame">
-      <img src="../assets/marketing/supervisor-backlog.png" alt="Supervisor index, Backlog tab: the bead backlog as a filterable table with search and type, status, priority and model filters, each row showing its issue type, status, priority and assigned model tier." loading="lazy">
+      <img src="../../assets/marketing/supervisor-backlog.png" alt="Supervisor index, Backlog tab: the bead backlog as a filterable table with search and type, status, priority and model filters, each row showing its issue type, status, priority and assigned model tier." loading="lazy">
     </div>
     <figcaption>assets/marketing/supervisor-backlog.png &mdash; supervisor index, Backlog tab</figcaption>
   </figure>
 
   <figure>
     <div class="frame">
-      <img src="../assets/marketing/supervisor-launch-form.png" alt="The Launch Sprint panel at the foot of the Backlog tab: a member list with a role dropdown per member, a goal selector, branch and base-branch fields, an override-relaunch-gate checkbox and a Launch Sprint button." loading="lazy">
+      <img src="../../assets/marketing/supervisor-launch-form.png" alt="The Launch Sprint panel at the foot of the Backlog tab: a member list with a role dropdown per member, a goal selector, branch and base-branch fields, an override-relaunch-gate checkbox and a Launch Sprint button." loading="lazy">
     </div>
     <figcaption>assets/marketing/supervisor-launch-form.png &mdash; the Launch Sprint panel, at the foot of the Backlog tab</figcaption>
   </figure>
 
   <figure>
     <div class="frame">
-      <img src="../assets/marketing/sprint-live-view.png" alt="A sprint's live view: activity tree of commands and agent dispatches grouped by sprint cycle and phase, each row timestamped with its duration, model tier and success, failed or running status, above a header showing activity count, dollars spent, tokens and uptime." loading="lazy">
+      <img src="../../assets/marketing/sprint-live-view.png" alt="A sprint's live view: activity tree of commands and agent dispatches grouped by sprint cycle and phase, each row timestamped with its duration, model tier and success, failed or running status, above a header showing activity count, dollars spent, tokens and uptime." loading="lazy">
     </div>
     <figcaption>assets/marketing/sprint-live-view.png &mdash; a sprint's live view, Activity Tree tab</figcaption>
   </figure>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -146,9 +146,9 @@ apra-fleet workflow fleet-sprint \
 Open the dashboard, watch your fleet PLAN->BUILD->REVIEW->TEST->SHIP in a loop till closure
 
 > **New to fleet-sprint?** Read the
-> [fleet-sprint Getting Started Guide](docs/fleet-sprint-getting-started.md)
-> ([HTML](docs/fleet-sprint-getting-started.html) -
-> [PDF](docs/fleet-sprint-getting-started.pdf)) -- a plain-English walkthrough
+> [fleet-sprint Getting Started Guide](https://apra-labs.github.io/apra-fleet/fleet-sprint-getting-started.html)
+> ([Markdown](docs/fleet-sprint-getting-started.md) if you're reading this on
+> GitHub -- [PDF](docs/fleet-sprint-getting-started.pdf)) -- a plain-English walkthrough
 > of what it does, what you need to prepare (beads backlog, `deploy.md`,
 > test playbooks, member registration), how to launch and monitor a sprint,
 > and what's automated versus what's still your call.
@@ -276,7 +276,7 @@ third-party verticals.
 
 | Topic | Link |
 |-------|------|
-| **fleet-sprint Getting Started Guide (start here, plain English)** | [Markdown](docs/fleet-sprint-getting-started.md) - [HTML](docs/fleet-sprint-getting-started.html) - [PDF](docs/fleet-sprint-getting-started.pdf) |
+| **fleet-sprint Getting Started Guide (start here, plain English)** | [Website](https://apra-labs.github.io/apra-fleet/fleet-sprint-getting-started.html) - [Markdown](docs/fleet-sprint-getting-started.md) - [PDF](docs/fleet-sprint-getting-started.pdf) |
 | Codebase wiki (architecture, internals, AI Q&A) | [DeepWiki](https://deepwiki.com/Apra-Labs/apra-fleet) |
 | Install, uninstall, the `--llm` flag | [docs/install.md](docs/install.md) |
 | Choosing a provider (roles, gotchas, mixing providers, OpenCode/local models) | [docs/provider-guide.md](docs/provider-guide.md) |


### PR DESCRIPTION
## Summary
- Moves \`docs/fleet-sprint-getting-started.html\` into \`docs/site/\` so it renders as a real webpage via GitHub Pages instead of showing raw source when opened directly on github.com.
- Fixes its 6 relative asset references (\`../assets/marketing/*\` -> \`../../assets/marketing/*\`) for the new location.
- README's two links to the guide now point at the GitHub Pages URL as primary; the Markdown version is kept as an explicit fallback ("if you're reading this on GitHub" -- Markdown renders natively there, HTML doesn't). PDF link unchanged.
- \`packages/apra-fleet-se/apra-pm/docs/auto-sprint-slides.html\` deliberately NOT touched (obsolete concept, staying unlinked, out of scope per explicit direction).

## Test plan
- [x] Verified all 6 asset paths resolve (200) from the new location via local static server + Chrome, including confirming the lazy-loaded images (\`loading="lazy"\`) actually fetch successfully, not just appearing broken due to lazy-load timing.
- [x] Confirmed no other file in the repo references the old \`docs/fleet-sprint-getting-started.html\` path.
- [ ] After merge + Pages redeploy: confirm \`https://apra-labs.github.io/apra-fleet/fleet-sprint-getting-started.html\` renders (deploy is currently blocked by the ongoing GitHub Actions platform outage, not by anything in this change).