### PR TITLE
fix(test): update uninstall dry-run fixture for fleet-supervisor skill

### DIFF
--- a/tests/fixtures/regression-command-surface/uninstall-dry-run.txt
+++ b/tests/fixtures/regression-command-surface/uninstall-dry-run.txt
@@ -7,6 +7,7 @@ Cleaning up Claude...
   - Removing auto-sprint-args skill: {ARGS_SKILL_DIR}
   - Removing PM agent files: {AGENTS_DIR}
   - Removing fleet-sprint-cli skill: {CLI_SKILL_DIR}
+  - Removing fleet-supervisor skill: {SUPERVISOR_SKILL_DIR}
   - Removing fleet skills: {FLEET_SKILLS_DIR}
 Cleaning up workflow subsystem...
   - Removing workflow runtime: {NODE_MODULES_DIR}

--- a/tests/uninstall.test.ts
+++ b/tests/uninstall.test.ts
@@ -91,6 +91,7 @@ describe('uninstall', () => {
       PM_SKILLS_DIR: claudePaths.skillsDir,
       ARGS_SKILL_DIR: path.join(claudePaths.configDir, 'skills', 'auto-sprint-args'),
       CLI_SKILL_DIR: path.join(claudePaths.configDir, 'skills', 'fleet-sprint-cli'),
+      SUPERVISOR_SKILL_DIR: path.join(claudePaths.configDir, 'skills', 'fleet-supervisor'),
       AGENTS_DIR: claudePaths.agentsDir!,
       FLEET_SKILLS_DIR: claudePaths.fleetSkillsDir,
       NODE_MODULES_DIR: config.NODE_MODULES_DIR,


### PR DESCRIPTION
## Summary
Fixes CI failure in [run 31771148402](https://github.com/Apra-Labs/apra-fleet/actions/runs/31771148402) (PR #409, all 3 OS jobs).

Commit c2827db1 on this branch renamed/split the `fleet-sprint-cli` helper skill install to also install a new `fleet-supervisor` skill, and updated `src/cli/uninstall.ts` to print/remove it (`Removing fleet-supervisor skill: ...`). It did not update the byte-for-byte `tests/fixtures/regression-command-surface/uninstall-dry-run.txt` regression fixture used by `tests/uninstall.test.ts`'s apra-fleet-7pm.14 guard, so the fixture-equality assertion failed everywhere in CI.

## Fix
- Added the missing `- Removing fleet-supervisor skill: {SUPERVISOR_SKILL_DIR}` line to `tests/fixtures/regression-command-surface/uninstall-dry-run.txt`.
- Added the corresponding `SUPERVISOR_SKILL_DIR` placeholder fill in `tests/uninstall.test.ts`.

## Test plan
- [x] `npx vitest run tests/uninstall.test.ts` -- 22/22 passing
- [ ] Full `npm test` (running in background at review time)