### PR TITLE
fix(tests): raise EBUSY cleanup retry budget for Windows embeddeddolt sandbox test

### DIFF
--- a/tests/check-sandbox-sync-remote.test.ts
+++ b/tests/check-sandbox-sync-remote.test.ts
@@ -434,10 +434,17 @@ describe('checkDoltRemoteAbsent: Dolt-level remote resolves-inside-sandbox (apra
       expect(result.message).toMatch(/Dolt-level remotes|unavailable/);
 
     } finally {
-      // Clean up: on Windows, file locks may persist briefly after the function call,
-      // so retry cleanup with delays to allow locks to be released.
+      // Clean up: on Windows, file locks may persist after the function call --
+      // this test spawns a REAL `bd` (no execFileSync injected), and bd's own
+      // dolt process can take longer than a few hundred ms to release its
+      // handle on tmpDir under CI load (observed live: a loaded windows-latest
+      // runner still held the lock past a 10x50ms=500ms budget -- see
+      // EBUSY_RETRY_DELAY_MS=200 in src/cli/workflow-assets.ts for the same
+      // class of Windows EBUSY retry elsewhere in this codebase). 30x200ms=6s
+      // gives real headroom without slowing the common (already-released) case,
+      // since the loop exits on the first successful attempt.
       if (tmpDir) {
-        const cleanupAttempts = 10;
+        const cleanupAttempts = 30;
         for (let i = 0; i < cleanupAttempts; i++) {
           try {
             fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -445,7 +452,7 @@ describe('checkDoltRemoteAbsent: Dolt-level remote resolves-inside-sandbox (apra
           } catch (err) {
             if (i === cleanupAttempts - 1) throw err;
             // Small delay before retry to allow file handles to be released
-            await new Promise((resolve) => setTimeout(resolve, 50));
+            await new Promise((resolve) => setTimeout(resolve, 200));
           }
         }
       }


### PR DESCRIPTION
## Summary
- Main's CI failed twice in a row on the windows-latest runner at `tests/check-sandbox-sync-remote.test.ts:443` with `EBUSY: resource busy or locked, rmdir '...\toy-repo'` -- content was byte-identical to a commit that already passed CI (including windows) as part of PR #409, so this is a Windows-only test-cleanup race, not a real regression.
- The test spawns a real `bd` (no injected `execFileSync`); its dolt process can hold a handle on the temp dir past the previous 10x50ms=500ms cleanup retry budget under a loaded CI runner.
- Raised the budget to 30x200ms=6s, matching the `EBUSY_RETRY_DELAY_MS=200` precedent already used for the same class of Windows lock retry in `src/cli/workflow-assets.ts`.

## Test plan
- [x] Reproduced the failure via `gh run view` logs on two consecutive main CI runs (31915909187, both attempts)
- [x] Root-caused to the vitest suite (not the apra-fleet-se node:test suite, which reported pass=2114/fail=0 both times -- the SUMMARY line was a red herring since `scripts/run-all-tests.mjs` runs both suites unconditionally)
- [ ] CI green on this PR (pending)