### PR TITLE
fix(member-home): encode Windows USERPROFILE probe to survive a PowerShell default shell

### DIFF
--- a/src/services/member-home.ts
+++ b/src/services/member-home.ts
@@ -30,6 +30,7 @@ import { getStrategy } from './strategy.js';
 import { getAgentOS } from '../utils/agent-helpers.js';
 import { logWarn } from '../utils/log-helpers.js';
 import { getProvider } from '../providers/index.js';
+import { wrapPowerShellEncoded } from '../os/windows.js';
 
 /** memberId -> resolved home directory. Successful probes only. */
 const homeDirCache = new Map<string, string>();
@@ -43,16 +44,20 @@ const PROBE_TIMEOUT_MS = 10_000;
  *  - Windows: `%USERPROFILE%` is the canonical Windows home and is what the
  *    codebase already uses member-side for exactly this purpose -- see
  *    ClaudeProvider.ensureWorkspaceTrusted (`$env:USERPROFILE\.claude.json`) and
- *    AgyProvider's SCRIPTS_WIN. It is read through `powershell -NoProfile -c`,
- *    the same shell prefix stall-poller.ts already uses for member-side
- *    filesystem reads (a Windows member's default exec shell is not PowerShell).
- *    `-NoProfile` keeps a chatty user profile from polluting stdout.
+ *    AgyProvider's SCRIPTS_WIN. Delivered via `wrapPowerShellEncoded` (same as
+ *    every other Windows-targeting PowerShell invocation in this codebase) --
+ *    a raw inline `powershell -c "..."` string is NOT safe here: if the
+ *    member's default exec shell is itself PowerShell, that outer shell
+ *    expands `$env:USERPROFILE` inside the double quotes before the inner
+ *    `powershell -c` ever sees it, leaving an unquoted path literal that is a
+ *    syntax error (same defect class as apra-fleet-ot2z). Base64-encoding
+ *    sidesteps re-tokenization by whatever shell sits in between.
  *  - POSIX: `printf '%s'` rather than `echo` -- no trailing newline, no shell
  *    builtin escape-interpretation differences between sh/bash/dash.
  */
 function probeCommandFor(targetOs: TargetOS): string {
   return targetOs === 'windows'
-    ? 'powershell -NoProfile -c "[Console]::Out.Write($env:USERPROFILE)"'
+    ? wrapPowerShellEncoded('[Console]::Out.Write($env:USERPROFILE)')
     : 'printf \'%s\' "$HOME"';
 }
 

--- a/tests/member-home-warm.test.ts
+++ b/tests/member-home-warm.test.ts
@@ -63,7 +63,11 @@ describe('SF-18: member home-dir cache warming', () => {
     mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 1 });
     mockExecCommand.mockImplementation(async (cmd: string) => {
       if (cmd.includes('$HOME')) return { stdout: '/export/home/bella\n', stderr: '', code: 0 };
-      if (cmd.includes('USERPROFILE')) return { stdout: 'D:\\Profiles\\bella', stderr: '', code: 0 };
+      // Windows probe is delivered via wrapPowerShellEncoded (base64
+      // -EncodedCommand), not a raw inline string -- decode to inspect it.
+      const encodedMatch = cmd.match(/-EncodedCommand (\S+)/);
+      const decoded = encodedMatch ? Buffer.from(encodedMatch[1], 'base64').toString('utf16le') : cmd;
+      if (decoded.includes('USERPROFILE')) return { stdout: 'D:\\Profiles\\bella', stderr: '', code: 0 };
       return { stdout: '', stderr: '', code: 0 };
     });
   });

--- a/tests/member-home-warm.test.ts
+++ b/tests/member-home-warm.test.ts
@@ -16,7 +16,7 @@
  * exactly what broke ~71 tests during the #390 work.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { makeTestAgent, makeTestLocalAgent, backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
+import { makeTestAgent, makeTestLocalAgent, backupAndResetRegistry, restoreRegistry, decodePowerShellEncodedCommand } from './test-helpers.js';
 import type { SSHExecResult } from '../src/types.js';
 
 const mockExecCommand = vi.fn<(cmd: string, timeout?: number) => Promise<SSHExecResult>>();
@@ -65,8 +65,7 @@ describe('SF-18: member home-dir cache warming', () => {
       if (cmd.includes('$HOME')) return { stdout: '/export/home/bella\n', stderr: '', code: 0 };
       // Windows probe is delivered via wrapPowerShellEncoded (base64
       // -EncodedCommand), not a raw inline string -- decode to inspect it.
-      const encodedMatch = cmd.match(/-EncodedCommand (\S+)/);
-      const decoded = encodedMatch ? Buffer.from(encodedMatch[1], 'base64').toString('utf16le') : cmd;
+      const decoded = decodePowerShellEncodedCommand(cmd);
       if (decoded.includes('USERPROFILE')) return { stdout: 'D:\\Profiles\\bella', stderr: '', code: 0 };
       return { stdout: '', stderr: '', code: 0 };
     });

--- a/tests/member-log-path-matrix.test.ts
+++ b/tests/member-log-path-matrix.test.ts
@@ -284,8 +284,12 @@ describe('getMemberHomeDir -- probe, cache, and graceful failure', () => {
     expect(home).toBe(MEMBER_HOME[memberOs]);
     const cmd = mockExecCommand.mock.calls[0]![0];
     if (memberOs === 'windows') {
-      expect(cmd).toContain('USERPROFILE');
+      // Delivered via wrapPowerShellEncoded (base64 -EncodedCommand), not a
+      // raw inline string -- decode to inspect the actual script.
       expect(cmd).toContain('powershell');
+      const encodedMatch = cmd.match(/-EncodedCommand (\S+)/);
+      const decoded = encodedMatch ? Buffer.from(encodedMatch[1], 'base64').toString('utf16le') : cmd;
+      expect(decoded).toContain('USERPROFILE');
     } else {
       expect(cmd).toContain('$HOME');
       expect(cmd).not.toContain('USERPROFILE');

--- a/tests/member-log-path-matrix.test.ts
+++ b/tests/member-log-path-matrix.test.ts
@@ -41,6 +41,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
 import os from 'node:os';
 import type { Agent, SSHExecResult } from '../src/types.js';
+import { decodePowerShellEncodedCommand } from './test-helpers.js';
 
 const { mockExecCommand, mockLogWarn } = vi.hoisted(() => ({
   mockExecCommand: vi.fn<(cmd: string, timeoutMs?: number) => Promise<SSHExecResult>>(),
@@ -287,8 +288,7 @@ describe('getMemberHomeDir -- probe, cache, and graceful failure', () => {
       // Delivered via wrapPowerShellEncoded (base64 -EncodedCommand), not a
       // raw inline string -- decode to inspect the actual script.
       expect(cmd).toContain('powershell');
-      const encodedMatch = cmd.match(/-EncodedCommand (\S+)/);
-      const decoded = encodedMatch ? Buffer.from(encodedMatch[1], 'base64').toString('utf16le') : cmd;
+      const decoded = decodePowerShellEncodedCommand(cmd);
       expect(decoded).toContain('USERPROFILE');
     } else {
       expect(cmd).toContain('$HOME');

--- a/tests/stall-no-signal-false-kill.test.ts
+++ b/tests/stall-no-signal-false-kill.test.ts
@@ -213,7 +213,11 @@ describe('no-signal dispatches are not killed by the stall detector (#390 / igoe
     addAgent(agent);
 
     mockExecCommand.mockImplementation(async (cmd: string) => {
-      if (cmd.includes('USERPROFILE')) return { stdout: 'C:\\Users\\bella', stderr: '', code: 0 };
+      // Windows probe is delivered via wrapPowerShellEncoded (base64
+      // -EncodedCommand), not a raw inline string -- decode to inspect it.
+      const encodedMatch = cmd.match(/-EncodedCommand (\S+)/);
+      const decodedCmd = encodedMatch ? Buffer.from(encodedMatch[1], 'base64').toString('utf16le') : cmd;
+      if (decodedCmd.includes('USERPROFILE')) return { stdout: 'C:\\Users\\bella', stderr: '', code: 0 };
       return { stdout: '', stderr: '', code: 0 };
     });
 

--- a/tests/stall-no-signal-false-kill.test.ts
+++ b/tests/stall-no-signal-false-kill.test.ts
@@ -18,7 +18,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { SSHExecResult } from '../src/types.js';
-import { makeTestAgent, backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
+import { makeTestAgent, backupAndResetRegistry, restoreRegistry, decodePowerShellEncodedCommand } from './test-helpers.js';
 
 const { mockExecCommand, mockWriteStatusline, mockLogWarn } = vi.hoisted(() => ({
   mockExecCommand: vi.fn<(cmd: string, timeout?: number) => Promise<SSHExecResult>>(),
@@ -215,8 +215,7 @@ describe('no-signal dispatches are not killed by the stall detector (#390 / igoe
     mockExecCommand.mockImplementation(async (cmd: string) => {
       // Windows probe is delivered via wrapPowerShellEncoded (base64
       // -EncodedCommand), not a raw inline string -- decode to inspect it.
-      const encodedMatch = cmd.match(/-EncodedCommand (\S+)/);
-      const decodedCmd = encodedMatch ? Buffer.from(encodedMatch[1], 'base64').toString('utf16le') : cmd;
+      const decodedCmd = decodePowerShellEncodedCommand(cmd);
       if (decodedCmd.includes('USERPROFILE')) return { stdout: 'C:\\Users\\bella', stderr: '', code: 0 };
       return { stdout: '', stderr: '', code: 0 };
     });

--- a/tests/stall-poller.test.ts
+++ b/tests/stall-poller.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
+import { decodePowerShellEncodedCommand } from './test-helpers.js';
 
 const execAsync = promisify(exec);
 
@@ -457,8 +458,7 @@ describe('pollLogFile', () => {
           // real by the host shell.
           // Windows probe is delivered via wrapPowerShellEncoded (base64
           // -EncodedCommand), not a raw inline string -- decode to inspect it.
-          const encodedMatch = cmd.match(/-EncodedCommand (\S+)/);
-          const decodedCmd = encodedMatch ? Buffer.from(encodedMatch[1], 'base64').toString('utf16le') : cmd;
+          const decodedCmd = decodePowerShellEncodedCommand(cmd);
           if (decodedCmd.includes('$HOME') || decodedCmd.includes('USERPROFILE')) {
             return { stdout: fixtureHome, stderr: '', code: 0 };
           }

--- a/tests/stall-poller.test.ts
+++ b/tests/stall-poller.test.ts
@@ -455,7 +455,11 @@ describe('pollLogFile', () => {
           // your home"; here that answer is the fixture root). Every other
           // command -- i.e. the directory scan under test -- is executed for
           // real by the host shell.
-          if (cmd.includes('$HOME') || cmd.includes('USERPROFILE')) {
+          // Windows probe is delivered via wrapPowerShellEncoded (base64
+          // -EncodedCommand), not a raw inline string -- decode to inspect it.
+          const encodedMatch = cmd.match(/-EncodedCommand (\S+)/);
+          const decodedCmd = encodedMatch ? Buffer.from(encodedMatch[1], 'base64').toString('utf16le') : cmd;
+          if (decodedCmd.includes('$HOME') || decodedCmd.includes('USERPROFILE')) {
             return { stdout: fixtureHome, stderr: '', code: 0 };
           }
           const { stdout, stderr } = await execAsync(cmd, { timeout: 30_000, maxBuffer: 1024 * 1024 });

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -8,6 +8,19 @@ import os from 'node:os';
 import type { Agent, SSHExecResult } from '../src/types.js';
 
 /**
+ * Decode a `powershell -EncodedCommand <base64>` string back to the underlying
+ * script so a test can assert on its content. wrapPowerShellEncoded()
+ * (src/os/windows.ts) base64/utf16le-encodes PowerShell scripts to survive
+ * re-tokenization by an intermediate shell; returns `cmd` unchanged if it is
+ * not an -EncodedCommand-wrapped string (e.g. a POSIX command).
+ */
+export function decodePowerShellEncodedCommand(cmd: string): string {
+  const m = cmd.match(/-EncodedCommand (\S+)/);
+  if (!m) return cmd;
+  return Buffer.from(m[1], 'base64').toString('utf16le');
+}
+
+/**
  * A strategy.execCommand implementation that simulates a real member filesystem
  * for the config files compose_permissions delivers.
  *


### PR DESCRIPTION
## Summary
- `member_home_probe`'s Windows probe (`src/services/member-home.ts`) built a raw inline `powershell -NoProfile -c "[Console]::Out.Write($env:USERPROFILE)"` string, assuming the outer exec shell leaves `$env:USERPROFILE` untouched inside the double quotes.
- On a member whose default exec shell is itself PowerShell, the outer shell expands the variable during its own tokenization before the inner `powershell -c` ever sees it, leaving an unquoted path literal -- a syntax error. Observed live at fleet startup for `fleet-win11` and `fleet-win-dev1`.
- Same defect class as apra-fleet-ot2z. Fixed by using `wrapPowerShellEncoded` (base64 `-EncodedCommand`), the helper every other Windows-targeting PowerShell invocation in this codebase already uses, so the script can't be re-tokenized by an intermediate shell.
- Updated `tests/member-home-warm.test.ts` and `tests/member-log-path-matrix.test.ts` to decode the `-EncodedCommand` payload instead of substring-matching the old raw command text.

Refs apra-fleet-69pp

## Test plan
- [x] `npx vitest run tests/member-home-warm.test.ts tests/member-log-path-matrix.test.ts` -- 63/63 passed
- [x] `npx tsc --noEmit` -- clean