### PR TITLE
docs(fleet-supervisor skill): document how to start and smoke-test the supervisor

### DIFF
--- a/packages/apra-fleet-se/fleet-sprint/skills/fleet-supervisor/SKILL.md
+++ b/packages/apra-fleet-se/fleet-sprint/skills/fleet-supervisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fleet-supervisor
-description: How to start, check, and kill fleet-sprints via the supervisor HTTP API only (POST /api/sprints on localhost:8787). Never call the fleet-sprint CLI directly. Trigger whenever asked to start/launch/check/stop/kill a sprint.
+description: How to start/smoke-test the supervisor process itself, and start, check, and kill fleet-sprints via its HTTP API only (POST /api/sprints on localhost:8787). Never call the fleet-sprint CLI directly. Trigger whenever asked to start/launch/check/stop/kill the supervisor or a sprint.
 ---
 
 # fleet-supervisor (supervisor API)
@@ -9,7 +9,30 @@ Sprints are started, checked, and killed through the supervisor's HTTP API.
 Default port: **8787**. Never invoke `apra-fleet workflow fleet-sprint` or
 `bin/cli.mjs` directly -- always go through this API.
 
-## 0. Before you launch
+## 0. Start the supervisor (if not already running)
+
+Check first: `curl -s -m 5 http://localhost:8787/api/sprints`. Connection
+refused/timeout = not running. `{"sprints": [...]}` = already up, skip this.
+
+Start it detached (it runs indefinitely -- exits only on `POST
+/api/shutdown` or SIGINT/SIGTERM, never on its own):
+
+```bash
+node packages/apra-fleet-se/bin/serve.mjs   # background/detached, from repo root
+```
+
+`--port <n>` overrides the default (8787). Self-logs to
+`<dataDir>/logs/supervisor.log` in addition to stdout.
+
+Smoke test (a few seconds after launch -- give it time to bind):
+```bash
+curl -s -m 5 http://localhost:8787/api/sprints   # expect {"sprints":[],...}
+curl -s -m 5 http://localhost:8787/api/members   # expect the registered fleet, non-empty
+```
+Both must succeed before treating the supervisor as up -- a bound port with
+a 500 on `/api/members` still means something is broken.
+
+## 1. Before you launch a sprint
 
 1. If you just created/edited beads locally, push them first:
    `bd dolt commit` then `bd dolt push`. Members pull their own copy; a
@@ -19,7 +42,7 @@ Default port: **8787**. Never invoke `apra-fleet workflow fleet-sprint` or
    launch crashes immediately with a topology error. If unsure, use ONE
    member. Don't guess a member list -- ask, or default to one.
 
-## 1. Start a sprint
+## 2. Start a sprint
 
 ```bash
 curl -s -X POST http://localhost:8787/api/sprints \
@@ -51,10 +74,10 @@ Field names, exactly as the API expects them:
 
 Response has `sprintId`, `pid`, `port` (its own dashboard), `logPath`.
 **A 201 response does NOT mean the sprint is alive** -- it can crash in the
-first few seconds (bad topology, bad member, etc). Always verify (step 2)
+first few seconds (bad topology, bad member, etc). Always verify (step 3)
 a few seconds after launch.
 
-## 2. Check status
+## 3. Check status
 
 All live sprints:
 ```bash
@@ -70,7 +93,7 @@ curl -s http://localhost:8787/api/sprints/<sprintId>
 Sprint-scoped dashboard (per-role activity, bead DAG, cost, PR link):
 `http://localhost:<port>` (the `port` from the launch response).
 
-## 3. Kill a sprint
+## 4. Kill a sprint
 
 ```bash
 curl -s -X POST http://localhost:8787/api/sprints/<sprintId>/stop


### PR DESCRIPTION
## Summary
- The fleet-supervisor skill only documented talking to an already-running supervisor via its HTTP API -- it never covered starting the supervisor process itself.
- Adds a step 0: check if it's already up (`GET /api/sprints`), start it detached via `node packages/apra-fleet-se/bin/serve.mjs` if not, and smoke-test with `GET /api/sprints` + `GET /api/members`.
- Renumbered the existing steps (1-4) accordingly and fixed the internal cross-reference.
- Reinstalled via `node dist/index.js install` and confirmed the installed copy at `~/.claude/skills/fleet-supervisor/SKILL.md` matches the source.

## Test plan
- [x] Started the supervisor locally per the new instructions, confirmed `GET /api/sprints` and `GET /api/members` both succeed.
- [x] Diffed installed skill copy against source after reinstall -- identical.