### PR TITLE
fix(tests): raise sandbox-seed-beads integ test timeout to 120s

### DIFF
--- a/tests/2cc-win-bd-invocation-integ.test.ts
+++ b/tests/2cc-win-bd-invocation-integ.test.ts
@@ -134,7 +134,7 @@ describe('scripts/sandbox-seed-beads.mjs reaches completion of its bd steps agai
       expect(fs.existsSync(doltRemoteDir)).toBe(true);
       expect(fs.readdirSync(doltRemoteDir).length).toBeGreaterThan(0);
     },
-    60000,
+    120000,
   );
 });
 


### PR DESCRIPTION
## Summary
- CI failed on `main` immediately after PR #413's squash-merge (run 31971079518, job `build-and-test (windows-latest)`).
- Root cause: `tests/2cc-win-bd-invocation-integ.test.ts:105` ("a real spawned sandbox-seed-beads.mjs run...") does a real git init + real bd Dolt init/create/export/push, and hit the test's 60000ms timeout on `windows-latest`. Confirmed via the downloaded job log -- `Error: Test timed out in 60000ms`, unrelated to PR #413's actual content (member-home.ts / test-helpers.ts).
- Bumped the timeout for that one test to 120000ms, matching the convention already used by other real-child-process tests in this suite (90-120s) for similarly heavy Dolt work.

## Test plan
- [x] CI green on this branch (build-and-test on all platforms)