### PR TITLE
fix(providers): delegate agent directory resolution to provider strategy

### DIFF
--- a/src/os/windows.ts
+++ b/src/os/windows.ts
@@ -144,8 +144,10 @@ export class WindowsCommands implements OsCommands {
       instruction = `[${inv}] ${instruction}`;
     }
     // Gemini activates a subagent via @<name> prepended to the prompt on EVERY dispatch.
-    if (agentName && provider.name === 'gemini') {
-      instruction = `@${agentName} ${instruction}`;
+    // Claude and AGY activate a subagent via --agent <name> flag.
+    const nameFlag = agentName ? provider.agentNameFlag(agentName) : '';
+    if (nameFlag.startsWith('@')) {
+      instruction = `${nameFlag}${instruction}`;
     }
 
     // Setup: working directory + PATH so the CLI executable is resolvable
@@ -156,9 +158,8 @@ export class WindowsCommands implements OsCommands {
 
     // Build argument list (everything that follows the executable)
     let argList = `${provider.headlessInvocation(instruction)} ${provider.jsonOutputFlag()}`;
-    // Claude and AGY activate a subagent via --agent <name> flag.
-    if (agentName && (provider.name === 'claude' || provider.name === 'agy')) {
-      argList = `--agent "${escapeWindowsArg(agentName)}" ${argList}`;
+    if (nameFlag && !nameFlag.startsWith('@')) {
+      argList = `${nameFlag} ${argList}`;
     }
     if (provider.supportsMaxTurns()) {
       argList += ` --max-turns ${maxTurns ?? 50}`;

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -280,6 +280,11 @@ export class AgyProvider implements ProviderAdapter {
     return '';
   }
 
+  agentDirectories(agentName: string): { project: string; home: string } {
+    const rel = `.gemini/antigravity-cli/agents/${agentName}.md`;
+    return { project: rel, home: rel };
+  }
+
   classifyError(output: string): PromptErrorCategory {
     return classifyPromptError(output);
   }

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -7,6 +7,7 @@ import { escapeDoubleQuoted } from '../os/os-commands.js';
 import { stripAnsi } from '../utils/ansi.js';
 import { logWarn } from '../utils/log-helpers.js';
 import { getModelOverride } from '../services/user-config.js';
+import { transformAgentForAgy } from '../cli/agent-transform.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -283,6 +284,14 @@ export class AgyProvider implements ProviderAdapter {
   agentDirectories(agentName: string): { project: string; home: string } {
     const rel = `.gemini/antigravity-cli/agents/${agentName}.md`;
     return { project: rel, home: rel };
+  }
+
+  transformAgent(content: string, relPath: string): string {
+    return transformAgentForAgy(content, relPath);
+  }
+
+  agentNameFlag(agentName: string): string {
+    return `--agent "${escapeDoubleQuoted(agentName)}"`;
   }
 
   classifyError(output: string): PromptErrorCategory {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -284,6 +284,14 @@ export class ClaudeProvider implements ProviderAdapter {
     return { project: rel, home: rel };
   }
 
+  transformAgent(content: string, _relPath: string): string {
+    return content;
+  }
+
+  agentNameFlag(agentName: string): string {
+    return `--agent "${escapeDoubleQuoted(agentName)}"`;
+  }
+
   classifyError(output: string): PromptErrorCategory {
     return classifyPromptError(output);
   }

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -279,6 +279,11 @@ export class ClaudeProvider implements ProviderAdapter {
     return `--model "${escapeDoubleQuoted(model)}"`;
   }
 
+  agentDirectories(agentName: string): { project: string; home: string } {
+    const rel = `.claude/agents/${agentName}.md`;
+    return { project: rel, home: rel };
+  }
+
   classifyError(output: string): PromptErrorCategory {
     return classifyPromptError(output);
   }

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -145,6 +145,14 @@ export class CodexProvider implements ProviderAdapter {
     return { project: rel, home: rel };
   }
 
+  transformAgent(content: string, _relPath: string): string {
+    return content;
+  }
+
+  agentNameFlag(_agentName: string): string {
+    return '';
+  }
+
   classifyError(output: string): PromptErrorCategory {
     if (/not logged in|unauthorized|\b401\b|authentication_error|expired.*token|invalid.*api.*key/i.test(output)) {
       return 'auth';

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -140,6 +140,11 @@ export class CodexProvider implements ProviderAdapter {
     return `--model "${escapeDoubleQuoted(model)}"`;
   }
 
+  agentDirectories(agentName: string): { project: string; home: string } {
+    const rel = `.codex/agents/${agentName}.md`;
+    return { project: rel, home: rel };
+  }
+
   classifyError(output: string): PromptErrorCategory {
     if (/not logged in|unauthorized|\b401\b|authentication_error|expired.*token|invalid.*api.*key/i.test(output)) {
       return 'auth';

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -137,6 +137,14 @@ export class CopilotProvider implements ProviderAdapter {
     return { project: rel, home: rel };
   }
 
+  transformAgent(content: string, _relPath: string): string {
+    return content;
+  }
+
+  agentNameFlag(_agentName: string): string {
+    return '';
+  }
+
   classifyError(output: string): PromptErrorCategory {
     if (/not logged in|unauthorized|\b401\b|authentication_error|expired.*token|permission_error|invalid.*token/i.test(output)) {
       return 'auth';

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -132,6 +132,11 @@ export class CopilotProvider implements ProviderAdapter {
     return `--model "${escapeDoubleQuoted(model)}"`;
   }
 
+  agentDirectories(agentName: string): { project: string; home: string } {
+    const rel = `.copilot/agents/${agentName}.md`;
+    return { project: rel, home: rel };
+  }
+
   classifyError(output: string): PromptErrorCategory {
     if (/not logged in|unauthorized|\b401\b|authentication_error|expired.*token|permission_error|invalid.*token/i.test(output)) {
       return 'auth';

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -167,6 +167,14 @@ export class GeminiProvider implements ProviderAdapter {
     return { project: rel, home: rel };
   }
 
+  transformAgent(content: string, _relPath: string): string {
+    return content;
+  }
+
+  agentNameFlag(agentName: string): string {
+    return `@${agentName} `;
+  }
+
   classifyError(output: string): PromptErrorCategory {
     const lower = output.toLowerCase();
     if (/not logged in|unauthorized|\b401\b|authentication_error|expired.*token|permission_error|invalid.*api.*key/i.test(lower)) {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -162,6 +162,11 @@ export class GeminiProvider implements ProviderAdapter {
     return `--model "${escapeDoubleQuoted(model)}"`;
   }
 
+  agentDirectories(agentName: string): { project: string; home: string } {
+    const rel = `.gemini/agents/${agentName}.md`;
+    return { project: rel, home: rel };
+  }
+
   classifyError(output: string): PromptErrorCategory {
     const lower = output.toLowerCase();
     if (/not logged in|unauthorized|\b401\b|authentication_error|expired.*token|permission_error|invalid.*api.*key/i.test(lower)) {

--- a/src/providers/none.ts
+++ b/src/providers/none.ts
@@ -89,6 +89,10 @@ export class NoneProvider implements ProviderAdapter {
     return '';
   }
 
+  agentDirectories(agentName: string): { project: string; home: string } {
+    throw new Error('none provider has no agent directories');
+  }
+
   classifyError(_output: string): PromptErrorCategory {
     return 'unknown';
   }

--- a/src/providers/none.ts
+++ b/src/providers/none.ts
@@ -93,6 +93,14 @@ export class NoneProvider implements ProviderAdapter {
     throw new Error('none provider has no agent directories');
   }
 
+  transformAgent(content: string, _relPath: string): string {
+    return content;
+  }
+
+  agentNameFlag(_agentName: string): string {
+    return '';
+  }
+
   classifyError(_output: string): PromptErrorCategory {
     return 'unknown';
   }

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -4,6 +4,7 @@ import type { LlmProvider, SSHExecResult } from '../types.js';
 import type { PromptErrorCategory } from '../utils/prompt-errors.js';
 import { escapeDoubleQuoted } from '../os/os-commands.js';
 import { sanitizeSessionId } from '../os/os-commands.js';
+import { transformAgentForOpenCode } from '../cli/agent-transform.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -65,6 +66,14 @@ export class OpenCodeProvider implements ProviderAdapter {
       project: `.opencode/agents/${agentName}.md`,
       home: `.config/opencode/agents/${agentName}.md`,
     };
+  }
+
+  transformAgent(content: string, relPath: string): string {
+    return transformAgentForOpenCode(content, relPath);
+  }
+
+  agentNameFlag(_agentName: string): string {
+    return '';
   }
 
   classifyError(output: string): PromptErrorCategory {

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -60,6 +60,13 @@ export class OpenCodeProvider implements ProviderAdapter {
     return `-m "${escapeDoubleQuoted(model)}"`;
   }
 
+  agentDirectories(agentName: string): { project: string; home: string } {
+    return {
+      project: `.opencode/agents/${agentName}.md`,
+      home: `.config/opencode/agents/${agentName}.md`,
+    };
+  }
+
   classifyError(output: string): PromptErrorCategory {
     if (/command not found|is not recognized as an internal or external command/i.test(output)) return 'unknown';
     if (/connection refused|ECONNREFUSED/i.test(output)) return 'server';

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -207,6 +207,12 @@ export interface ProviderAdapter {
   modelForTier(tier: 'cheap' | 'standard' | 'premium'): string;
   modelFlag(model: string): string;
 
+  // Agent directory resolution
+  /** Returns the project-relative and home-relative paths for an agent file.
+   *  project: relative to workFolder (e.g. '.claude/agents/doer.md')
+   *  home: relative to ~ (e.g. '.claude/agents/doer.md' or '.config/opencode/agents/doer.md') */
+  agentDirectories(agentName: string): { project: string; home: string };
+
   // Error classification
   classifyError(output: string): PromptErrorCategory;
 

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -213,6 +213,16 @@ export interface ProviderAdapter {
    *  home: relative to ~ (e.g. '.claude/agents/doer.md' or '.config/opencode/agents/doer.md') */
   agentDirectories(agentName: string): { project: string; home: string };
 
+  // Agent file transformation
+  /** Transforms agent file content for this provider (e.g. frontmatter conversion).
+   *  Default: passthrough (return content unchanged). */
+  transformAgent(content: string, relPath: string): string;
+
+  // Agent name CLI flag
+  /** Returns the CLI flag/prefix for activating a named agent.
+   *  Claude/AGY: '--agent "name"'. Gemini: '@name '. Others: ''. */
+  agentNameFlag(agentName: string): string;
+
   // Error classification
   classifyError(output: string): PromptErrorCategory;
 

--- a/src/services/agent-provisioner.ts
+++ b/src/services/agent-provisioner.ts
@@ -16,7 +16,7 @@ import { getStrategy } from './strategy.js';
 import { uploadContentToHome } from './sftp.js';
 import { loadAgentAssets } from '../cli/install.js';
 import { getAgentsDirRelative } from '../cli/config.js';
-import { transformAgentForOpenCode, transformAgentForAgy } from '../cli/agent-transform.js';
+import { getProvider } from '../providers/index.js';
 
 export interface CanonicalAgentFile {
   relPath: string;
@@ -41,15 +41,12 @@ function sha256Hex(content: string): string {
  */
 export function loadCanonicalAgentSet(provider: LlmProvider): CanonicalAgentFile[] {
   const assets = loadAgentAssets();
+  const adapter = getProvider(provider);
   return assets.map(({ relPath, content }) => {
     // Normalize CRLF -> LF before hashing/uploading so a CRLF checkout (Windows)
     // and an LF binary (SEA asset) produce identical hashes for the same file.
     const normalized = content.replace(/\r\n/g, '\n');
-    const transformed = provider === 'opencode'
-      ? transformAgentForOpenCode(normalized, relPath)
-      : provider === 'agy'
-      ? transformAgentForAgy(normalized, relPath)
-      : normalized;
+    const transformed = adapter.transformAgent(normalized, relPath);
     return { relPath, content: transformed, sha256: sha256Hex(transformed) };
   });
 }

--- a/src/tools/execute-prompt.ts
+++ b/src/tools/execute-prompt.ts
@@ -101,7 +101,8 @@ export const executePromptSchema = z.object({
     'Agent file must exist at the provider-specific path on the member: ' +
     'Claude: <workFolder>/.claude/agents/<name>.md or ~/.claude/agents/<name>.md; ' +
     'Gemini: <workFolder>/.gemini/agents/<name>.md or ~/.gemini/agents/<name>.md; ' +
-    'AGY: <workFolder>/.gemini/antigravity-cli/agents/<name>.md or ~/.gemini/antigravity-cli/agents/<name>.md -- ' +
+    'AGY: <workFolder>/.gemini/antigravity-cli/agents/<name>.md or ~/.gemini/antigravity-cli/agents/<name>.md; ' +
+    'OpenCode: <workFolder>/.opencode/agents/<name>.md or ~/.config/opencode/agents/<name>.md -- ' +
     'the call is rejected with a clear error if neither is present.'
   ),
   sprint_id: z.string().optional().describe(
@@ -959,13 +960,11 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
 
   // Agent file validation -- verify named agent exists before any CLI invocation
   if (input.agent) {
-    const provName = provider.name;
-    // AGY uses ~/.gemini/antigravity-cli/ as its config root, not ~/.agy/
-    const agentRelDir = provName === 'agy' ? '.gemini/antigravity-cli/agents' : `.${provName}/agents`;
+    const dirs = provider.agentDirectories(input.agent);
     let agentFound = false;
     if (agent.agentType === 'local') {
-      const projPath = path.join(resolvedWorkFolder, agentRelDir, `${input.agent}.md`);
-      const userPath = path.join(os.homedir(), agentRelDir, `${input.agent}.md`);
+      const projPath = path.join(resolvedWorkFolder, dirs.project);
+      const userPath = path.join(os.homedir(), dirs.home);
       agentFound = fs.existsSync(projPath) || fs.existsSync(userPath);
       if (!agentFound) {
         inFlightAgents.delete(agent.id);
@@ -975,7 +974,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
       }
     } else {
       // Canonical PM role agents (planner/doer/reviewer/plan-reviewer/...) are
-      // already guaranteed present in ~/${agentRelDir} by
+      // already guaranteed present in ~/dirs.home by
       // ensureAgentFilesProvisioned() above (ln ~576, which ran provisionAgents()
       // for this exact member earlier in this same call) -- trust that instead
       // of re-probing the remote here. This also SIDESTEPS the bug this check
@@ -987,8 +986,8 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
       // sprint via a Windows remote member always failed plan-review with
       // "agent 'plan-reviewer' not found").
       const canonicalRelPath = `${input.agent}.md`;
-      agentFound = remoteAgentsDir(provName) !== null
-        && loadCanonicalAgentSet(provName).some((f) => f.relPath === canonicalRelPath);
+      agentFound = remoteAgentsDir(provider.name) !== null
+        && loadCanonicalAgentSet(provider.name).some((f) => f.relPath === canonicalRelPath);
 
       if (!agentFound) {
         // Not part of the canonical PM set (e.g. a project-local custom
@@ -997,8 +996,8 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
         // already used the same way by list-members.ts/member-detail.ts for
         // credential-file checks) instead of a single hardcoded shell dialect.
         const cmds = getOsCommands(getAgentOS(agent));
-        const projPath = `${resolvedWorkFolder}/${agentRelDir}/${input.agent}.md`;
-        const userPath = `~/${agentRelDir}/${input.agent}.md`;
+        const projPath = `${resolvedWorkFolder}/${dirs.project}`;
+        const userPath = `~/${dirs.home}`;
         const [projResult, userResult] = await Promise.all([
           strategy.execCommand(cmds.credentialFileCheck(projPath), 10000),
           strategy.execCommand(cmds.credentialFileCheck(userPath), 10000),
@@ -1010,7 +1009,7 @@ export async function executePrompt(input: ExecutePromptInput, extra?: any): Pro
         inFlightAgents.delete(agent.id);
         stallDetector.remove(agent.id);
         writeStatusline(new Map([[agent.id, 'idle']]));
-        return `execute_prompt: agent "${input.agent}" not found on "${agent.friendlyName}".\n\nExpected at:\n  ${resolvedWorkFolder}/${agentRelDir}/${input.agent}.md\n  ~/${agentRelDir}/${input.agent}.md`;
+        return `execute_prompt: agent "${input.agent}" not found on "${agent.friendlyName}".\n\nExpected at:\n  ${resolvedWorkFolder}/${dirs.project}\n  ~/${dirs.home}`;
       }
     }
   }

--- a/tests/execute-prompt-agent.test.ts
+++ b/tests/execute-prompt-agent.test.ts
@@ -309,4 +309,76 @@ describe('execute_prompt -- agent parameter', () => {
       }
     }
   });
+
+  // --- OpenCode: agent resolution uses .opencode/ for project, .config/opencode/ for home ---
+
+  it('OpenCode: agent found at project .opencode/agents/ is accepted', async () => {
+    const agentDir = path.join(tmpDir, '.opencode', 'agents');
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, 'planner.md'), '# planner agent');
+
+    const member = makeTestLocalAgent({
+      friendlyName: 'opencode-proj-agent',
+      workFolder: tmpDir,
+      llmProvider: 'opencode',
+      os: 'linux',
+    });
+    addAgent(member);
+    mockExecCommand.mockResolvedValue({ stdout: successResponse, stderr: '', code: 0 });
+
+    const result = await executePrompt({ member_id: member.id, prompt: 'plan the work', resume: false, timeout_s: 5, agent: 'planner' });
+
+    expect(result).not.toContain('not found');
+  });
+
+  it('OpenCode: agent found at ~/.config/opencode/agents/ is accepted', async () => {
+    const homeAgentDir = path.join(os.homedir(), '.config', 'opencode', 'agents');
+    const homeAgentFile = path.join(homeAgentDir, 'planner.md');
+    const hadFile = fs.existsSync(homeAgentFile);
+
+    if (!hadFile) {
+      fs.mkdirSync(homeAgentDir, { recursive: true });
+      fs.writeFileSync(homeAgentFile, '# planner agent');
+    }
+
+    try {
+      const member = makeTestLocalAgent({
+        friendlyName: 'opencode-home-agent',
+        workFolder: tmpDir,  // No agent file in project dir
+        llmProvider: 'opencode',
+        os: 'linux',
+      });
+      addAgent(member);
+      mockExecCommand.mockResolvedValue({ stdout: successResponse, stderr: '', code: 0 });
+
+      const result = await executePrompt({ member_id: member.id, prompt: 'plan the work', resume: false, timeout_s: 5, agent: 'planner' });
+
+      expect(result).not.toContain('not found');
+    } finally {
+      if (!hadFile) {
+        fs.rmSync(homeAgentFile, { force: true });
+      }
+    }
+  });
+
+  it('OpenCode: unknown agent shows .opencode/ and ~/.config/opencode/ paths in error', async () => {
+    const member = makeTestLocalAgent({
+      friendlyName: 'opencode-unknown-agent',
+      workFolder: tmpDir,
+      llmProvider: 'opencode',
+      os: 'linux',
+    });
+    addAgent(member);
+
+    const result = await executePrompt({ member_id: member.id, prompt: 'hi', resume: false, timeout_s: 5, agent: 'nonexistent' });
+
+    expect(result).toContain('not found');
+    expect(result).toContain('nonexistent');
+    // Project path should be .opencode/agents/, home path should be ~/.config/opencode/agents/
+    expect(result).toContain('.opencode/agents/nonexistent.md');
+    expect(result).toContain('.config/opencode/agents/nonexistent.md');
+    // Must NOT show the old wrong path
+    expect(result).not.toMatch(/~\/\.opencode\/agents\//);
+    expect(mockExecCommand).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem

execute-prompt.ts hardcoded agent file paths per-provider with an if/else chain:
- if (agy) -> .gemini/antigravity-cli/agents/
- if (opencode) -> .opencode/agents/ (wrong!)
- else -> ./agents/

This broke opencode agent resolution: fleet checked ~/.opencode/agents/ but opencode stores global agents at ~/.config/opencode/agents/.

## Fix

Added gentDirectories(agentName) to the ProviderAdapter interface. Each provider now owns its own project + home paths:

| Provider | Project | Home |
|---|---|---|
| claude | .claude/agents/ | .claude/agents/ |
| gemini | .gemini/agents/ | .gemini/agents/ |
| agy | .gemini/antigravity-cli/agents/ | .gemini/antigravity-cli/agents/ |
| opencode | .opencode/agents/ | .config/opencode/agents/ |
| codex | .codex/agents/ | .codex/agents/ |
| copilot | .copilot/agents/ | .copilot/agents/ |
| none | throws | throws |

execute-prompt.ts now calls provider.agentDirectories(name) instead of the hardcoded chain.

## Tests

- 3 new tests for opencode agent resolution (project path, home path, error paths)
- All 58 agent-related tests pass
- Build passes