### PR TITLE
chore(sprint-logs): ignore raw ledgers, keep the distilled artifacts tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,11 +31,29 @@ CLAUDE.md
 # E2E test fixtures (local only, never commit)
 .e2e-fixtures/
 
-# Sprint-log transcripts and analyses are per-run artifacts, not deliverables.
-# Files already tracked before this rule stay tracked (gitignore does not
-# untrack existing files) -- this only stops new ones from being committed.
+# sprint-logs/ holds three kinds of file and only two are deliverables. Keep
+# this split in sync with apra-pm/skills/pm/cost.md and
+# apra-pm/docs/sprint-workflow.md, which tell the harvester what to commit --
+# a rule here that contradicts those docs is silently unstageable output, and
+# a sprint has already burned a cycle rediscovering that (apra-fleet-tm7.13).
+#
+#   calibration.json          TRACKED. The blended historical averages future
+#                             cost quotes read; one bounded file per package.
+#   <branch>-<ts>.analysis.md TRACKED. The human-readable Sprint Execution
+#                             Summary, same class as docs/sprint-analysis-*.md.
+#   <branch>-<ts>.jsonl       IGNORED (below). Raw per-dispatch ledgers: they
+#                             accumulate per run with no bound, and they embed
+#                             the operator's home path -- redaction still
+#                             leaves the username inside the dash-encoded
+#                             Claude project slug, so they are not safe to
+#                             publish from a public repo.
+#   sprint_*.json             IGNORED (below). Per-run state snapshot written
+#                             by bin/cli.mjs on every sprint exit; pure scratch.
+#
+# Do NOT reintroduce a blanket '/sprint-logs/' directory rule: a directory-level
+# ignore shadows everything inside it, so the two tracked kinds above become
+# unstageable without 'git add -f' no matter what a narrower pattern says.
 **/sprint-logs/*.jsonl
-**/sprint-logs/*.analysis.md
 **/sprint-logs/sprint_*.json
 
 # Provider agent context files are tracked project deliverables (git add -f was used).
@@ -75,9 +93,11 @@ COPILOT-INSTRUCTIONS.md
 /integ-suite-heartbeat.json
 /integ-suite-run.log
 
-# Per-run sprint state dumps (bin/cli.mjs writes one automatically on every
-# sprint exit) -- local scratch, not a project deliverable.
-/sprint-logs/
+# (The per-run sprint state dumps bin/cli.mjs writes on every sprint exit are
+# covered by the scoped '**/sprint-logs/sprint_*.json' rule above. The blanket
+# '/sprint-logs/' rule that used to sit here shadowed the whole directory,
+# making calibration.json and the analysis summaries unstageable -- see the
+# note at the top of this file.)
 
 # Per-member installed agent role files -- must stay on disk, never committed
 .claude/agents/

--- a/packages/apra-fleet-se/apra-pm/docs/sprint-workflow.md
+++ b/packages/apra-fleet-se/apra-pm/docs/sprint-workflow.md
@@ -355,7 +355,12 @@ $0.0145 reviewer-c1-i1 -- reviewing tasks BD-5, BD-6
 ```
 
 At the end of each cycle, the full dispatch ledger is written as JSONL to
-`sprint-logs/<branch>-<timestamp>.jsonl` and committed to the branch. The branch name is
+`sprint-logs/<branch>-<timestamp>.jsonl`. It stays local and is NOT committed:
+the ledgers accumulate per run with no bound, and they embed the operator's
+home path (redaction still leaves the username inside the dash-encoded Claude
+project slug), so they are not safe to publish from a public repo. What is
+committed is the distilled output -- `calibration.json` and the
+`<timestamp>.analysis.md` summary, both described below. The branch name is
 sanitized (path separators and special characters replaced with dashes) and a
 `yyyymmdd_hhmmss` timestamp is appended, so that parallel sprints on the same or different
 branches never write to the same file. Each line records:
@@ -389,6 +394,11 @@ jq -r '"$\(.costUsd)  \(.label)  \(.context)"' sprint-logs/<branch>-<timestamp>.
 cat sprint-logs/*.jsonl | jq -r '"$\(.costUsd)  \(.label)  \(.context)"'
 ```
 
+These read the ledgers in your own checkout only -- `*.jsonl` is gitignored, so
+"all sprints in the repo" means every run on THIS machine, not every run the
+team has done. The cross-machine view is `calibration.json`, which is committed
+and blends each run's actuals into the historical averages.
+
 Costs reflect output tokens only -- input tokens are not exposed by the workflow
 harness. The true cost will be higher, typically 2-4x depending on model and
 context size.
@@ -405,8 +415,10 @@ When the sprint goal is met:
 - A reviewed pull request is open against `base_branch`
 - `docs/` is updated with architecture decisions and feature documentation
 - `CHANGELOG.md` has a new entry summarising the sprint
-- `sprint-logs/<branch>.jsonl` is committed to the branch with per-dispatch cost data
-- `sprint-logs/<branch>-<timestamp>.analysis.md` is written with a Sprint Execution
+- `sprint-logs/<branch>.jsonl` is written locally with per-dispatch cost data
+  (gitignored -- see the sprint-log note above)
+- `sprint-logs/calibration.json` is committed with the updated historical averages
+- `sprint-logs/<branch>-<timestamp>.analysis.md` is committed with a Sprint Execution
   Summary: cycles, per-phase token/cost/dispatch table, failures/retries, and
   remaining risks at close
 - A cost summary table is printed in the workflow output

--- a/tests/sprint-logs-ignore-policy.test.ts
+++ b/tests/sprint-logs-ignore-policy.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * sprint-logs/ is split three ways and the split lives in two places that
+ * cannot import each other: .gitignore, and the harvester instructions in
+ * apra-pm/docs/sprint-workflow.md + apra-pm/skills/pm/cost.md. When they
+ * disagree, the failure is silent -- the harvester writes a file it is told to
+ * commit, git refuses to stage it, and the sprint reports success. That drift
+ * shipped once already: main's .gitignore ignored *.jsonl and *.analysis.md
+ * while three separate doc lines said to commit them, and a sprint (apra-fleet
+ * -tm7.13) spent a cycle rediscovering it and "fixed" it in the other direction.
+ *
+ * This is the guard. It asserts the ignore rules directly rather than the prose,
+ * because the rules are what git actually enforces.
+ *
+ * --no-index is LOAD-BEARING on every check-ignore call below. Without it git
+ * silently skips paths that are tracked, so an assertion about calibration.json
+ * would pass vacuously no matter what the rules said.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function isIgnored(relPath: string): boolean {
+  try {
+    execFileSync('git', ['check-ignore', '--no-index', '-q', relPath], {
+      cwd: REPO_ROOT, stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Both depths matter: apra-pm keeps its own sprint-logs/ alongside the root one,
+// so a rule anchored at the root would silently miss half the cases.
+const DEPTHS = ['sprint-logs', 'packages/apra-fleet-se/apra-pm/sprint-logs'];
+
+describe('sprint-logs ignore policy', () => {
+  describe.each(DEPTHS)('%s', (dir) => {
+    it('ignores the raw per-dispatch ledgers', () => {
+      expect(isIgnored(`${dir}/feat-example-20260818_120000.jsonl`)).toBe(true);
+    });
+
+    it('ignores the per-run state snapshot bin/cli.mjs writes on exit', () => {
+      expect(isIgnored(`${dir}/sprint_130635.json`)).toBe(true);
+    });
+
+    // cost.md:118 tells the harvester to commit this; it is the only
+    // cross-machine cost record, so an ignore rule here loses the team's history.
+    it('keeps calibration.json stageable', () => {
+      expect(isIgnored(`${dir}/calibration.json`)).toBe(false);
+    });
+
+    // cost.md:115 tells the harvester to write and commit this summary.
+    it('keeps the analysis summary stageable', () => {
+      expect(isIgnored(`${dir}/feat-example-20260818_120000.analysis.md`)).toBe(false);
+    });
+  });
+
+  /**
+   * A directory-level ignore shadows everything inside it, so a blanket
+   * '/sprint-logs/' rule makes calibration.json and the analysis summaries
+   * unstageable no matter what a narrower pattern elsewhere says. That rule
+   * existed on main and is exactly what forced `git add -f` on every sprint.
+   */
+  it('carries no blanket sprint-logs directory rule', () => {
+    const rules = fs.readFileSync(path.join(REPO_ROOT, '.gitignore'), 'utf-8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.startsWith('#'));
+
+    const blanket = rules.filter((l) => /^\/?(\*\*\/)?sprint-logs\/?$/.test(l));
+    expect(blanket).toEqual([]);
+  });
+});


### PR DESCRIPTION
`main` contradicts itself about `sprint-logs/`: three doc lines tell the harvester to commit files that `.gitignore` refuses to stage.

| Says commit | Says ignore |
|---|---|
| `cost.md:115` -- analysis summary "and commit it" | `.gitignore:37` `**/sprint-logs/*.jsonl` |
| `cost.md:118` -- calibration.json "Commit it." | `.gitignore:38` `**/sprint-logs/*.analysis.md` |
| `sprint-workflow.md:358` ledger "committed to the branch" | `.gitignore:80` `/sprint-logs/` |
| `sprint-workflow.md:408` same, in the exit criteria | |

The failure is silent -- the harvester writes a file it is told to commit, git refuses to stage it, and the sprint reports success. It has already cost a cycle: `apra-fleet-tm7.13` rediscovered this and resolved it the *other* way, un-ignoring the ledgers.

## Resolution

Raw ledgers ignored, distilled artifacts tracked, **and the docs corrected to match** so the contradiction does not simply invert.

- `*.jsonl` -- stays ignored. Unbounded growth, and they embed the operator's home path. `tm7.17`'s redaction strips the `/home/<user>` prefix but the username survives inside the dash-encoded Claude project slug, so an acceptance criterion phrased as a grep for `/home/` passes while the leak remains. Verified on a real ledger.
- `sprint_*.json` -- stays ignored (per-run scratch from `bin/cli.mjs`).
- `calibration.json` -- now genuinely stageable. The only cross-machine cost record; future quotes read it.
- `<branch>-<ts>.analysis.md` -- now genuinely stageable. Same class as `docs/sprint-analysis-*.md`.

The blanket `/sprint-logs/` rule is **removed, not narrowed**: a directory-level ignore shadows everything inside it, so the tracked kinds were unstageable regardless of the narrower patterns. That is what let the contradiction survive.

## Verification

`tests/sprint-logs-ignore-policy.test.ts` -- 9 tests pinning all four outcomes at both depths (root and apra-pm's own `sprint-logs/`), plus the absence of a blanket rule. Mutation-checked: re-adding `/sprint-logs/` turns 3 red.

Every `check-ignore` call passes `--no-index`. Without it git silently skips tracked paths, which would make the `calibration.json` assertion vacuous -- a trap recorded in the KB by the sprint that hit it.