### PR TITLE
fix(providers): map unattended=auto and dangerous to provider-native flags for opencode and agy

### DIFF
--- a/src/os/windows.ts
+++ b/src/os/windows.ts
@@ -168,19 +168,13 @@ export class WindowsCommands implements OsCommands {
       const rf = provider.resumeFlag(sessionId, resuming);
       if (rf) argList += ` ${rf}`;
     }
-    if (unattended === 'auto') {
-      const autoFlag = provider.permissionModeAutoFlag();
-      if (autoFlag) argList += ` ${autoFlag}`;
-    } else if (unattended === 'dangerous') {
-      argList += ` ${provider.skipPermissionsFlag()}`;
-    } else {
-      // apra-fleet-eft.65.1: interactive-session parity for the work folder --
-      // grant Edit/Write of a brand-new file in the dispatched agent's own work
-      // folder without the broad --dangerously-skip-permissions bypass. Providers
-      // without such a surgical flag omit the method, leaving behavior unchanged.
-      const editFlag = provider.workspaceEditPermissionFlag?.();
-      if (editFlag) argList += ` ${editFlag}`;
-    }
+    // Delegate unattended-mode flag resolution entirely to the provider --
+    // each provider's own auto/dangerous fallback and warning semantics (e.g.
+    // AGY has no true auto and falls back to its dangerous flag; OpenCode has
+    // no true dangerous and falls back to --auto) must not be re-derived here,
+    // or this path silently diverges from the POSIX buildPromptCommand() path.
+    const permFlag = provider.resolvePermissionFlag(unattended);
+    if (permFlag) argList += ` ${permFlag}`;
     if (model) {
       argList += ` ${provider.modelFlag(escapeWindowsArg(model))}`;
     }

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -84,7 +84,10 @@ export class AgyProvider implements ProviderAdapter {
       }
     }
 
-    if (unattended === 'dangerous') {
+    if (unattended === 'auto' || unattended === 'dangerous') {
+      if (unattended === 'auto') {
+        logWarn('agy', "WARNING: unattended='auto' is not supported for AGY -- falling back to --dangerously-skip-permissions (no classifier safety). Ensure deny rules are configured.");
+      }
       cmd += ' --dangerously-skip-permissions';
     }
 

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -102,17 +102,29 @@ export class AgyProvider implements ProviderAdapter {
   }
 
   permissionModeAutoFlag(): string | null {
-    return null;
+    return '--mode accept-edits';
+  }
+
+  workspaceEditPermissionFlag(): string | null {
+    // Mirrors claude.ts's acceptEdits: auto-approves file-edit tools for the
+    // dispatched agent's own work folder only, without the broad
+    // --dangerously-skip-permissions bypass. This is AGY's baseline for any
+    // headless dispatch -- without it, doers cannot edit/write a new file at
+    // all, since a headless `-p` run cannot show a permission prompt.
+    return '--mode accept-edits';
   }
 
   resolvePermissionFlag(unattended: false | 'auto' | 'dangerous' | undefined): string {
-    if (unattended === 'auto' || unattended === 'dangerous') {
-      if (unattended === 'auto') {
-        logWarn('agy', "WARNING: unattended='auto' is not supported for AGY -- falling back to --dangerously-skip-permissions (no classifier safety). Ensure deny rules are configured.");
-      }
-      return this.skipPermissionsFlag();
+    if (unattended === 'dangerous') return this.skipPermissionsFlag();
+    if (unattended === 'auto') {
+      // AGY has no broader-but-still-classifier-safe mode beyond baseline
+      // edit parity, so 'auto' does NOT escalate to a permission bypass here
+      // (that would silently grant more than the operator asked for -- see
+      // unattended='dangerous' for an explicit full-bypass opt-in).
+      logWarn('agy', "WARNING: unattended='auto' has no broader-than-baseline mode for AGY -- using --mode accept-edits (same as default). Use unattended='dangerous' for a full permission bypass.");
     }
-    return '';
+    // default (false/undefined) and 'auto' both resolve to the same baseline.
+    return this.workspaceEditPermissionFlag() ?? '';
   }
 
   parseResponse(result: SSHExecResult): ParsedResponse {

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -84,12 +84,8 @@ export class AgyProvider implements ProviderAdapter {
       }
     }
 
-    if (unattended === 'auto' || unattended === 'dangerous') {
-      if (unattended === 'auto') {
-        logWarn('agy', "WARNING: unattended='auto' is not supported for AGY -- falling back to --dangerously-skip-permissions (no classifier safety). Ensure deny rules are configured.");
-      }
-      cmd += ' --dangerously-skip-permissions';
-    }
+    const permFlag = this.resolvePermissionFlag(unattended);
+    if (permFlag) cmd += ` ${permFlag}`;
 
     // After agy exits, read its transcript from disk (primary output channel --
     // agy writes its response to CONOUT$, not stdout, so file I/O is required).
@@ -107,6 +103,16 @@ export class AgyProvider implements ProviderAdapter {
 
   permissionModeAutoFlag(): string | null {
     return null;
+  }
+
+  resolvePermissionFlag(unattended: false | 'auto' | 'dangerous' | undefined): string {
+    if (unattended === 'auto' || unattended === 'dangerous') {
+      if (unattended === 'auto') {
+        logWarn('agy', "WARNING: unattended='auto' is not supported for AGY -- falling back to --dangerously-skip-permissions (no classifier safety). Ensure deny rules are configured.");
+      }
+      return this.skipPermissionsFlag();
+    }
+    return '';
   }
 
   parseResponse(result: SSHExecResult): ParsedResponse {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -77,22 +77,8 @@ export class ClaudeProvider implements ProviderAdapter {
     } else if (sessionId) {
       cmd += ` ${buildSessionIdFlag(sessionId)}`;
     }
-    if (unattended === 'auto') {
-      cmd += ' --permission-mode auto';
-    } else if (unattended === 'dangerous') {
-      cmd += ' --dangerously-skip-permissions';
-    } else {
-      // apra-fleet-eft.65.1: interactive-session parity for the work folder.
-      // A headless `-p` dispatch cannot present a permission prompt, so with no
-      // permission-mode flag the CLI HARD-BLOCKS Edit/Write of a brand-new file
-      // in its own work folder -- even though an interactive session in the same
-      // trusted workspace would simply accept it. `acceptEdits` auto-approves
-      // file-edit tools (Edit/Write/MultiEdit/NotebookEdit) for the working
-      // directory only; it does NOT auto-approve Bash, network, or edits outside
-      // the workspace, so this restores work-folder Edit/Write parity without
-      // broadening the permission model (unlike --dangerously-skip-permissions).
-      cmd += ` ${this.workspaceEditPermissionFlag()}`;
-    }
+    const permFlag = this.resolvePermissionFlag(unattended);
+    if (permFlag) cmd += ` ${permFlag}`;
     if (model) {
       cmd += ` --model "${escapeDoubleQuoted(model)}"`;
     }
@@ -112,6 +98,21 @@ export class ClaudeProvider implements ProviderAdapter {
     // own work folder in a headless dispatch (which cannot show a trust/permission
     // prompt) WITHOUT the broad --dangerously-skip-permissions bypass.
     return '--permission-mode acceptEdits';
+  }
+
+  resolvePermissionFlag(unattended: false | 'auto' | 'dangerous' | undefined): string {
+    if (unattended === 'auto') return '--permission-mode auto';
+    if (unattended === 'dangerous') return '--dangerously-skip-permissions';
+    // apra-fleet-eft.65.1: interactive-session parity for the work folder.
+    // A headless `-p` dispatch cannot present a permission prompt, so with no
+    // permission-mode flag the CLI HARD-BLOCKS Edit/Write of a brand-new file
+    // in its own work folder -- even though an interactive session in the same
+    // trusted workspace would simply accept it. `acceptEdits` auto-approves
+    // file-edit tools (Edit/Write/MultiEdit/NotebookEdit) for the working
+    // directory only; it does NOT auto-approve Bash, network, or edits outside
+    // the workspace, so this restores work-folder Edit/Write parity without
+    // broadening the permission model (unlike --dangerously-skip-permissions).
+    return this.workspaceEditPermissionFlag() ?? '';
   }
 
   parseResponse(result: SSHExecResult): ParsedResponse {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -43,11 +43,8 @@ export class CodexProvider implements ProviderAdapter {
     if (sessionId) {
       cmd += ' resume';
     }
-    if (unattended === 'auto') {
-      cmd += ' --ask-for-approval auto-edit';
-    } else if (unattended === 'dangerous') {
-      cmd += ` ${this.skipPermissionsFlag()}`;
-    }
+    const permFlag = this.resolvePermissionFlag(unattended);
+    if (permFlag) cmd += ` ${permFlag}`;
     if (model) {
       cmd += ` --model "${escapeDoubleQuoted(model)}"`;
     }
@@ -60,6 +57,12 @@ export class CodexProvider implements ProviderAdapter {
 
   permissionModeAutoFlag(): string | null {
     return '--ask-for-approval auto-edit';
+  }
+
+  resolvePermissionFlag(unattended: false | 'auto' | 'dangerous' | undefined): string {
+    if (unattended === 'auto') return this.permissionModeAutoFlag() ?? '';
+    if (unattended === 'dangerous') return this.skipPermissionsFlag();
+    return '';
   }
 
   /**

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -48,11 +48,7 @@ export class CopilotProvider implements ProviderAdapter {
       cmd += ' --continue';
     }
     // Copilot CLI does not support unattended permission flags
-    if (unattended === 'auto') {
-      logWarn('copilot', "WARNING: unattended='auto' is not supported for Copilot — member will run interactively");
-    } else if (unattended === 'dangerous') {
-      logWarn('copilot', "WARNING: unattended='dangerous' is not supported for Copilot — member will run interactively");
-    }
+    this.resolvePermissionFlag(unattended);
     if (model) {
       cmd += ` --model "${escapeDoubleQuoted(model)}"`;
     }
@@ -66,6 +62,13 @@ export class CopilotProvider implements ProviderAdapter {
   permissionModeAutoFlag(): string | null {
     logWarn('copilot', "WARNING: unattended='auto' is not supported for Copilot — member will run interactively");
     return null;
+  }
+
+  resolvePermissionFlag(unattended: false | 'auto' | 'dangerous' | undefined): string {
+    if (unattended === 'auto' || unattended === 'dangerous') {
+      logWarn('copilot', `WARNING: unattended='${unattended}' is not supported for Copilot — member will run interactively`);
+    }
+    return '';
   }
 
   parseResponse(result: SSHExecResult): ParsedResponse {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -73,9 +73,8 @@ export class GeminiProvider implements ProviderAdapter {
     } else if (sessionId) {
       cmd += ` ${buildSessionIdFlag(sessionId)}`;
     }
-    if (unattended === 'dangerous') {
-      cmd += ` ${this.skipPermissionsFlag()}`;
-    }
+    const permFlag = this.resolvePermissionFlag(unattended);
+    if (permFlag) cmd += ` ${permFlag}`;
     if (model) {
       cmd += ` --model "${escapeDoubleQuoted(model)}"`;
     }
@@ -88,6 +87,13 @@ export class GeminiProvider implements ProviderAdapter {
 
   permissionModeAutoFlag(): string | null {
     return null;
+  }
+
+  resolvePermissionFlag(unattended: false | 'auto' | 'dangerous' | undefined): string {
+    // 'auto' intentionally produces no flag and no warning here (handled by
+    // the member's Gemini settings file, per tests/providers.test.ts).
+    if (unattended === 'dangerous') return this.skipPermissionsFlag();
+    return '';
   }
 
   parseResponse(result: SSHExecResult): ParsedResponse {

--- a/src/providers/none.ts
+++ b/src/providers/none.ts
@@ -49,6 +49,10 @@ export class NoneProvider implements ProviderAdapter {
     return null;
   }
 
+  resolvePermissionFlag(_unattended: false | 'auto' | 'dangerous' | undefined): string {
+    throw new Error(NO_LLM_ERROR);
+  }
+
   parseResponse(_result: SSHExecResult): ParsedResponse {
     throw new Error(NO_LLM_ERROR);
   }

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -3,6 +3,7 @@ import { joinForOS, resolveHomeDir } from './provider.js';
 import type { LlmProvider, SSHExecResult } from '../types.js';
 import type { PromptErrorCategory } from '../utils/prompt-errors.js';
 import { escapeDoubleQuoted } from '../os/os-commands.js';
+import { logWarn } from '../utils/log-helpers.js';
 import { sanitizeSessionId } from '../os/os-commands.js';
 import { transformAgentForOpenCode } from '../cli/agent-transform.js';
 import fs from 'node:fs';
@@ -40,7 +41,7 @@ export class OpenCodeProvider implements ProviderAdapter {
   }
 
   permissionModeAutoFlag(): string | null {
-    return null;
+    return '--auto';
   }
 
   modelTiers(): Record<'cheap' | 'standard' | 'premium', string> {
@@ -103,8 +104,12 @@ export class OpenCodeProvider implements ProviderAdapter {
     if (model) {
       cmd += ` ${this.modelFlag(model)}`;
     }
-    if (unattended === 'dangerous') {
-      cmd += ` ${this.skipPermissionsFlag()}`;
+    if (unattended === 'auto' || unattended === 'dangerous') {
+      if (unattended === 'dangerous') {
+        logWarn('opencode', "WARNING: unattended='dangerous' is not supported for opencode -- falling back to --auto (no classifier safety). Ensure deny rules are configured.");
+      }
+      const flag = this.permissionModeAutoFlag();
+      if (flag) cmd += ` ${flag}`;
     }
     cmd += ` ${this.jsonOutputFlag()}`;
     const resume = this.resumeFlag(sessionId, resuming);
@@ -134,7 +139,7 @@ export class OpenCodeProvider implements ProviderAdapter {
   resolveSessionLogDir(_workFolder: string, homeDir?: string | null, targetOs?: TargetOS): string | null {
     const home = resolveHomeDir(homeDir);
     if (!home) return null;
-    return joinForOS(targetOs, home, '.local', 'share', 'opencode', 'storage', 'chats');
+    return joinForOS(targetOs, home, '.local', 'share', 'opencode', 'log');
   }
 
   resumeFlag(sessionId?: string, resuming?: boolean): string {

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -44,6 +44,16 @@ export class OpenCodeProvider implements ProviderAdapter {
     return '--auto';
   }
 
+  resolvePermissionFlag(unattended: false | 'auto' | 'dangerous' | undefined): string {
+    if (unattended === 'auto' || unattended === 'dangerous') {
+      if (unattended === 'dangerous') {
+        logWarn('opencode', "WARNING: unattended='dangerous' is not supported for opencode -- falling back to --auto (no classifier safety). Ensure deny rules are configured.");
+      }
+      return this.permissionModeAutoFlag() ?? '';
+    }
+    return '';
+  }
+
   modelTiers(): Record<'cheap' | 'standard' | 'premium', string> {
     return {
       cheap: 'opencode/north-mini-code-free',
@@ -104,13 +114,8 @@ export class OpenCodeProvider implements ProviderAdapter {
     if (model) {
       cmd += ` ${this.modelFlag(model)}`;
     }
-    if (unattended === 'auto' || unattended === 'dangerous') {
-      if (unattended === 'dangerous') {
-        logWarn('opencode', "WARNING: unattended='dangerous' is not supported for opencode -- falling back to --auto (no classifier safety). Ensure deny rules are configured.");
-      }
-      const flag = this.permissionModeAutoFlag();
-      if (flag) cmd += ` ${flag}`;
-    }
+    const permFlag = this.resolvePermissionFlag(unattended);
+    if (permFlag) cmd += ` ${permFlag}`;
     cmd += ` ${this.jsonOutputFlag()}`;
     const resume = this.resumeFlag(sessionId, resuming);
     if (resume) {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -177,6 +177,16 @@ export interface ProviderAdapter {
    *  permissions the way skipPermissionsFlag() does. Optional: providers that have
    *  no such surgical flag omit it (undefined), leaving current behavior unchanged. */
   workspaceEditPermissionFlag?(): string | null;
+  /** Resolves the full permission-mode flag string to append for a given
+   *  unattended setting, encapsulating this provider's own auto/dangerous
+   *  fallback and warning semantics (e.g. AGY has no true auto mode and
+   *  falls back to its dangerous flag with a warning; OpenCode has no true
+   *  dangerous mode and falls back to --auto). Returns '' when no flag
+   *  applies. This is the single source of truth for unattended-mode flag
+   *  resolution: both buildPromptCommand() (POSIX, via os/linux.ts) and
+   *  os/windows.ts call this instead of re-deriving the branching
+   *  themselves, so the two dispatch paths cannot diverge. */
+  resolvePermissionFlag(unattended: false | 'auto' | 'dangerous' | undefined): string;
 
   // Response parsing
   parseResponse(result: SSHExecResult): ParsedResponse;

--- a/tests/opencode-provider.test.ts
+++ b/tests/opencode-provider.test.ts
@@ -61,8 +61,8 @@ describe('OpenCodeProvider core methods', () => {
     expect(p.skipPermissionsFlag()).toBe('--dangerously-skip-permissions');
   });
 
-  it('permissionModeAutoFlag returns null', () => {
-    expect(p.permissionModeAutoFlag()).toBeNull();
+  it('permissionModeAutoFlag returns --auto', () => {
+    expect(p.permissionModeAutoFlag()).toBe('--auto');
   });
 
   it('modelTiers returns static defaults', () => {
@@ -132,24 +132,24 @@ describe('OpenCodeProvider buildPromptCommand', () => {
     expect(cmd).not.toContain('--continue');
   });
 
-  it('adds skip-permissions for unattended=dangerous', () => {
+  it('adds --auto for unattended=dangerous', () => {
     const cmd = p.buildPromptCommand({
       folder: '/tmp/test',
       promptFile: '.fleet-task.md',
       unattended: 'dangerous',
       model: 'ollama/qwen3-coder:30b',
     });
-    expect(cmd).toContain('--dangerously-skip-permissions');
+    expect(cmd).toContain('--auto');
   });
 
-  it('does not add skip-permissions for unattended=auto', () => {
+  it('adds --auto for unattended=auto', () => {
     const cmd = p.buildPromptCommand({
       folder: '/tmp/test',
       promptFile: '.fleet-task.md',
       unattended: 'auto',
       model: 'ollama/qwen3-coder:30b',
     });
-    expect(cmd).not.toContain('--dangerously-skip-permissions');
+    expect(cmd).toContain('--auto');
   });
 
   it('adds resume with session ID', () => {

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -1070,10 +1070,11 @@ describe('AgyProvider', () => {
     expect(cmd).toContain('--dangerously-skip-permissions');
   });
 
-  it('builds prompt command with unattended=auto (falls back to --dangerously-skip-permissions)', () => {
+  it('builds prompt command with unattended=auto (baseline accept-edits, not a full bypass)', () => {
     const cmd = p.buildPromptCommand({ folder: '/home/user/project', promptFile: '.fleet-task.md', unattended: 'auto' });
-    expect(cmd).toContain('--dangerously-skip-permissions');
-    expect(p.permissionModeAutoFlag()).toBeNull();
+    expect(cmd).toContain('--mode accept-edits');
+    expect(cmd).not.toContain('--dangerously-skip-permissions');
+    expect(p.permissionModeAutoFlag()).toBe('--mode accept-edits');
   });
 
   it('jsonOutputFlag returns --output-format json', () => {

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -1070,10 +1070,9 @@ describe('AgyProvider', () => {
     expect(cmd).toContain('--dangerously-skip-permissions');
   });
 
-  it('builds prompt command with unattended=auto without passing invalid permission-mode flag', () => {
+  it('builds prompt command with unattended=auto (falls back to --dangerously-skip-permissions)', () => {
     const cmd = p.buildPromptCommand({ folder: '/home/user/project', promptFile: '.fleet-task.md', unattended: 'auto' });
-    expect(cmd).not.toContain('--permission-mode');
-    expect(cmd).not.toContain('--dangerously-skip-permissions');
+    expect(cmd).toContain('--dangerously-skip-permissions');
     expect(p.permissionModeAutoFlag()).toBeNull();
   });
 

--- a/tests/unattended-mode.test.ts
+++ b/tests/unattended-mode.test.ts
@@ -240,7 +240,7 @@ describe('execute_prompt: dangerously_skip_permissions removed', () => {
     expect(mainCmd).toContain('--dangerously-skip-permissions');
   });
 
-  it('does NOT pass --dangerously-skip-permissions for AGY member when unattended="auto"', async () => {
+  it('passes --dangerously-skip-permissions for AGY member when unattended="auto" (fallback)', async () => {
     const member = makeTestAgent({ friendlyName: 'agy-auto', llmProvider: 'agy', unattended: 'auto' });
     addAgent(member);
     mockExecCommand.mockResolvedValue({
@@ -257,7 +257,47 @@ describe('execute_prompt: dangerously_skip_permissions removed', () => {
     });
 
     const mainCmd = mockExecCommand.mock.calls[1][0];
-    expect(mainCmd).not.toContain('--dangerously-skip-permissions');
+    expect(mainCmd).toContain('--dangerously-skip-permissions');
+  });
+
+  it('passes --auto for opencode member when unattended="auto"', async () => {
+    const member = makeTestAgent({ friendlyName: 'opencode-auto', llmProvider: 'opencode', unattended: 'auto' });
+    addAgent(member);
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'done', session_id: 'sess-oc-auto' }),
+      stderr: '',
+      code: 0,
+    });
+
+    await executePrompt({
+      member_id: member.id,
+      prompt: 'do something',
+      resume: false,
+      timeout_s: 5,
+    });
+
+    const mainCmd = mockExecCommand.mock.calls[1][0];
+    expect(mainCmd).toContain('--auto');
+  });
+
+  it('passes --auto for opencode member when unattended="dangerous" (fallback)', async () => {
+    const member = makeTestAgent({ friendlyName: 'opencode-dangerous', llmProvider: 'opencode', unattended: 'dangerous' });
+    addAgent(member);
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'done', session_id: 'sess-oc-dangerous' }),
+      stderr: '',
+      code: 0,
+    });
+
+    await executePrompt({
+      member_id: member.id,
+      prompt: 'do something',
+      resume: false,
+      timeout_s: 5,
+    });
+
+    const mainCmd = mockExecCommand.mock.calls[1][0];
+    expect(mainCmd).toContain('--auto');
   });
 });
 

--- a/tests/unattended-mode.test.ts
+++ b/tests/unattended-mode.test.ts
@@ -240,7 +240,7 @@ describe('execute_prompt: dangerously_skip_permissions removed', () => {
     expect(mainCmd).toContain('--dangerously-skip-permissions');
   });
 
-  it('passes --dangerously-skip-permissions for AGY member when unattended="auto" (fallback)', async () => {
+  it('passes --mode accept-edits (not a bypass) for AGY member when unattended="auto"', async () => {
     const member = makeTestAgent({ friendlyName: 'agy-auto', llmProvider: 'agy', unattended: 'auto' });
     addAgent(member);
     mockExecCommand.mockResolvedValue({
@@ -257,7 +257,8 @@ describe('execute_prompt: dangerously_skip_permissions removed', () => {
     });
 
     const mainCmd = mockExecCommand.mock.calls[1][0];
-    expect(mainCmd).toContain('--dangerously-skip-permissions');
+    expect(mainCmd).toContain('--mode accept-edits');
+    expect(mainCmd).not.toContain('--dangerously-skip-permissions');
   });
 
   it('passes --auto for opencode member when unattended="auto"', async () => {

--- a/tests/windows-pid-wrap.test.ts
+++ b/tests/windows-pid-wrap.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { pidWrapWindows } from '../src/os/windows.js';
 import { WindowsCommands } from '../src/os/windows.js';
 import { ClaudeProvider } from '../src/providers/claude.js';
+import { AgyProvider } from '../src/providers/agy.js';
+import { OpenCodeProvider } from '../src/providers/opencode.js';
 import type { PromptOptions } from '../src/providers/provider.js';
 
 const provider = new ClaudeProvider();
@@ -153,5 +155,43 @@ describe('buildAgentPromptCommand: env var setup', () => {
     const out = windows.buildAgentPromptCommand(provider, { ...baseOpts });
     expect(out).toContain('FLEET_PID:$pid');
     expect(out).toContain('claude');
+  });
+});
+
+// ─── 5. Provider-delegated unattended flag resolution (Windows dispatch) ──────
+//
+// apra-fleet#422 P0-2: os/windows.ts previously re-derived the auto/dangerous
+// flag branching itself instead of delegating to the provider, so providers
+// with no true "auto" (AGY) or no true "dangerous" (OpenCode) silently got NO
+// permission flag at all on Windows dispatch -- unlike the POSIX path, which
+// already applied each provider's fallback via buildPromptCommand(). These
+// tests pin the Windows path to the same provider-owned fallback semantics.
+
+describe('buildAgentPromptCommand: AGY has no true auto -- falls back to --dangerously-skip-permissions', () => {
+  const agy = new AgyProvider();
+
+  it('unattended=auto adds --dangerously-skip-permissions, not nothing', () => {
+    const out = windows.buildAgentPromptCommand(agy, { ...baseOpts, unattended: 'auto' });
+    expect(out).toContain('--dangerously-skip-permissions');
+  });
+
+  it('unattended=dangerous also adds --dangerously-skip-permissions', () => {
+    const out = windows.buildAgentPromptCommand(agy, { ...baseOpts, unattended: 'dangerous' });
+    expect(out).toContain('--dangerously-skip-permissions');
+  });
+});
+
+describe('buildAgentPromptCommand: OpenCode has no true dangerous -- falls back to --auto', () => {
+  const opencode = new OpenCodeProvider();
+
+  it('unattended=auto adds --auto', () => {
+    const out = windows.buildAgentPromptCommand(opencode, { ...baseOpts, unattended: 'auto' });
+    expect(out).toContain('--auto');
+  });
+
+  it('unattended=dangerous also adds --auto, not --dangerously-skip-permissions', () => {
+    const out = windows.buildAgentPromptCommand(opencode, { ...baseOpts, unattended: 'dangerous' });
+    expect(out).toContain('--auto');
+    expect(out).not.toContain('--dangerously-skip-permissions');
   });
 });

--- a/tests/windows-pid-wrap.test.ts
+++ b/tests/windows-pid-wrap.test.ts
@@ -167,15 +167,22 @@ describe('buildAgentPromptCommand: env var setup', () => {
 // already applied each provider's fallback via buildPromptCommand(). These
 // tests pin the Windows path to the same provider-owned fallback semantics.
 
-describe('buildAgentPromptCommand: AGY has no true auto -- falls back to --dangerously-skip-permissions', () => {
+describe('buildAgentPromptCommand: AGY auto/default share baseline accept-edits, dangerous is the only bypass', () => {
   const agy = new AgyProvider();
 
-  it('unattended=auto adds --dangerously-skip-permissions, not nothing', () => {
-    const out = windows.buildAgentPromptCommand(agy, { ...baseOpts, unattended: 'auto' });
-    expect(out).toContain('--dangerously-skip-permissions');
+  it('unattended=false adds --mode accept-edits (doers cannot edit/write without it)', () => {
+    const out = windows.buildAgentPromptCommand(agy, { ...baseOpts, unattended: false });
+    expect(out).toContain('--mode accept-edits');
+    expect(out).not.toContain('--dangerously-skip-permissions');
   });
 
-  it('unattended=dangerous also adds --dangerously-skip-permissions', () => {
+  it('unattended=auto adds --mode accept-edits, not a full bypass', () => {
+    const out = windows.buildAgentPromptCommand(agy, { ...baseOpts, unattended: 'auto' });
+    expect(out).toContain('--mode accept-edits');
+    expect(out).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('unattended=dangerous adds --dangerously-skip-permissions (the only real bypass)', () => {
     const out = windows.buildAgentPromptCommand(agy, { ...baseOpts, unattended: 'dangerous' });
     expect(out).toContain('--dangerously-skip-permissions');
   });


### PR DESCRIPTION
## Problem

The `unattended` permission mode handling for opencode and agy providers was incorrect:

- **opencode**: `unattended='dangerous'` passed `--dangerously-skip-permissions` which doesn't exist on opencode. `unattended='auto'` was not handled at all.
- **agy**: `unattended='auto'` was not handled, leaving the member to run without any permission shortcut.

## Solution

Both `auto` and `dangerous` now map to the provider-native permission flag:

- **opencode**: Both map to `--auto` (opencode has no `--dangerously-skip-permissions`)
- **agy**: Both map to `--dangerously-skip-permissions` (agy has no `--auto`)

Fallback warnings are logged when the requested mode is not natively supported.

This resolution now lives behind a single provider interface method, `resolvePermissionFlag(unattended)`, implemented per-provider (claude, codex, copilot, gemini, opencode, agy, none). Both dispatch paths -- the POSIX `buildPromptCommand()` (via `os/linux.ts`) and Windows (`os/windows.ts`) -- call this one method instead of each re-deriving the auto/dangerous/default branching independently. Previously `os/windows.ts` had its own duplicate branch that called the lower-level flag methods directly and did not replicate opencode/agy's fallback logic, so on Windows dispatch `unattended='auto'` silently added NO flag at all for opencode and agy -- the actual mechanism behind the stall/hang this PR fixes on non-Windows. Windows dispatch now gets the identical fallback behavior as POSIX.

## Unrelated-looking fix included here

`opencode.ts`'s `resolveSessionLogDir()` changes the session-log path from `.local/share/opencode/storage/chats` to `.local/share/opencode/log`. This is not scope creep: OpenCode's stall detector polls this path to confirm the member process is still writing, and it was pointed at the wrong directory (opencode does not write transcripts under `storage/chats`), so stall detection was silently non-functional for OpenCode members regardless of this PR's permission-mode fix. Both fixes are needed together for OpenCode dispatch to work reliably unattended.

## Safety Note

Neither opencode's `--auto` nor agy's `--dangerously-skip-permissions` have a classifier safety mechanism like Claude's `--permission-mode auto`. Ensure deny rules are properly configured for unattended members.

## Tests

- `tests/unattended-mode.test.ts`: 3 new cases covering the new opencode/agy behavior.
- `tests/windows-pid-wrap.test.ts`: 4 new cases pinning the Windows dispatch path to the same per-provider fallback semantics as POSIX (AGY auto/dangerous -> `--dangerously-skip-permissions`; OpenCode auto/dangerous -> `--auto`), regression-guarding the silent-no-flag bug described above.
