### PR TITLE
docs: persistent-memory disambiguation rule (Claude memory / bd remember / KB)

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+Commands below use `node .gitnexus/run.cjs <command>` -- the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
+
+> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent -- e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
+
+## Commands
+
+### analyze -- Build or refresh the index
+
+```bash
+node .gitnexus/run.cjs analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+| `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+| `--pdg` | Build the program-dependence layers used by `explain` and `pdg_query` (taint, CDG, and REACHING_DEF). |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` -- the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
+
+### status -- Check index freshness
+
+```bash
+node .gitnexus/run.cjs status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean -- Delete the index
+
+```bash
+node .gitnexus/run.cjs clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki -- Generate documentation from the graph
+
+```bash
+node .gitnexus/run.cjs wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list -- Show all indexed repos
+
+```bash
+node .gitnexus/run.cjs list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. query({search_query: "<error or symptom>"})            -> Find related execution flows
+2. context({name: "<suspect>"})                    -> See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                -> Trace execution flow
+4. cypher({statement: "MATCH path..."})                 -> Custom traces if needed
+```
+
+> If "Index is stale" -> run `node .gitnexus/run.cjs analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `query` for error text -> `context` on throw sites |
+| Wrong return value   | `context` on the function -> trace callees for data flow    |
+| Intermittent failure | `context` -> look for external calls, async deps            |
+| Performance issue    | `context` -> find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+| "How does A reach B?" | `trace` between the two symbols -- shortest call chain in one call |
+
+## Tools
+
+**query** -- find code related to error:
+
+```
+query({search_query: "payment validation error"})
+-> Processes: CheckoutFlow, ErrorHandling
+-> Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**context** -- full context for a suspect:
+
+```
+context({name: "validatePayment"})
+-> Incoming calls: processCheckout, webhookHandler
+-> Outgoing calls: verifyCard, fetchRates (external API!)
+-> Processes: CheckoutFlow (step 3/7)
+```
+
+**cypher** -- custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+**trace** -- shortest call chain between two symbols ("how does A reach B?"), one call instead of chaining `context` hops:
+
+```
+trace({ from: "processCheckout", to: "fetchRates" })
+-> status: ok, hopCount: 3
+-> hops: processCheckout -> validatePayment -> verifyCard -> fetchRates
+-> edges: CALLS (1.0), CALLS (0.95), CALLS (1.0)
+```
+
+When no path exists, `trace` reports the furthest reachable node -- exactly where the chain breaks (dynamic dispatch, reflection, or an external boundary).
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. query({search_query: "payment error handling"})
+   -> Processes: CheckoutFlow, ErrorHandling
+   -> Symbols: validatePayment, handlePaymentError
+
+2. context({name: "validatePayment"})
+   -> Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   -> Step 3: validatePayment -> calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          -> Discover indexed repos
+2. READ gitnexus://repo/{name}/context             -> Codebase overview, check staleness
+3. query({search_query: "<what you want to understand>"})  -> Find related execution flows
+4. context({name: "<symbol>"})            -> Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      -> Trace full execution flow
+```
+
+> If step 2 says "Index is stale" -> run `node .gitnexus/run.cjs analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**query** -- find execution flows related to a concept:
+
+```
+query({search_query: "payment processing"})
+-> Processes: CheckoutFlow, RefundFlow, WebhookHandler
+-> Symbols grouped by flow with file locations
+```
+
+**context** -- 360-degree view of a symbol:
+
+```
+context({name: "validateUser"})
+-> Incoming calls: loginHandler, apiMiddleware
+-> Outgoing calls: checkToken, getUserById
+-> Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       -> 918 symbols, 45 processes
+2. query({search_query: "payment processing"})
+   -> CheckoutFlow: processPayment -> validateCard -> chargeStripe
+   -> RefundFlow: initiateRefund -> calculateRefund -> processRefund
+3. context({name: "processPayment"})
+   -> Incoming: checkoutHandler, webhookHandler
+   -> Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself -- available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** -- codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence -- execution flows related to a concept |
+| `context`        | 360-degree symbol view -- categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius -- what breaks at depth 1/2/3 with confidence         |
+| `trace`          | Shortest path between two symbols -- "how does A reach B?" in one call     |
+| `detect_changes` | Git-diff impact -- what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `explain`        | Persisted taint findings -- source->sink data flows (needs `analyze --pdg`) |
+| `pdg_query`      | Control/data dependence -- what gates X (CDG) / where Y flows (REACHING_DEF); needs `analyze --pdg` |
+| `check`          | Check graph invariants such as circular imports                          |
+| `route_map`      | API route map -- which components/hooks fetch which endpoints, and the handler files that serve them |
+| `shape_check`    | Response-shape drift -- keys each route returns vs keys its consumers access (flags MISMATCH) |
+| `api_impact`     | Pre-change report for an API route -- consumers, middleware, shape mismatches, risk level |
+| `tool_map`       | MCP/RPC tool definitions and the files that handle them                  |
+| `group_list`     | List configured multi-repo groups, or one group's config                 |
+| `group_sync`     | Rebuild a group's Contract Registry (cross-repo HTTP contract links); run after `group.yaml` changes or member re-index |
+| `list_repos`     | Discover indexed repos (paginated -- `limit`/`offset`)                    |
+
+### Paginating `list_repos`
+
+`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
+
+```jsonc
+{
+  "repositories": [
+    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
+  ],
+  "pagination": {
+    "total": 437,
+    "limit": 50,
+    "offset": 0,
+    "returned": 50,
+    "hasMore": true,
+    "nextOffset": 50
+  }
+}
+```
+
+To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
+
+```text
+list_repos {}               -> repos 1-50,    nextOffset 50,  hasMore true
+list_repos { offset: 50 }   -> repos 51-100,  nextOffset 100, hasMore true
+...
+list_repos { offset: 400 }  -> repos 401-437,                 hasMore false   (done)
+```
+
+Notes: `offset` >= `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error -- `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
+
+### Taint findings (`explain`)
+
+`explain` returns taint findings recorded by `gitnexus analyze --pdg` -- intra-procedural `TAINTED` edges plus cross-function `TAINT_PATH` hops where the interprocedural taint phase found a function-level source->sink chain. Each finding includes a sink category (command-injection, code-injection, path-traversal, sql-injection, xss), source/sink lines, and the ordered hop path with the variable carried on each hop.
+
+- `explain {}` -- enumerate all findings for the repo (bounded by `limit`, deterministic order)
+- `explain { target: "src/vuln.ts" }` -- findings in a file (suffix path match accepted)
+- `explain { target: "runUserCommand" }` -- findings in a function (resolved like `context`; ambiguous names return ranked candidates)
+
+A repo indexed without `--pdg` returns a clear "no taint layer" note. Caveats: closure/callback, property/field, and implicit flows are not modeled, and interprocedural findings are function-level `TAINT_PATH` hops rather than statement-level path proof, so the absence of a finding is **not** proof of safety. `SANITIZES` (sanitizer-kill) edges are queryable via `cypher`.
+
+### Control & data dependence (`pdg_query`)
+
+`pdg_query` reads the control/data-dependence layers `gitnexus analyze --pdg` records (CDG + REACHING_DEF, basic-block granular) -- the control/data analog of `explain`. It is **always anchored** (a `target` file path or symbol, resolved like `context`) and has two modes:
+
+- `pdg_query { mode: "controls", target: "..." }` -- CDG: "under what condition does X run?". Each edge is a controlling predicate block -> dependent block with the branch sense (`'T'`/`'F'`) in `reason`; an edge into an early `return`/`throw` is flagged `guard: true` (guard-clause discovery -- the sense depends on the predicate, so don't filter guards by a fixed label).
+- `pdg_query { mode: "flows", target: "...", variable?: "..." }` -- REACHING_DEF def->use edges within the function; pass `variable` to trace one binding.
+
+A repo indexed without `--pdg` returns a "no PDG layer" note (or "status unknown" when the layer can't be confirmed). Intra-procedural only -- cross-function flow is taint's domain (`explain`). The raw CDG/REACHING_DEF edges are also queryable via `cypher`. See the `gitnexus-pdg-query` skill for the full query surface.
+
+### Shortest path between two symbols (`trace`)
+
+`trace` answers "how does A reach B?" in one call -- the shortest directed path over `CALLS` (plus `HAS_METHOD`, so a class-rooted trace descends into its methods) instead of chaining 3-8 `context`/`impact` hops by hand.
+
+- `trace { from: "validateUser", to: "executeQuery" }` -- shortest path between two symbols.
+- Disambiguate common names with `from_uid`/`to_uid` (zero-ambiguity) or `from_file`/`to_file`; an ambiguous name returns ranked candidates.
+- `maxDepth` (default 10, max 30) bounds the search; `includeTests` (default false) lets the traversal pass through test-file symbols.
+
+Returns ordered `hops` (each `{ name, filePath, startLine }`) and an aligned `edges[]` of `{ relType, confidence }`, so call hops and containment (`HAS_METHOD`) hops stay distinguishable. When no path exists it reports the **furthest** reachable node (where the chain breaks) and sets `truncated: true` if a traversal cap was hit first. Every result carries a `status`: `ok` / `no_path` / `ambiguous` / `not_found` / `error`.
+
+Cross-repo (experimental): pass `repo: "@groupName"` to trace across a group's member repos -- the path may cross **one** `ContractLink` boundary (reported as a `CONTRACT_LINK` hop with the bridged contract in `crossings[]`). Omit `to` entirely to follow `from`'s outgoing HTTP call to whatever provider endpoint it lands on. Groups are configured via `group_list` / `group_sync`.
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Folder, Function, Class, Interface, Method, CodeElement, Community, Process, Route, Tool, plus language-specific types (Struct, Enum, Trait, Impl, Namespace, Module, ...) and BasicBlock (`--pdg` indexes only). The full node list lives in `gitnexus://repo/{name}/schema`.
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, CONTAINS, MEMBER_OF, HAS_METHOD, HAS_PROPERTY, ACCESSES, METHOD_OVERRIDES, METHOD_IMPLEMENTS, STEP_IN_PROCESS, HANDLES_ROUTE, FETCHES, HANDLES_TOOL, ENTRY_POINT_OF, WRAPS, QUERIES, INJECTS, plus `--pdg`-only types (CFG, REACHING_DEF, TAINTED, SANITIZES, TAINT_PATH, CDG -- zero rows on a default index).
+
+Read `gitnexus://repo/{name}/schema` before writing Cypher -- it is the authoritative schema for the indexed repo.
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing -- to understand what your changes affect
+
+## Workflow
+
+```
+1. impact({target: "X", direction: "upstream"})  -> What depends on this
+2. READ gitnexus://repo/{name}/processes                   -> Check affected execution flows
+3. detect_changes()                               -> Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" -> run `node .gitnexus/run.cjs analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**impact** -- the primary tool for symbol blast radius:
+
+```
+impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+-> d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+-> d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**detect_changes** -- git-diff based impact analysis:
+
+```
+detect_changes({scope: "staged"})
+
+-> Changed: 5 symbols in 3 files
+-> Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+-> Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. impact({target: "validateUser", direction: "upstream"})
+   -> d=1: loginHandler, apiMiddleware (WILL BREAK)
+   -> d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   -> LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. impact({target: "X", direction: "upstream"})  -> Map all dependents
+2. query({search_query: "X"})                            -> Find execution flows involving X
+3. context({name: "X"})                           -> See all incoming/outgoing refs
+4. Plan update order: interfaces -> implementations -> callers -> tests
+```
+
+> If "Index is stale" -> run `node .gitnexus/run.cjs analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) -- preview all edits
+- [ ] Review graph edits (high confidence) and text_search edits (review carefully)
+- [ ] If satisfied: rename({..., dry_run: false}) -- apply edits
+- [ ] detect_changes() -- verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] context({name: target}) -- see all incoming/outgoing refs
+- [ ] impact({target, direction: "upstream"}) -- find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] detect_changes() -- verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] context({name: target}) -- understand all callees
+- [ ] Group callees by responsibility
+- [ ] impact({target, direction: "upstream"}) -- map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] detect_changes() -- verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**rename** -- automated multi-file rename:
+
+```
+rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+-> 12 edits across 8 files
+-> 10 graph edits (high confidence), 2 text_search edits (review)
+-> Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**impact** -- map all dependents first:
+
+```
+impact({target: "validateUser", direction: "upstream"})
+-> d=1: loginHandler, apiMiddleware, testUtils
+-> Affected Processes: LoginFlow, TokenRefresh
+```
+
+**detect_changes** -- verify your changes after refactoring:
+
+```
+detect_changes({scope: "all"})
+-> Changed: 8 files, 12 symbols
+-> Affected processes: LoginFlow, TokenRefresh
+-> Risk: MEDIUM
+```
+
+**cypher** -- custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   -> 12 edits: 10 graph (safe), 2 text_search (review)
+   -> Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review text_search edits (config.json: dynamic reference!)
+
+3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   -> Applied 12 edits across 8 files
+
+4. detect_changes({scope: "all"})
+   -> Affected: LoginFlow, TokenRefresh
+   -> Risk: MEDIUM -- run tests for these flows
+```

--- a/.fleet/kb-canonical.json
+++ b/.fleet/kb-canonical.json
@@ -1,9 +1,9 @@
 {
   "version": 2,
   "provenance": {
-    "commit": "29e823d77149bacd99a92800cff822abfa008f5b",
-    "branch": "fix/kb-remote-anchor-and-wiring",
-    "entry_count": 31
+    "commit": "aef342816f5c232202c0679e98dc814f11e0076f",
+    "branch": "chore/persistent-memory-disambiguation-rule",
+    "entry_count": 36
   },
   "entries": [
     {
@@ -22,7 +22,25 @@
         "src/tools/kb-import.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T16:18:03.897Z"
+      "updated_at": "2026-08-18T20:35:07.242Z"
+    },
+    {
+      "id": "10e15056-ffd7-4f2a-9441-0847c0f382a2",
+      "type": "knowledge",
+      "title": "Provider abstraction: never assume Claude",
+      "summary": "apra-fleet supports seven LLM providers (claude, agy, opencode, codex, copilot, gemini, none), not just Claude. Any auth/credential/dispatch-related change must go through the generic ProviderAdapter interface rather than assuming Claude-specific fields or behavior.",
+      "symbols": [
+        "ProviderAdapter",
+        "authEnvVar",
+        "authEnvVarForToken",
+        "oauthCredentialFiles"
+      ],
+      "source_files": [
+        "src/providers/provider.ts",
+        "src/providers/opencode.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T21:51:20.998Z"
     },
     {
       "id": "130bc73b-fade-4d3a-8254-2ad3b2e1bfef",
@@ -34,7 +52,29 @@
         "src/services/knowledge/kb-providers.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T20:10:22.938Z"
+      "updated_at": "2026-08-18T20:35:07.323Z"
+    },
+    {
+      "id": "138565bf-b3ed-4901-8aab-d6adffb232ec",
+      "type": "knowledge",
+      "title": "One anchor policy, three branches: verbatim for read tools, hard-fail for kb_export",
+      "summary": "kb_session_prime and kb_stats pass a supplied repo_path to getKbProviders verbatim so an unreachable remote anchor stays honestly missing; kb_export deliberately keeps throwing instead, because it writes into repo_path -- and it throws before getKbProviders, so it never anchors at the server cwd either.",
+      "symbols": [
+        "kbStats",
+        "kbExport",
+        "kbSessionPrime",
+        "getKbProviders",
+        "resolveRepoPath"
+      ],
+      "source_files": [
+        "src/tools/kb-stats.ts",
+        "src/tools/kb-export.ts",
+        "src/tools/kb-session-prime.ts",
+        "src/services/knowledge/kb-providers.ts",
+        "tests/knowledge/kb-anchor-never-cwd.test.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:07.882Z"
     },
     {
       "id": "1ae4ce00-ce11-4bc4-becb-7e6355809f6b",
@@ -48,7 +88,38 @@
         "packages/apra-fleet-se/apra-pm/skills/pm/cost.md"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-12T05:18:16.610Z"
+      "updated_at": "2026-08-18T20:35:07.375Z"
+    },
+    {
+      "id": "202cd324-f6d9-42d0-b0a2-a4aa8e1741ef",
+      "type": "knowledge",
+      "title": "Local members use host OAuth; provision_llm_auth skips them",
+      "summary": "Local fleet members share the orchestrator's own machine, so they use whatever OAuth session is already active on that host. provision_llm_auth explicitly skips local members rather than attempting to provision credentials for them.",
+      "symbols": [
+        "provisionAuth"
+      ],
+      "source_files": [
+        "src/tools/provision-auth.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T21:51:01.387Z"
+    },
+    {
+      "id": "2198295a-c0a8-4598-a612-17742024970b",
+      "type": "knowledge",
+      "title": "Same-slug callers now open two SqliteProvider handles on one kb.sqlite",
+      "summary": "Keying the KB provider cache by (slug, repoPath) means two local clones of the same remote get two separate SqliteProvider instances pointed at the same kb.sqlite file; this is safe by design because init sets WAL plus busy_timeout=5000.",
+      "symbols": [
+        "getKbProviders",
+        "createKbProvidersForSlug",
+        "SqliteProvider.init"
+      ],
+      "source_files": [
+        "src/services/knowledge/kb-providers.ts",
+        "src/services/knowledge/sqlite-provider.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:08.266Z"
     },
     {
       "id": "254b18e2-8f53-4a3b-bebd-3ab08609aec7",
@@ -63,7 +134,7 @@
         "src/services/knowledge/project-slug.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T16:29:49.112Z"
+      "updated_at": "2026-08-18T20:35:07.445Z"
     },
     {
       "id": "2ff14a5c-f502-4212-bc1d-89c5955cd364",
@@ -81,25 +152,44 @@
         "src/tools/kb-list.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T16:29:49.115Z"
+      "updated_at": "2026-08-18T20:35:07.501Z"
     },
     {
-      "id": "40b95472-f615-4235-9fa7-3010a65a603a",
+      "id": "34887ffc-e128-46b6-962e-23b1c62eb9b7",
       "type": "knowledge",
-      "title": "KB slug cache is keyed by (cwd, remoteUrl) but the provider cache is still keyed by slug alone",
-      "summary": "_slugCache uses a NUL-joined (cwd, remoteUrl) key so a later URL-bearing call is not pinned to an earlier path-only slug; _providers is still keyed by slug only, so the cached provider keeps the FIRST caller's repoPath.",
+      "title": "Four resolveRepoPath helpers exist in src/tools, but only prime and stats ever had the null-to-cwd shape",
+      "summary": "kb-session-prime.ts and kb-stats.ts returned string|null and degraded to process.cwd(); kb-export.ts and kb-import.ts have always returned string and thrown, so they were never part of the b4g.7 anchor defect despite the bead naming kb-export as a third instance.",
       "symbols": [
-        "slugFor",
-        "getKbProviders",
-        "createKbProviders",
-        "resetKbProviders"
+        "resolveRepoPath",
+        "kbImport",
+        "kbExport",
+        "getKbProviders"
       ],
       "source_files": [
-        "src/services/knowledge/kb-providers.ts",
-        "src/services/knowledge/project-slug.ts"
+        "src/tools/kb-import.ts",
+        "src/tools/kb-export.ts",
+        "src/tools/kb-stats.ts",
+        "src/tools/kb-session-prime.ts",
+        "docs/knowledge-layer.md"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T15:01:39.752Z"
+      "updated_at": "2026-08-18T20:35:07.946Z"
+    },
+    {
+      "id": "40295d4d-390f-466a-87c9-2df0a94cf3a6",
+      "type": "knowledge",
+      "title": "The embeddeddolt sandbox test can pass vacuously when bd is unavailable",
+      "summary": "checkDoltRemoteAbsent's bd-unavailable fallback message contains the word 'unavailable', which the embeddeddolt test's own /Dolt-level remotes|unavailable/ assertion accepts -- so on a machine without bd the test is green without ever reaching the parser it is meant to exercise.",
+      "symbols": [
+        "checkDoltRemoteAbsent",
+        "parseDoltRemoteList"
+      ],
+      "source_files": [
+        "tests/check-sandbox-sync-remote.test.ts",
+        "scripts/check-sandbox-sync-remote.mjs"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:08.515Z"
     },
     {
       "id": "45fa7bb5-1af4-474d-a958-0c1d7f6ec75c",
@@ -113,24 +203,82 @@
         "src/services/knowledge/audn.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-04T04:04:51.757Z"
+      "updated_at": "2026-08-18T20:35:07.598Z"
     },
     {
-      "id": "494a1ec0-6245-460e-908a-b6ad41e0a199",
-      "type": "learning",
-      "title": "Provider cache key mutation test confirms b4g.2.2 pins the b4g.2.1 fix, not a vacuous test",
-      "summary": "Reverting getKbProviders' cache key from providerKey(slug, repoPath) to slug-only makes tests/knowledge/kb-provider-cache-key.test.ts fail on cases 1 and 3 (2 of 4), confirming the new regression test in apra-fleet-b4g.2.2 actually detects the bug apra-fleet-b4g.2.1 fixed rather than passing regardless.",
+      "id": "4844d64a-deee-4b5d-87d2-6fcd8c596f64",
+      "type": "knowledge",
+      "title": "apra-fleet-se's plain npm test never sets APRA_FLEET_TEST_CONCURRENCY",
+      "summary": "packages/apra-fleet-se's \"test\" script runs node --test directly with --test-concurrency=8, but does NOT set the APRA_FLEET_TEST_CONCURRENCY env var -- only the separate test:unit/test:integration/test:record scripts (which route through scripts/run-tests.mjs) set it. A scaledTimeout()/waitFor() call that relies on the env var being set will silently use an unscaled timeout under plain npm test.",
       "symbols": [
-        "getKbProviders",
-        "providerKey",
-        "resetKbProviders"
+        "scaledTimeout",
+        "waitFor"
       ],
       "source_files": [
-        "tests/knowledge/kb-provider-cache-key.test.ts",
-        "src/services/knowledge/kb-providers.ts"
+        "packages/apra-fleet-se/package.json",
+        "packages/apra-fleet-se/scripts/run-tests.mjs",
+        "packages/apra-fleet-se/test/helpers/scaled-timeout.mjs"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T16:04:51.480Z"
+      "updated_at": "2026-08-18T21:50:58.094Z"
+    },
+    {
+      "id": "4f84e1c5-733d-40c3-84e2-8eb1b45d3e22",
+      "type": "knowledge",
+      "title": "The .trim() guard in resolveProjectSlug is provably redundant and cannot be pinned by any test",
+      "summary": "project-slug.ts guards its remote-URL short-circuit twice, but the outer remoteUrl.trim() check is unreachable-by-effect given slugify, so no input can distinguish its removal and no regression test can pin it.",
+      "symbols": [
+        "resolveProjectSlug",
+        "slugify"
+      ],
+      "source_files": [
+        "src/services/knowledge/project-slug.ts",
+        "tests/knowledge/kb-remote-scope.test.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:08.862Z"
+    },
+    {
+      "id": "56d8e8d0-f704-467b-b2a3-2611ccf6e0df",
+      "type": "knowledge",
+      "title": "kb-setup is the one kb tool that takes repo_path but resolves no KB",
+      "summary": "Fifteen of the sixteen src/tools/kb-*.ts tools spread kbScopeFields and forward repo_remote_url to getKbProviders; kb-setup is excluded by design because its repo_path only locates a .git dir for hook installation and it writes a single global config, never selecting a project KB.",
+      "symbols": [
+        "kbSetup",
+        "kbSetupSchema",
+        "kbScopeFields",
+        "getKbProviders"
+      ],
+      "source_files": [
+        "src/tools/kb-setup.ts",
+        "src/services/knowledge/kb-scope-input.ts",
+        "src/tools/kb-list.ts",
+        "src/tools/kb-stats.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:08.627Z"
+    },
+    {
+      "id": "5d7d0886-e403-482a-83c9-709efc6b0d56",
+      "type": "knowledge",
+      "title": "repo_remote_url is defined once in kbScopeFields but only 3 of ~16 kb_* tools spread it",
+      "summary": "src/services/knowledge/kb-scope-input.ts holds the single zod definition; only kb_session_prime, kb_capture and kb_harvest spread it, so kb_list and the other read tools silently drop the field and resolve to the path-derived KB.",
+      "symbols": [
+        "kbScopeFields",
+        "kbListSchema",
+        "kbCaptureSchema",
+        "kbHarvestSchema",
+        "kbSessionPrimeSchema"
+      ],
+      "source_files": [
+        "src/services/knowledge/kb-scope-input.ts",
+        "src/tools/kb-list.ts",
+        "src/tools/kb-capture.ts",
+        "src/tools/kb-harvest.ts",
+        "src/tools/kb-session-prime.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:09.001Z"
     },
     {
       "id": "62a26c94-e079-4158-b83b-5702e317b54c",
@@ -145,7 +293,7 @@
         "packages/apra-fleet-se/apra-pm/test/sprint-meta.test.mjs"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-12T05:53:12.692Z"
+      "updated_at": "2026-08-18T20:35:07.705Z"
     },
     {
       "id": "66075242-ab8e-40f1-a1b4-c2ecb01a007c",
@@ -159,7 +307,7 @@
         "packages/apra-fleet-se/apra-pm/test/sprint-log-flush.test.mjs"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-12T05:53:12.698Z"
+      "updated_at": "2026-08-18T20:35:07.763Z"
     },
     {
       "id": "696d42bc-615c-4156-b43a-b67210fc2dea",
@@ -180,50 +328,82 @@
         "tests/execute-prompt-kb-harvest-remote-url.test.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T21:02:37.672Z"
+      "updated_at": "2026-08-18T20:35:07.824Z"
     },
     {
-      "id": "89906789-4847-40ec-a5a6-2bd17c766180",
+      "id": "735f21d3-01da-4913-9ebe-d31320b9bef4",
       "type": "knowledge",
-      "title": "One anchor policy, three branches: verbatim for read tools, hard-fail for kb_export",
-      "summary": "kb_session_prime and kb_stats pass a supplied repo_path to getKbProviders verbatim so an unreachable remote anchor stays honestly missing; kb_export deliberately keeps throwing instead, because it writes into repo_path -- and it throws before getKbProviders, so it never anchors at the server cwd either.",
+      "title": "{{secure.NAME}} substitution is pre-escaped and launch-time bound",
+      "summary": "execute_command resolves {{secure.NAME}} fleet-secret placeholders with single-quote escaping already applied. Reference the token bare in a command string, not wrapped in your own quotes -- double-escaping produces a corrupted value and a false 401/invalid-token error.",
       "symbols": [
-        "kbStats",
-        "kbExport",
-        "kbSessionPrime",
+        "resolveSecurePlaceholders"
+      ],
+      "source_files": [
+        "src/tools/execute-command.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T21:51:09.005Z"
+    },
+    {
+      "id": "7cc58351-c7f9-4f14-99b0-cdd04cf83d7c",
+      "type": "knowledge",
+      "title": "Member OS resolution: always via agent.os",
+      "summary": "The orchestrator and each fleet member can independently run Windows/Mac/Linux -- local members share the orchestrator's own OS, but remote members can be any OS regardless of the orchestrator's. Never assume a target member's shell/OS matches the orchestrator's.",
+      "symbols": [
+        "getAgentOS",
+        "getOsCommands"
+      ],
+      "source_files": [
+        "src/os/index.ts",
+        "src/utils/agent-helpers.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T21:51:13.164Z"
+    },
+    {
+      "id": "8997f326-d6e7-485f-ad84-782650030314",
+      "type": "knowledge",
+      "title": "Local vs remote member dispatch paths",
+      "summary": "Local members share the orchestrator's own machine and credentials, so no SSH or file probe is needed -- check agent.agentType === 'local' and short-circuit. Remote members require actual SSH connectivity and credential probes.",
+      "symbols": [
+        "preflightCheck"
+      ],
+      "source_files": [
+        "src/services/preflight-check.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T21:51:16.901Z"
+    },
+    {
+      "id": "a2bed3b4-6a18-4ee6-b736-333981d804ba",
+      "type": "learning",
+      "title": "Provider cache key mutation test confirms b4g.2.2 pins the b4g.2.1 fix, not a vacuous test",
+      "summary": "Reverting getKbProviders' cache key from providerKey(slug, repoPath) to slug-only makes tests/knowledge/kb-provider-cache-key.test.ts fail on cases 1 and 3 (2 of 4), confirming the new regression test in apra-fleet-b4g.2.2 actually detects the bug apra-fleet-b4g.2.1 fixed rather than passing regardless.",
+      "symbols": [
         "getKbProviders",
-        "resolveRepoPath"
+        "providerKey",
+        "resetKbProviders"
       ],
       "source_files": [
-        "src/tools/kb-stats.ts",
-        "src/tools/kb-export.ts",
-        "src/tools/kb-session-prime.ts",
-        "src/services/knowledge/kb-providers.ts",
-        "tests/knowledge/kb-anchor-never-cwd.test.ts"
+        "tests/knowledge/kb-provider-cache-key.test.ts",
+        "src/services/knowledge/kb-providers.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T21:02:37.666Z"
+      "updated_at": "2026-08-18T20:35:07.650Z"
     },
     {
-      "id": "a236cdef-507f-463e-a807-50878e0e4246",
+      "id": "a96e64d8-e304-4a46-baeb-d36fe1371a94",
       "type": "knowledge",
-      "title": "Four resolveRepoPath helpers exist in src/tools, but only prime and stats ever had the null-to-cwd shape",
-      "summary": "kb-session-prime.ts and kb-stats.ts returned string|null and degraded to process.cwd(); kb-export.ts and kb-import.ts have always returned string and thrown, so they were never part of the b4g.7 anchor defect despite the bead naming kb-export as a third instance.",
-      "symbols": [
-        "resolveRepoPath",
-        "kbImport",
-        "kbExport",
-        "getKbProviders"
-      ],
+      "title": "Lockfile drift is invisible to npm test",
+      "summary": "A PR review that runs only 'npm test' cannot catch package.json/package-lock.json drift (e.g. a dependency override added to package.json without regenerating the lockfile), because npm test runs against whatever node_modules is already populated. Only 'npm ci' -- the reproducible-install path CI actually uses -- reproduces that failure.",
+      "symbols": [],
       "source_files": [
-        "src/tools/kb-import.ts",
-        "src/tools/kb-export.ts",
-        "src/tools/kb-stats.ts",
-        "src/tools/kb-session-prime.ts",
-        "docs/knowledge-layer.md"
+        "package.json",
+        "package-lock.json",
+        "packages/apra-fleet-se/fleet-sprint/runner.js"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T22:15:35.319Z"
+      "updated_at": "2026-08-18T21:51:04.975Z"
     },
     {
       "id": "b0f6be79-738c-491b-9ba5-7c7e5d69b805",
@@ -244,7 +424,7 @@
         "src/tools/code-intelligence-kb-enrich.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T21:58:44.645Z"
+      "updated_at": "2026-08-18T20:35:08.007Z"
     },
     {
       "id": "b368ad28-9c4a-47fd-9acf-5f25a8a29bca",
@@ -257,7 +437,25 @@
         ".claude/settings.json"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-12T05:07:17.774Z"
+      "updated_at": "2026-08-18T20:35:08.060Z"
+    },
+    {
+      "id": "b86607c4-ff63-427e-bf6a-01ae5870e51e",
+      "type": "knowledge",
+      "title": "A missing-anchor freshness regression surfaces first as kb_list dropping entries, not as a stale-flag assertion",
+      "summary": "In tests/knowledge/kb-remote-member-e2e.test.ts the four remote-member assertions live in one it(), so removing SqliteProvider's anchorIsMissing guard fails at the SAME DATABASE read-back (line 165) and never reaches the raw stale-row check (line 181).",
+      "symbols": [
+        "anchorIsMissing",
+        "checkFreshness",
+        "kbStats"
+      ],
+      "source_files": [
+        "tests/knowledge/kb-remote-member-e2e.test.ts",
+        "src/services/knowledge/sqlite-provider.ts",
+        "src/tools/kb-stats.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:08.929Z"
     },
     {
       "id": "beb4faf7-40fa-4484-9cf5-b287df8f47d2",
@@ -270,7 +468,7 @@
         "src/services/knowledge/kb-scope-input.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T20:10:22.943Z"
+      "updated_at": "2026-08-18T20:35:08.112Z"
     },
     {
       "id": "c2899616-0cb1-41e8-b229-76e291a0cd81",
@@ -290,10 +488,54 @@
         "tests/knowledge/kb-remote-anchor-freshness.test.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T20:10:22.934Z"
+      "updated_at": "2026-08-18T20:35:08.160Z"
     },
     {
-      "id": "c2d3fa00-5f7f-408e-9bdd-0f49101173fc",
+      "id": "c9047868-445d-41a8-b951-ccb2f195d21b",
+      "type": "knowledge",
+      "title": "bd dolt remote list --json prints null, not [], when no remotes are configured",
+      "summary": "parseDoltRemoteList must map the JSON literal null to an empty array; treating null as an unexpected shape makes checkDoltRemoteAbsent return ok:false ('could not parse') for a repo that is simply not wired to any Dolt remote.",
+      "symbols": [
+        "parseDoltRemoteList",
+        "checkDoltRemoteAbsent"
+      ],
+      "source_files": [
+        "scripts/check-sandbox-sync-remote.mjs",
+        "tests/check-sandbox-sync-remote.test.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:08.353Z"
+    },
+    {
+      "id": "c996a17a-24af-4009-8472-0f1c5b868ca7",
+      "type": "knowledge",
+      "title": "deploy.md's Permissions section is the source of truth for .claude/settings.json allow-list",
+      "summary": "The deploy phase's runnable command set is defined by deploy.md lines 6-18, and .claude/settings.json permissions.allow must mirror exactly that list -- bead descriptions quoting an older list are stale and must not be followed.",
+      "symbols": [],
+      "source_files": [
+        "deploy.md",
+        ".claude/settings.json"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:08.404Z"
+    },
+    {
+      "id": "c9ec410a-37d6-4434-b1af-f87e45f90eef",
+      "type": "knowledge",
+      "title": "The embeddeddolt test now branches on bd availability instead of a loose regex",
+      "summary": "tests/check-sandbox-sync-remote.test.ts probes `bd --version` and asserts /Dolt-level remotes/ when bd is reachable, /unavailable/ when it is not, closing the vacuous-pass hole the old combined regex left open.",
+      "symbols": [
+        "checkDoltRemoteAbsent"
+      ],
+      "source_files": [
+        "tests/check-sandbox-sync-remote.test.ts",
+        "scripts/check-sandbox-sync-remote.mjs"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-18T20:35:08.456Z"
+    },
+    {
+      "id": "d2c1e093-0c14-40e7-8798-4deb8c931435",
       "type": "knowledge",
       "title": "kb_session_prime must pass an explicit repo_path to getKbProviders verbatim, never through resolveRepoPath",
       "summary": "Validating repo_path before handing it to getKbProviders converts a remote member's unreachable path into the fleet server's own cwd, silently staling healthy entries in the shared project KB; the anchor must stay honestly missing.",
@@ -310,84 +552,7 @@
         "tests/knowledge/kb-remote-anchor-freshness.test.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T21:02:37.675Z"
-    },
-    {
-      "id": "c596e547-f4bc-44e9-8399-73a04cb845c1",
-      "type": "knowledge",
-      "title": "Same-slug callers now open two SqliteProvider handles on one kb.sqlite",
-      "summary": "Keying the KB provider cache by (slug, repoPath) means two local clones of the same remote get two separate SqliteProvider instances pointed at the same kb.sqlite file; this is safe by design because init sets WAL plus busy_timeout=5000.",
-      "symbols": [
-        "getKbProviders",
-        "createKbProvidersForSlug",
-        "SqliteProvider.init"
-      ],
-      "source_files": [
-        "src/services/knowledge/kb-providers.ts",
-        "src/services/knowledge/sqlite-provider.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T16:04:51.485Z"
-    },
-    {
-      "id": "c9047868-445d-41a8-b951-ccb2f195d21b",
-      "type": "knowledge",
-      "title": "bd dolt remote list --json prints null, not [], when no remotes are configured",
-      "summary": "parseDoltRemoteList must map the JSON literal null to an empty array; treating null as an unexpected shape makes checkDoltRemoteAbsent return ok:false ('could not parse') for a repo that is simply not wired to any Dolt remote.",
-      "symbols": [
-        "parseDoltRemoteList",
-        "checkDoltRemoteAbsent"
-      ],
-      "source_files": [
-        "scripts/check-sandbox-sync-remote.mjs",
-        "tests/check-sandbox-sync-remote.test.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-12T05:18:16.605Z"
-    },
-    {
-      "id": "c996a17a-24af-4009-8472-0f1c5b868ca7",
-      "type": "knowledge",
-      "title": "deploy.md's Permissions section is the source of truth for .claude/settings.json allow-list",
-      "summary": "The deploy phase's runnable command set is defined by deploy.md lines 6-18, and .claude/settings.json permissions.allow must mirror exactly that list -- bead descriptions quoting an older list are stale and must not be followed.",
-      "symbols": [],
-      "source_files": [
-        "deploy.md",
-        ".claude/settings.json"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-12T05:07:17.779Z"
-    },
-    {
-      "id": "c9ec410a-37d6-4434-b1af-f87e45f90eef",
-      "type": "knowledge",
-      "title": "The embeddeddolt test now branches on bd availability instead of a loose regex",
-      "summary": "tests/check-sandbox-sync-remote.test.ts probes `bd --version` and asserts /Dolt-level remotes/ when bd is reachable, /unavailable/ when it is not, closing the vacuous-pass hole the old combined regex left open.",
-      "symbols": [
-        "checkDoltRemoteAbsent"
-      ],
-      "source_files": [
-        "tests/check-sandbox-sync-remote.test.ts",
-        "scripts/check-sandbox-sync-remote.mjs"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T15:01:39.756Z"
-    },
-    {
-      "id": "d1d891d8-ac6a-4114-8dea-3e669c2712a7",
-      "type": "knowledge",
-      "title": "The embeddeddolt sandbox test can pass vacuously when bd is unavailable",
-      "summary": "checkDoltRemoteAbsent's bd-unavailable fallback message contains the word 'unavailable', which the embeddeddolt test's own /Dolt-level remotes|unavailable/ assertion accepts -- so on a machine without bd the test is green without ever reaching the parser it is meant to exercise.",
-      "symbols": [
-        "checkDoltRemoteAbsent",
-        "parseDoltRemoteList"
-      ],
-      "source_files": [
-        "tests/check-sandbox-sync-remote.test.ts",
-        "scripts/check-sandbox-sync-remote.mjs"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-12T05:37:52.943Z"
+      "updated_at": "2026-08-18T20:35:08.212Z"
     },
     {
       "id": "daf6fb22-307e-45b4-87ce-0dbcedca9064",
@@ -401,27 +566,7 @@
         ".gitignore"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-12T05:53:12.703Z"
-    },
-    {
-      "id": "e257834c-77e0-4bc9-a80d-bb1dae9b5f00",
-      "type": "knowledge",
-      "title": "kb-setup is the one kb tool that takes repo_path but resolves no KB",
-      "summary": "Fifteen of the sixteen src/tools/kb-*.ts tools spread kbScopeFields and forward repo_remote_url to getKbProviders; kb-setup is excluded by design because its repo_path only locates a .git dir for hook installation and it writes a single global config, never selecting a project KB.",
-      "symbols": [
-        "kbSetup",
-        "kbSetupSchema",
-        "kbScopeFields",
-        "getKbProviders"
-      ],
-      "source_files": [
-        "src/tools/kb-setup.ts",
-        "src/services/knowledge/kb-scope-input.ts",
-        "src/tools/kb-list.ts",
-        "src/tools/kb-stats.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T16:18:03.899Z"
+      "updated_at": "2026-08-18T20:35:08.567Z"
     },
     {
       "id": "eb1611af-81c9-4331-b9f4-65d6427ae818",
@@ -434,7 +579,7 @@
         "tests/check-sandbox-sync-remote.test.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T14:35:21.893Z"
+      "updated_at": "2026-08-18T20:35:08.685Z"
     },
     {
       "id": "ec8b983b-88f0-4830-bd56-0068aa91cd0b",
@@ -450,82 +595,7 @@
         "src/tools/register-member.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T21:58:44.639Z"
-    },
-    {
-      "id": "f4bbc2aa-3e45-4112-860c-aab263e2736a",
-      "type": "learning",
-      "title": "Wrap getKbProviders with a delegating vi.mock to assert real provider anchoring",
-      "summary": "To assert which dbPath/repoPath a kb tool actually anchored at, vi.mock kb-providers.js with importOriginal, spread the actual module and replace only getKbProviders with a spy that delegates to the real one and records (cwd, remoteUrl, providers).",
-      "symbols": [
-        "getKbProviders",
-        "resetKbProviders",
-        "SqliteProvider"
-      ],
-      "source_files": [
-        "tests/knowledge/kb-anchor-never-cwd.test.ts",
-        "tests/knowledge/kb-remote-url-forwarding.test.ts",
-        "tests/knowledge/kb-import.test.ts",
-        "src/services/knowledge/kb-providers.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T21:02:37.669Z"
-    },
-    {
-      "id": "f74bbf7b-2348-4959-991a-9a1a86d124e3",
-      "type": "knowledge",
-      "title": "The .trim() guard in resolveProjectSlug is provably redundant and cannot be pinned by any test",
-      "summary": "project-slug.ts guards its remote-URL short-circuit twice, but the outer remoteUrl.trim() check is unreachable-by-effect given slugify, so no input can distinguish its removal and no regression test can pin it.",
-      "symbols": [
-        "resolveProjectSlug",
-        "slugify"
-      ],
-      "source_files": [
-        "src/services/knowledge/project-slug.ts",
-        "tests/knowledge/kb-remote-scope.test.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T21:58:44.633Z"
-    },
-    {
-      "id": "f92f896f-cc6d-4c1f-8144-f42ce2a3707f",
-      "type": "knowledge",
-      "title": "A missing-anchor freshness regression surfaces first as kb_list dropping entries, not as a stale-flag assertion",
-      "summary": "In tests/knowledge/kb-remote-member-e2e.test.ts the four remote-member assertions live in one it(), so removing SqliteProvider's anchorIsMissing guard fails at the SAME DATABASE read-back (line 165) and never reaches the raw stale-row check (line 181).",
-      "symbols": [
-        "anchorIsMissing",
-        "checkFreshness",
-        "kbStats"
-      ],
-      "source_files": [
-        "tests/knowledge/kb-remote-member-e2e.test.ts",
-        "src/services/knowledge/sqlite-provider.ts",
-        "src/tools/kb-stats.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T22:08:25.572Z"
-    },
-    {
-      "id": "feb51d86-a540-489a-b41a-52986f2e3d3f",
-      "type": "knowledge",
-      "title": "repo_remote_url is defined once in kbScopeFields but only 3 of ~16 kb_* tools spread it",
-      "summary": "src/services/knowledge/kb-scope-input.ts holds the single zod definition; only kb_session_prime, kb_capture and kb_harvest spread it, so kb_list and the other read tools silently drop the field and resolve to the path-derived KB.",
-      "symbols": [
-        "kbScopeFields",
-        "kbListSchema",
-        "kbCaptureSchema",
-        "kbHarvestSchema",
-        "kbSessionPrimeSchema"
-      ],
-      "source_files": [
-        "src/services/knowledge/kb-scope-input.ts",
-        "src/tools/kb-list.ts",
-        "src/tools/kb-capture.ts",
-        "src/tools/kb-harvest.ts",
-        "src/tools/kb-session-prime.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-17T15:44:31.079Z"
+      "updated_at": "2026-08-18T20:35:08.741Z"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,48 @@ bd prime                # Refresh Beads context
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 <!-- END BEADS CODEX SETUP -->
+
+<!-- gitnexus:start -->
+# GitNexus -- Code Intelligence
+
+This project is indexed by GitNexus as **apra-fleet** (12888 symbols, 30673 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root -- it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash -> `npm i -g gitnexus`; #1939).
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol -- callers, callees, which execution flows it participates in -- use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source->sink flows; needs `analyze --pdg`).
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace -- use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/apra-fleet/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/apra-fleet/clusters` | All functional areas |
+| `gitnexus://repo/apra-fleet/processes` | All execution flows |
+| `gitnexus://repo/apra-fleet/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,18 @@ bd close <id>         # Complete work
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 
+### Persistent Memory - Which System
+
+Three memory systems exist; when asked to "remember" something, route by content:
+
+- **User/assistant preferences** (user's role, standing feedback on how the assistant collaborates, anything not about this repo's code) -> Claude's own auto-memory (`~/.claude/projects/.../memory/`). Not managed by this repo; named here only so it is not confused with the two below.
+- **Operational rules** (short, actionable directives for any dispatched agent during this project's beads-tracked work - test-harness gotchas, required flags, launch conventions) -> `bd remember`. Keep entries terse: the actionable rule only, no PR/bead/commit-ref padding.
+- **Technical facts about the codebase** (architecture decisions, gotchas, "why is it built this way" - tied to specific files/symbols, worth confidence-grading and contradiction-checking, shareable via `kb_export` to `.fleet/kb-canonical.json`) -> KB (`kb_capture`).
+
+When a rule is both operational and technical: prefer KB if it anchors to specific files/symbols and benefits from confidence-grading over time; prefer `bd remember` if it is a procedural directive with no file/symbol anchor.
+
+KB is opt-in per repo. If `kb_capture`/`kb_query` errors because `kb_setup` has not run here, do not treat it as a hard failure or drop the memory - fall back to `bd remember` (or tell the user) so the request still lands.
+
 ## Agent Context Profiles
 
 The managed Beads block is task-tracking guidance, not permission to override repository, user, or orchestrator instructions.

--- a/AGY.md
+++ b/AGY.md
@@ -57,6 +57,18 @@ bd close <id>         # Complete work
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 
+### Persistent Memory - Which System
+
+Three memory systems exist; when asked to "remember" something, route by content:
+
+- **User/assistant preferences** (user's role, standing feedback on how the assistant collaborates, anything not about this repo's code) -> Claude's own auto-memory (`~/.claude/projects/.../memory/`). Not managed by this repo; named here only so it is not confused with the two below.
+- **Operational rules** (short, actionable directives for any dispatched agent during this project's beads-tracked work - test-harness gotchas, required flags, launch conventions) -> `bd remember`. Keep entries terse: the actionable rule only, no PR/bead/commit-ref padding.
+- **Technical facts about the codebase** (architecture decisions, gotchas, "why is it built this way" - tied to specific files/symbols, worth confidence-grading and contradiction-checking, shareable via `kb_export` to `.fleet/kb-canonical.json`) -> KB (`kb_capture`).
+
+When a rule is both operational and technical: prefer KB if it anchors to specific files/symbols and benefits from confidence-grading over time; prefer `bd remember` if it is a procedural directive with no file/symbol anchor.
+
+KB is opt-in per repo. If `kb_capture`/`kb_query` errors because `kb_setup` has not run here, do not treat it as a hard failure or drop the memory - fall back to `bd remember` (or tell the user) so the request still lands.
+
 ## Agent Context Profiles
 
 The managed Beads block is task-tracking guidance, not permission to override repository, user, or orchestrator instructions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,18 @@ bd close <id>         # Complete work
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 
+### Persistent Memory - Which System
+
+Three memory systems exist; when asked to "remember" something, route by content:
+
+- **User/assistant preferences** (user's role, standing feedback on how the assistant collaborates, anything not about this repo's code) -> Claude's own auto-memory (`~/.claude/projects/.../memory/`). Not managed by this repo; named here only so it is not confused with the two below.
+- **Operational rules** (short, actionable directives for any dispatched agent during this project's beads-tracked work - test-harness gotchas, required flags, launch conventions) -> `bd remember`. Keep entries terse: the actionable rule only, no PR/bead/commit-ref padding.
+- **Technical facts about the codebase** (architecture decisions, gotchas, "why is it built this way" - tied to specific files/symbols, worth confidence-grading and contradiction-checking, shareable via `kb_export` to `.fleet/kb-canonical.json`) -> KB (`kb_capture`).
+
+When a rule is both operational and technical: prefer KB if it anchors to specific files/symbols and benefits from confidence-grading over time; prefer `bd remember` if it is a procedural directive with no file/symbol anchor.
+
+KB is opt-in per repo. If `kb_capture`/`kb_query` errors because `kb_setup` has not run here, do not treat it as a hard failure or drop the memory - fall back to `bd remember` (or tell the user) so the request still lands.
+
 ## Agent Context Profiles
 
 The managed Beads block is task-tracking guidance, not permission to override repository, user, or orchestrator instructions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,48 @@ This protocol applies when ending a Beads implementation workflow. It is subordi
 - Do not commit or push without clear authority from the active profile or the current user request.
 - If a required sync or push is blocked, stop and report the exact command and error.
 <!-- END BEADS INTEGRATION -->
+
+<!-- gitnexus:start -->
+# GitNexus -- Code Intelligence
+
+This project is indexed by GitNexus as **apra-fleet** (12888 symbols, 30673 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root -- it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash -> `npm i -g gitnexus`; #1939).
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol -- callers, callees, which execution flows it participates in -- use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source->sink flows; needs `analyze --pdg`).
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace -- use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/apra-fleet/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/apra-fleet/clusters` | All functional areas |
+| `gitnexus://repo/apra-fleet/processes` | All execution flows |
+| `gitnexus://repo/apra-fleet/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->


### PR DESCRIPTION
## Summary

- Adds a "Persistent Memory - Which System" section to CLAUDE.md (synced to AGENTS.md/AGY.md via `scripts/sync-agent-docs.mjs`), disambiguating when to use Claude's own auto-memory, `bd remember`, or the Knowledge Bank (`kb_capture`) -- including a graceful-fallback rule for repos where KB isn't set up.
- Exports the project's Knowledge Bank to `.fleet/kb-canonical.json` (36 CONFIRMED entries, auto-committed by `kb_export`).
- Adds the `gitnexus` code-intelligence skill files (`.claude/skills/gitnexus/*`) generated by running `gitnexus analyze` against this repo, so the skills ship alongside the gitnexus block already appended to CLAUDE.md/AGENTS.md.

## Test plan

- [x] `scripts/sync-agent-docs.mjs` re-run, AGENTS.md/AGY.md verified in sync with CLAUDE.md
- [x] `kb_stats` confirms 36 CONFIRMED entries post-export
- [x] Pre-commit ASCII-only hook passes on all changed files
