### PR TITLE
chore(kb): reconcile the knowledge bible against main (36 -> 24 entries)

### DIFF
--- a/.fleet/kb-canonical.json
+++ b/.fleet/kb-canonical.json
@@ -1,111 +1,33 @@
 {
   "version": 2,
   "provenance": {
-    "commit": "aef342816f5c232202c0679e98dc814f11e0076f",
-    "branch": "chore/persistent-memory-disambiguation-rule",
-    "entry_count": 36
+    "commit": "08ad5f1554e1a401d77320bf63f7f579c527387a",
+    "branch": "chore/kb-bible-reconcile",
+    "entry_count": 24
   },
   "entries": [
     {
-      "id": "0633ac36-3d13-49cc-a268-46425bbf8bf9",
+      "id": "0e10e4ea-5c23-4fc9-bd7a-baf1af522a3e",
       "type": "knowledge",
-      "title": "kb_export and kb_import validate repo_path on the real filesystem before getKbProviders",
-      "summary": "In the table-driven forwarding test, kb_export and kb_import cannot use an arbitrary fake repo_path string like the other kb tools -- both resolve and validate the path against the real filesystem before the mocked getKbProviders is reached, so their table entries must anchor on real tmpdir fixtures.",
+      "title": "Provider abstraction: six adapters, never assume Claude",
+      "summary": "src/providers/index.ts registers exactly six LlmProvider adapters -- claude, codex, copilot, agy, opencode, none -- matching the LlmProvider union at src/types.ts:4. There is no gemini adapter. Any auth, credential or dispatch change must route through the ProviderAdapter interface rather than assuming Claude-specific fields, and getProvider() defaults to claude only when the argument is null/undefined.",
       "symbols": [
-        "kbExport",
-        "kbImport",
-        "resolveRepoPath"
-      ],
-      "source_files": [
-        "tests/knowledge/kb-remote-url-forwarding.test.ts",
-        "src/tools/kb-export.ts",
-        "src/tools/kb-import.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.242Z"
-    },
-    {
-      "id": "10e15056-ffd7-4f2a-9441-0847c0f382a2",
-      "type": "knowledge",
-      "title": "Provider abstraction: never assume Claude",
-      "summary": "apra-fleet supports seven LLM providers (claude, agy, opencode, codex, copilot, gemini, none), not just Claude. Any auth/credential/dispatch-related change must go through the generic ProviderAdapter interface rather than assuming Claude-specific fields or behavior.",
-      "symbols": [
+        "LlmProvider",
         "ProviderAdapter",
-        "authEnvVar",
-        "authEnvVarForToken",
-        "oauthCredentialFiles"
+        "getProvider",
+        "ClaudeProvider",
+        "NoneProvider"
       ],
       "source_files": [
+        "src/providers/index.ts",
         "src/providers/provider.ts",
-        "src/providers/opencode.ts"
+        "src/types.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T21:51:20.998Z"
+      "updated_at": "2026-08-21T05:31:31.679Z"
     },
     {
-      "id": "130bc73b-fade-4d3a-8254-2ad3b2e1bfef",
-      "type": "knowledge",
-      "title": "KB provider cache is now keyed by (slug, repoPath), not slug alone",
-      "summary": "getKbProviders/_providers Map keys on providerKey(slug, repoPath) via a NUL join, so two callers resolving to the same project slug but different repoPath values get distinct provider instances, each anchored at its own caller's repoPath.",
-      "symbols": [],
-      "source_files": [
-        "src/services/knowledge/kb-providers.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.323Z"
-    },
-    {
-      "id": "138565bf-b3ed-4901-8aab-d6adffb232ec",
-      "type": "knowledge",
-      "title": "One anchor policy, three branches: verbatim for read tools, hard-fail for kb_export",
-      "summary": "kb_session_prime and kb_stats pass a supplied repo_path to getKbProviders verbatim so an unreachable remote anchor stays honestly missing; kb_export deliberately keeps throwing instead, because it writes into repo_path -- and it throws before getKbProviders, so it never anchors at the server cwd either.",
-      "symbols": [
-        "kbStats",
-        "kbExport",
-        "kbSessionPrime",
-        "getKbProviders",
-        "resolveRepoPath"
-      ],
-      "source_files": [
-        "src/tools/kb-stats.ts",
-        "src/tools/kb-export.ts",
-        "src/tools/kb-session-prime.ts",
-        "src/services/knowledge/kb-providers.ts",
-        "tests/knowledge/kb-anchor-never-cwd.test.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.882Z"
-    },
-    {
-      "id": "1ae4ce00-ce11-4bc4-becb-7e6355809f6b",
-      "type": "knowledge",
-      "title": "A directory-level gitignore rule shadows everything inside it, un-ignore patterns included",
-      "summary": "The blanket '/sprint-logs/' rule made every file under sprint-logs unstageable regardless of narrower rules elsewhere; only removing the directory rule and keeping the scoped '**/sprint-logs/sprint_*.json' rule restored the durable-vs-scratch split the sprint workflow documents.",
-      "symbols": [],
-      "source_files": [
-        ".gitignore",
-        "packages/apra-fleet-se/bin/cli.mjs",
-        "packages/apra-fleet-se/apra-pm/skills/pm/cost.md"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.375Z"
-    },
-    {
-      "id": "202cd324-f6d9-42d0-b0a2-a4aa8e1741ef",
-      "type": "knowledge",
-      "title": "Local members use host OAuth; provision_llm_auth skips them",
-      "summary": "Local fleet members share the orchestrator's own machine, so they use whatever OAuth session is already active on that host. provision_llm_auth explicitly skips local members rather than attempting to provision credentials for them.",
-      "symbols": [
-        "provisionAuth"
-      ],
-      "source_files": [
-        "src/tools/provision-auth.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T21:51:01.387Z"
-    },
-    {
-      "id": "2198295a-c0a8-4598-a612-17742024970b",
+      "id": "0f432ed4-a1fa-4185-8a5f-d7d62fe8cc5d",
       "type": "knowledge",
       "title": "Same-slug callers now open two SqliteProvider handles on one kb.sqlite",
       "summary": "Keying the KB provider cache by (slug, repoPath) means two local clones of the same remote get two separate SqliteProvider instances pointed at the same kb.sqlite file; this is safe by design because init sets WAL plus busy_timeout=5000.",
@@ -119,43 +41,196 @@
         "src/services/knowledge/sqlite-provider.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.266Z"
+      "updated_at": "2026-08-21T05:24:37.838Z"
     },
     {
-      "id": "254b18e2-8f53-4a3b-bebd-3ab08609aec7",
+      "id": "130bc73b-fade-4d3a-8254-2ad3b2e1bfef",
       "type": "knowledge",
-      "title": "The nonexistent-path + NO-url slug assertion passes on both pre-fix and post-fix trees",
-      "summary": "resolveProjectSlug(<nonexistent windows path>) returning 'default' is NOT a pre-fix failure and cannot be used as a regression pin for the remote-URL work; the assertions that actually go red on the pre-fix tree are the URL-bearing ones.",
-      "symbols": [
-        "resolveProjectSlug"
-      ],
+      "title": "KB provider cache is now keyed by (slug, repoPath), not slug alone",
+      "summary": "getKbProviders/_providers Map keys on providerKey(slug, repoPath) via a NUL join, so two callers resolving to the same project slug but different repoPath values get distinct provider instances, each anchored at its own caller's repoPath.",
+      "symbols": [],
       "source_files": [
-        "tests/knowledge/kb-remote-scope.test.ts",
-        "src/services/knowledge/project-slug.ts"
+        "src/services/knowledge/kb-providers.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.445Z"
+      "updated_at": "2026-08-17T20:10:22.938Z"
     },
     {
-      "id": "2ff14a5c-f502-4212-bc1d-89c5955cd364",
+      "id": "16ba5328-63a9-4f98-8614-fa3137afe2f3",
       "type": "knowledge",
-      "title": "kb-remote-scope.test.ts pins handler forwarding, not the zod schema spread",
-      "summary": "The b4g.1.5 end-to-end test calls kbCapture/kbList with raw objects cast 'as any', so it bypasses zod parse entirely and cannot detect a dropped ...kbScopeFields spread; that layer is pinned only by kb-remote-url-forwarding.test.ts.",
+      "title": "{{secure.NAME}} values arrive already shell-escaped, and the escaping is OS-branched",
+      "summary": "execute_command replaces each {{secure.NAME}} token with a value that has ALREADY been quoted for the target member's shell -- escapePowerShellArg for windows members, escapeShellArg otherwise, chosen from agentOs. Reference the token bare in a command string; wrapping it in your own quotes double-escapes the value and surfaces as a false 401 or invalid-token error.",
       "symbols": [
-        "kbList",
-        "kbListSchema",
-        "kbScopeFields"
+        "escapeShellArg",
+        "escapePowerShellArg",
+        "executeCommand"
       ],
       "source_files": [
-        "tests/knowledge/kb-remote-scope.test.ts",
-        "tests/knowledge/kb-remote-url-forwarding.test.ts",
-        "src/tools/kb-list.ts"
+        "src/tools/execute-command.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.501Z"
+      "updated_at": "2026-08-21T05:32:34.285Z"
     },
     {
-      "id": "34887ffc-e128-46b6-962e-23b1c62eb9b7",
+      "id": "1be49eaa-30f9-4ae0-917e-5b98d3d37eeb",
+      "type": "knowledge",
+      "title": "bd prints literal JSON null, not [], for an empty dolt remote list",
+      "summary": "`bd dolt remote list --json` emits the JSON literal null when no Dolt remotes are configured. parseDoltRemoteList maps that to [] before its non-array guard, so an unwired repo reads as \"no remotes\" rather than a parse error; every other non-array shape still throws. Without the null branch, checkDoltRemoteAbsent returns ok:false (\"could not parse\") for a repo that is simply not wired to a Dolt remote.",
+      "symbols": [
+        "parseDoltRemoteList",
+        "checkDoltRemoteAbsent"
+      ],
+      "source_files": [
+        "scripts/check-sandbox-sync-remote.mjs",
+        "tests/check-sandbox-sync-remote.test.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:32:37.012Z"
+    },
+    {
+      "id": "202cd324-f6d9-42d0-b0a2-a4aa8e1741ef",
+      "type": "knowledge",
+      "title": "Local members use host OAuth; provision_llm_auth skips them",
+      "summary": "Local fleet members share the orchestrator's own machine, so they use whatever OAuth session is already active on that host. provision_llm_auth explicitly skips local members rather than attempting to provision credentials for them.",
+      "symbols": [
+        "provisionAuth"
+      ],
+      "source_files": [
+        "src/tools/provision-auth.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:24:37.822Z"
+    },
+    {
+      "id": "22e52be3-d44c-4c71-ae51-9f25a498af40",
+      "type": "knowledge",
+      "title": "sprint-logs/ must never carry a blanket directory ignore -- .gitignore says so inline",
+      "summary": "A directory-level rule such as '/sprint-logs/' shadows everything beneath it, un-ignore patterns included, and silently breaks the sprint cost ledger because auto-sprint.js stages it with an unguarded `git add sprint-logs/`. Merged main keeps only scoped rules and records the prohibition as a comment in .gitignore itself, so the lesson survives without depending on the KB.",
+      "symbols": [
+        "redactHomeFromTranscriptDir"
+      ],
+      "source_files": [
+        ".gitignore",
+        "packages/apra-fleet-se/apra-pm/.claude/workflows/auto-sprint.js"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:35:33.037Z"
+    },
+    {
+      "id": "256b2dc0-4d08-40e9-b3c6-0f79dd824b8e",
+      "type": "knowledge",
+      "title": "kb-setup is the one kb tool that takes repo_path but resolves no KB",
+      "summary": "Fifteen of the sixteen src/tools/kb-*.ts tools spread kbScopeFields and forward repo_remote_url to getKbProviders; kb-setup is excluded by design because its repo_path only locates a .git dir for hook installation and it writes a single global config, never selecting a project KB.",
+      "symbols": [
+        "kbSetup",
+        "kbSetupSchema",
+        "kbScopeFields",
+        "getKbProviders"
+      ],
+      "source_files": [
+        "src/tools/kb-setup.ts",
+        "src/services/knowledge/kb-scope-input.ts",
+        "src/tools/kb-list.ts",
+        "src/tools/kb-stats.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:24:37.901Z"
+    },
+    {
+      "id": "4406ee08-d77d-44a5-a5d2-83c9d02ba092",
+      "type": "knowledge",
+      "title": "A fallback message sharing the assertion's alternate keyword makes a test vacuous",
+      "summary": "checkDoltRemoteAbsent's bd-unavailable fallback messages all contain the word \"unavailable\", so the old combined assertion /Dolt-level remotes|unavailable/ was satisfied on any machine without bd without ever reaching the parser under test. Merged main closes this by probing bd --version first and asserting the two cases separately. The reusable trap: never OR an assertion's success keyword with its own fallback keyword.",
+      "symbols": [
+        "checkDoltRemoteAbsent",
+        "parseDoltRemoteList"
+      ],
+      "source_files": [
+        "tests/check-sandbox-sync-remote.test.ts",
+        "scripts/check-sandbox-sync-remote.mjs"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:31:45.629Z"
+    },
+    {
+      "id": "45fa7bb5-1af4-474d-a958-0c1d7f6ec75c",
+      "type": "knowledge",
+      "title": "hasOppositePolarity matches on word-boundary regexes, not substrings",
+      "summary": "audn.ts hasOppositePolarity tests NEGATIVE_PATTERNS/POSITIVE_PATTERNS with precompiled word-boundary regexes, so \"prefixed\" no longer collides with \"fixed\".",
+      "symbols": [
+        "hasOppositePolarity"
+      ],
+      "source_files": [
+        "src/services/knowledge/audn.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-04T04:04:51.757Z"
+    },
+    {
+      "id": "4844d64a-deee-4b5d-87d2-6fcd8c596f64",
+      "type": "knowledge",
+      "title": "apra-fleet-se's plain npm test never sets APRA_FLEET_TEST_CONCURRENCY",
+      "summary": "packages/apra-fleet-se's \"test\" script runs node --test directly with --test-concurrency=8, but does NOT set the APRA_FLEET_TEST_CONCURRENCY env var -- only the separate test:unit/test:integration/test:record scripts (which route through scripts/run-tests.mjs) set it. A scaledTimeout()/waitFor() call that relies on the env var being set will silently use an unscaled timeout under plain npm test.",
+      "symbols": [
+        "scaledTimeout",
+        "waitFor"
+      ],
+      "source_files": [
+        "packages/apra-fleet-se/package.json",
+        "packages/apra-fleet-se/scripts/run-tests.mjs",
+        "packages/apra-fleet-se/test/helpers/scaled-timeout.mjs"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:24:37.879Z"
+    },
+    {
+      "id": "6241ee4c-ceb3-4b58-b1b4-015a0d8d8ec1",
+      "type": "knowledge",
+      "title": "The .trim() guard in resolveProjectSlug is provably redundant and cannot be pinned by any test",
+      "summary": "project-slug.ts guards its remote-URL short-circuit twice, but the outer remoteUrl.trim() check is unreachable-by-effect given slugify, so no input can distinguish its removal and no regression test can pin it.",
+      "symbols": [
+        "resolveProjectSlug",
+        "slugify"
+      ],
+      "source_files": [
+        "src/services/knowledge/project-slug.ts",
+        "tests/knowledge/kb-remote-scope.test.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:24:37.888Z"
+    },
+    {
+      "id": "7cc58351-c7f9-4f14-99b0-cdd04cf83d7c",
+      "type": "knowledge",
+      "title": "Member OS resolution: always via agent.os",
+      "summary": "The orchestrator and each fleet member can independently run Windows/Mac/Linux -- local members share the orchestrator's own OS, but remote members can be any OS regardless of the orchestrator's. Never assume a target member's shell/OS matches the orchestrator's.",
+      "symbols": [
+        "getAgentOS",
+        "getOsCommands"
+      ],
+      "source_files": [
+        "src/os/index.ts",
+        "src/utils/agent-helpers.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:24:37.927Z"
+    },
+    {
+      "id": "8997f326-d6e7-485f-ad84-782650030314",
+      "type": "knowledge",
+      "title": "Local vs remote member dispatch paths",
+      "summary": "Local members share the orchestrator's own machine and credentials, so no SSH or file probe is needed -- check agent.agentType === 'local' and short-circuit. Remote members require actual SSH connectivity and credential probes.",
+      "symbols": [
+        "preflightCheck"
+      ],
+      "source_files": [
+        "src/services/preflight-check.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:24:37.934Z"
+    },
+    {
+      "id": "91cb711b-9ca0-4994-b73b-2d93cb8e47d8",
       "type": "knowledge",
       "title": "Four resolveRepoPath helpers exist in src/tools, but only prime and stats ever had the null-to-cwd shape",
       "summary": "kb-session-prime.ts and kb-stats.ts returned string|null and degraded to process.cwd(); kb-export.ts and kb-import.ts have always returned string and thrown, so they were never part of the b4g.7 anchor defect despite the bead naming kb-export as a third instance.",
@@ -173,223 +248,25 @@
         "docs/knowledge-layer.md"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.946Z"
+      "updated_at": "2026-08-21T05:24:37.855Z"
     },
     {
-      "id": "40295d4d-390f-466a-87c9-2df0a94cf3a6",
+      "id": "96a63862-eb7a-43f3-8352-4cd686412d43",
       "type": "knowledge",
-      "title": "The embeddeddolt sandbox test can pass vacuously when bd is unavailable",
-      "summary": "checkDoltRemoteAbsent's bd-unavailable fallback message contains the word 'unavailable', which the embeddeddolt test's own /Dolt-level remotes|unavailable/ assertion accepts -- so on a machine without bd the test is green without ever reaching the parser it is meant to exercise.",
+      "title": "gitRepos is an access list; only a single URL-shaped entry is a usable origin",
+      "summary": "agent.gitRepos is declared string[] and holds bare \"Owner/Repo\" access identifiers, not clone URLs. knownRepoRemoteUrl (now in src/services/member-remote-url.ts, re-exported from execute-prompt.ts) returns a URL only when gitRepos has EXACTLY one entry AND that entry is scheme-qualified; anything else yields undefined rather than a guessed URL.",
       "symbols": [
-        "checkDoltRemoteAbsent",
-        "parseDoltRemoteList"
-      ],
-      "source_files": [
-        "tests/check-sandbox-sync-remote.test.ts",
-        "scripts/check-sandbox-sync-remote.mjs"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.515Z"
-    },
-    {
-      "id": "45fa7bb5-1af4-474d-a958-0c1d7f6ec75c",
-      "type": "knowledge",
-      "title": "hasOppositePolarity matches on word-boundary regexes, not substrings",
-      "summary": "audn.ts hasOppositePolarity tests NEGATIVE_PATTERNS/POSITIVE_PATTERNS with precompiled word-boundary regexes, so \"prefixed\" no longer collides with \"fixed\".",
-      "symbols": [
-        "hasOppositePolarity"
-      ],
-      "source_files": [
-        "src/services/knowledge/audn.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.598Z"
-    },
-    {
-      "id": "4844d64a-deee-4b5d-87d2-6fcd8c596f64",
-      "type": "knowledge",
-      "title": "apra-fleet-se's plain npm test never sets APRA_FLEET_TEST_CONCURRENCY",
-      "summary": "packages/apra-fleet-se's \"test\" script runs node --test directly with --test-concurrency=8, but does NOT set the APRA_FLEET_TEST_CONCURRENCY env var -- only the separate test:unit/test:integration/test:record scripts (which route through scripts/run-tests.mjs) set it. A scaledTimeout()/waitFor() call that relies on the env var being set will silently use an unscaled timeout under plain npm test.",
-      "symbols": [
-        "scaledTimeout",
-        "waitFor"
-      ],
-      "source_files": [
-        "packages/apra-fleet-se/package.json",
-        "packages/apra-fleet-se/scripts/run-tests.mjs",
-        "packages/apra-fleet-se/test/helpers/scaled-timeout.mjs"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T21:50:58.094Z"
-    },
-    {
-      "id": "4f84e1c5-733d-40c3-84e2-8eb1b45d3e22",
-      "type": "knowledge",
-      "title": "The .trim() guard in resolveProjectSlug is provably redundant and cannot be pinned by any test",
-      "summary": "project-slug.ts guards its remote-URL short-circuit twice, but the outer remoteUrl.trim() check is unreachable-by-effect given slugify, so no input can distinguish its removal and no regression test can pin it.",
-      "symbols": [
-        "resolveProjectSlug",
-        "slugify"
-      ],
-      "source_files": [
-        "src/services/knowledge/project-slug.ts",
-        "tests/knowledge/kb-remote-scope.test.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.862Z"
-    },
-    {
-      "id": "56d8e8d0-f704-467b-b2a3-2611ccf6e0df",
-      "type": "knowledge",
-      "title": "kb-setup is the one kb tool that takes repo_path but resolves no KB",
-      "summary": "Fifteen of the sixteen src/tools/kb-*.ts tools spread kbScopeFields and forward repo_remote_url to getKbProviders; kb-setup is excluded by design because its repo_path only locates a .git dir for hook installation and it writes a single global config, never selecting a project KB.",
-      "symbols": [
-        "kbSetup",
-        "kbSetupSchema",
-        "kbScopeFields",
-        "getKbProviders"
-      ],
-      "source_files": [
-        "src/tools/kb-setup.ts",
-        "src/services/knowledge/kb-scope-input.ts",
-        "src/tools/kb-list.ts",
-        "src/tools/kb-stats.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.627Z"
-    },
-    {
-      "id": "5d7d0886-e403-482a-83c9-709efc6b0d56",
-      "type": "knowledge",
-      "title": "repo_remote_url is defined once in kbScopeFields but only 3 of ~16 kb_* tools spread it",
-      "summary": "src/services/knowledge/kb-scope-input.ts holds the single zod definition; only kb_session_prime, kb_capture and kb_harvest spread it, so kb_list and the other read tools silently drop the field and resolve to the path-derived KB.",
-      "symbols": [
-        "kbScopeFields",
-        "kbListSchema",
-        "kbCaptureSchema",
-        "kbHarvestSchema",
-        "kbSessionPrimeSchema"
-      ],
-      "source_files": [
-        "src/services/knowledge/kb-scope-input.ts",
-        "src/tools/kb-list.ts",
-        "src/tools/kb-capture.ts",
-        "src/tools/kb-harvest.ts",
-        "src/tools/kb-session-prime.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:09.001Z"
-    },
-    {
-      "id": "62a26c94-e079-4158-b83b-5702e317b54c",
-      "type": "knowledge",
-      "title": "auto-sprint workflow VM has no fs/os/process.env, so path redaction must be pure string work",
-      "summary": "redactHomeFromTranscriptDir anchors on the literal '/.claude/projects/' substring instead of comparing against $HOME because the auto-sprint workflow VM cannot read env or fs; the anchor is safe only because Setup Step 7 constructs transcriptDir as $HOME/.claude/projects/<slug>.",
-      "symbols": [
-        "redactHomeFromTranscriptDir"
-      ],
-      "source_files": [
-        "packages/apra-fleet-se/apra-pm/.claude/workflows/auto-sprint.js",
-        "packages/apra-fleet-se/apra-pm/test/sprint-meta.test.mjs"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.705Z"
-    },
-    {
-      "id": "66075242-ab8e-40f1-a1b4-c2ecb01a007c",
-      "type": "knowledge",
-      "title": "git add <dir>/ errors on a directory-level ignore but silently no-ops on an inner file glob",
-      "summary": "The failure mode of an ignored sprint-logs/ is not uniform: a directory rule like '/sprint-logs/' makes `git add sprint-logs/` exit 1 with an explicit advice message, while a file-glob rule like '**/sprint-logs/*.jsonl' makes the same command exit 0 and stage nothing.",
-      "symbols": [],
-      "source_files": [
-        ".gitignore",
-        "packages/apra-fleet-se/apra-pm/.claude/workflows/auto-sprint.js",
-        "packages/apra-fleet-se/apra-pm/test/sprint-log-flush.test.mjs"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.763Z"
-    },
-    {
-      "id": "696d42bc-615c-4156-b43a-b67210fc2dea",
-      "type": "knowledge",
-      "title": "agent.gitRepos is a bare owner/repo access-list, never a full git remote URL, in live fleet data",
-      "summary": "Empirically verified against this fleet's own ~/.apra-fleet/data/registry.json: every populated gitRepos entry across all registered members (local and remote) is a short 'Owner/Repo' GitHub identifier, never a scheme-qualified clone URL -- confirming src/services/vcs/github.ts's own https://github.com/${repo}.git construction (used only for connectivity testing) is the correct mental model for what this field actually contains.",
-      "symbols": [
-        "Agent",
         "knownRepoRemoteUrl",
-        "enrichMember"
+        "Agent",
+        "gitRepos"
       ],
       "source_files": [
+        "src/services/member-remote-url.ts",
         "src/types.ts",
-        "src/tools/register-member.ts",
-        "src/services/vcs/github.ts",
-        "src/services/watch/project-resolver.ts",
-        "src/tools/execute-prompt.ts",
-        "tests/execute-prompt-kb-harvest-remote-url.test.ts"
+        "src/tools/execute-prompt.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.824Z"
-    },
-    {
-      "id": "735f21d3-01da-4913-9ebe-d31320b9bef4",
-      "type": "knowledge",
-      "title": "{{secure.NAME}} substitution is pre-escaped and launch-time bound",
-      "summary": "execute_command resolves {{secure.NAME}} fleet-secret placeholders with single-quote escaping already applied. Reference the token bare in a command string, not wrapped in your own quotes -- double-escaping produces a corrupted value and a false 401/invalid-token error.",
-      "symbols": [
-        "resolveSecurePlaceholders"
-      ],
-      "source_files": [
-        "src/tools/execute-command.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T21:51:09.005Z"
-    },
-    {
-      "id": "7cc58351-c7f9-4f14-99b0-cdd04cf83d7c",
-      "type": "knowledge",
-      "title": "Member OS resolution: always via agent.os",
-      "summary": "The orchestrator and each fleet member can independently run Windows/Mac/Linux -- local members share the orchestrator's own OS, but remote members can be any OS regardless of the orchestrator's. Never assume a target member's shell/OS matches the orchestrator's.",
-      "symbols": [
-        "getAgentOS",
-        "getOsCommands"
-      ],
-      "source_files": [
-        "src/os/index.ts",
-        "src/utils/agent-helpers.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T21:51:13.164Z"
-    },
-    {
-      "id": "8997f326-d6e7-485f-ad84-782650030314",
-      "type": "knowledge",
-      "title": "Local vs remote member dispatch paths",
-      "summary": "Local members share the orchestrator's own machine and credentials, so no SSH or file probe is needed -- check agent.agentType === 'local' and short-circuit. Remote members require actual SSH connectivity and credential probes.",
-      "symbols": [
-        "preflightCheck"
-      ],
-      "source_files": [
-        "src/services/preflight-check.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T21:51:16.901Z"
-    },
-    {
-      "id": "a2bed3b4-6a18-4ee6-b736-333981d804ba",
-      "type": "learning",
-      "title": "Provider cache key mutation test confirms b4g.2.2 pins the b4g.2.1 fix, not a vacuous test",
-      "summary": "Reverting getKbProviders' cache key from providerKey(slug, repoPath) to slug-only makes tests/knowledge/kb-provider-cache-key.test.ts fail on cases 1 and 3 (2 of 4), confirming the new regression test in apra-fleet-b4g.2.2 actually detects the bug apra-fleet-b4g.2.1 fixed rather than passing regardless.",
-      "symbols": [
-        "getKbProviders",
-        "providerKey",
-        "resetKbProviders"
-      ],
-      "source_files": [
-        "tests/knowledge/kb-provider-cache-key.test.ts",
-        "src/services/knowledge/kb-providers.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:07.650Z"
+      "updated_at": "2026-08-21T05:35:02.929Z"
     },
     {
       "id": "a96e64d8-e304-4a46-baeb-d36fe1371a94",
@@ -403,7 +280,7 @@
         "packages/apra-fleet-se/fleet-sprint/runner.js"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T21:51:04.975Z"
+      "updated_at": "2026-08-21T05:24:37.949Z"
     },
     {
       "id": "b0f6be79-738c-491b-9ba5-7c7e5d69b805",
@@ -424,38 +301,7 @@
         "src/tools/code-intelligence-kb-enrich.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.007Z"
-    },
-    {
-      "id": "b368ad28-9c4a-47fd-9acf-5f25a8a29bca",
-      "type": "knowledge",
-      "title": "git check-ignore silently skips tracked paths unless --no-index",
-      "summary": "An acceptance criterion of the form 'git check-ignore -v <path> returns no match' does not prove the path is unignored -- check-ignore ignores index entries by default, so any tracked path reports no match even when a .gitignore rule matches it.",
-      "symbols": [],
-      "source_files": [
-        ".gitignore",
-        ".claude/settings.json"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.060Z"
-    },
-    {
-      "id": "b86607c4-ff63-427e-bf6a-01ae5870e51e",
-      "type": "knowledge",
-      "title": "A missing-anchor freshness regression surfaces first as kb_list dropping entries, not as a stale-flag assertion",
-      "summary": "In tests/knowledge/kb-remote-member-e2e.test.ts the four remote-member assertions live in one it(), so removing SqliteProvider's anchorIsMissing guard fails at the SAME DATABASE read-back (line 165) and never reaches the raw stale-row check (line 181).",
-      "symbols": [
-        "anchorIsMissing",
-        "checkFreshness",
-        "kbStats"
-      ],
-      "source_files": [
-        "tests/knowledge/kb-remote-member-e2e.test.ts",
-        "src/services/knowledge/sqlite-provider.ts",
-        "src/tools/kb-stats.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.929Z"
+      "updated_at": "2026-08-17T21:58:44.645Z"
     },
     {
       "id": "beb4faf7-40fa-4484-9cf5-b287df8f47d2",
@@ -468,7 +314,7 @@
         "src/services/knowledge/kb-scope-input.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.112Z"
+      "updated_at": "2026-08-17T20:10:22.943Z"
     },
     {
       "id": "c2899616-0cb1-41e8-b229-76e291a0cd81",
@@ -488,54 +334,10 @@
         "tests/knowledge/kb-remote-anchor-freshness.test.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.160Z"
+      "updated_at": "2026-08-17T20:10:22.934Z"
     },
     {
-      "id": "c9047868-445d-41a8-b951-ccb2f195d21b",
-      "type": "knowledge",
-      "title": "bd dolt remote list --json prints null, not [], when no remotes are configured",
-      "summary": "parseDoltRemoteList must map the JSON literal null to an empty array; treating null as an unexpected shape makes checkDoltRemoteAbsent return ok:false ('could not parse') for a repo that is simply not wired to any Dolt remote.",
-      "symbols": [
-        "parseDoltRemoteList",
-        "checkDoltRemoteAbsent"
-      ],
-      "source_files": [
-        "scripts/check-sandbox-sync-remote.mjs",
-        "tests/check-sandbox-sync-remote.test.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.353Z"
-    },
-    {
-      "id": "c996a17a-24af-4009-8472-0f1c5b868ca7",
-      "type": "knowledge",
-      "title": "deploy.md's Permissions section is the source of truth for .claude/settings.json allow-list",
-      "summary": "The deploy phase's runnable command set is defined by deploy.md lines 6-18, and .claude/settings.json permissions.allow must mirror exactly that list -- bead descriptions quoting an older list are stale and must not be followed.",
-      "symbols": [],
-      "source_files": [
-        "deploy.md",
-        ".claude/settings.json"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.404Z"
-    },
-    {
-      "id": "c9ec410a-37d6-4434-b1af-f87e45f90eef",
-      "type": "knowledge",
-      "title": "The embeddeddolt test now branches on bd availability instead of a loose regex",
-      "summary": "tests/check-sandbox-sync-remote.test.ts probes `bd --version` and asserts /Dolt-level remotes/ when bd is reachable, /unavailable/ when it is not, closing the vacuous-pass hole the old combined regex left open.",
-      "symbols": [
-        "checkDoltRemoteAbsent"
-      ],
-      "source_files": [
-        "tests/check-sandbox-sync-remote.test.ts",
-        "scripts/check-sandbox-sync-remote.mjs"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.456Z"
-    },
-    {
-      "id": "d2c1e093-0c14-40e7-8798-4deb8c931435",
+      "id": "c2d3fa00-5f7f-408e-9bdd-0f49101173fc",
       "type": "knowledge",
       "title": "kb_session_prime must pass an explicit repo_path to getKbProviders verbatim, never through resolveRepoPath",
       "summary": "Validating repo_path before handing it to getKbProviders converts a remote member's unreachable path into the fleet server's own cwd, silently staling healthy entries in the shared project KB; the anchor must stay honestly missing.",
@@ -552,50 +354,66 @@
         "tests/knowledge/kb-remote-anchor-freshness.test.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.212Z"
+      "updated_at": "2026-08-17T21:02:37.675Z"
     },
     {
-      "id": "daf6fb22-307e-45b4-87ce-0dbcedca9064",
-      "type": "knowledge",
-      "title": "The auto-sprint cost ledger is staged by an unconditional plain git add sprint-logs/",
-      "summary": "beads-export-cleanup stages sprint logs with a plain, unguarded `git add sprint-logs/` before `bd export` and the export commit, pinned by sprint-log-flush.test.mjs -- so any gitignore rule covering that directory silently drops the ledger rather than erroring.",
-      "symbols": [],
-      "source_files": [
-        "packages/apra-fleet-se/apra-pm/.claude/workflows/auto-sprint.js",
-        "packages/apra-fleet-se/apra-pm/test/sprint-log-flush.test.mjs",
-        ".gitignore"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.567Z"
-    },
-    {
-      "id": "eb1611af-81c9-4331-b9f4-65d6427ae818",
-      "type": "knowledge",
-      "title": "bd prints literal 'null' for an empty dolt remote list, not an empty array",
-      "summary": "Code parsing bd's dolt-remote-list output must treat a parsed result of null (or whitespace-padded 'null\\n') as 'no remotes configured' rather than a parse error; any other non-array non-null shape is still a genuine error.",
-      "symbols": [],
-      "source_files": [
-        "scripts/check-sandbox-sync-remote.mjs",
-        "tests/check-sandbox-sync-remote.test.ts"
-      ],
-      "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.685Z"
-    },
-    {
-      "id": "ec8b983b-88f0-4830-bd56-0068aa91cd0b",
+      "id": "f4bbc2aa-3e45-4112-860c-aab263e2736a",
       "type": "learning",
-      "title": "gitRepos is single-entry-safe, multi-entry-ambiguous for deriving an origin URL",
-      "summary": "knownRepoRemoteUrl(agent) in src/tools/execute-prompt.ts only treats agent.gitRepos[0] as a genuine origin URL when gitRepos has exactly one entry; a multi-entry gitRepos (an access list, not an origin field) is left unforwarded even if its first element already looks like a URL, since it could belong to an unrelated repo.",
+      "title": "Wrap getKbProviders with a delegating vi.mock to assert real provider anchoring",
+      "summary": "To assert which dbPath/repoPath a kb tool actually anchored at, vi.mock kb-providers.js with importOriginal, spread the actual module and replace only getKbProviders with a spy that delegates to the real one and records (cwd, remoteUrl, providers).",
       "symbols": [
-        "knownRepoRemoteUrl"
+        "getKbProviders",
+        "resetKbProviders",
+        "SqliteProvider"
       ],
       "source_files": [
-        "src/tools/execute-prompt.ts",
-        "tests/execute-prompt-kb-harvest-remote-url.test.ts",
-        "src/tools/register-member.ts"
+        "tests/knowledge/kb-anchor-never-cwd.test.ts",
+        "tests/knowledge/kb-remote-url-forwarding.test.ts",
+        "tests/knowledge/kb-import.test.ts",
+        "src/services/knowledge/kb-providers.ts"
       ],
       "confidence": "CONFIRMED",
-      "updated_at": "2026-08-18T20:35:08.741Z"
+      "updated_at": "2026-08-17T21:02:37.669Z"
+    },
+    {
+      "id": "f92f896f-cc6d-4c1f-8144-f42ce2a3707f",
+      "type": "knowledge",
+      "title": "A missing-anchor freshness regression surfaces first as kb_list dropping entries, not as a stale-flag assertion",
+      "summary": "In tests/knowledge/kb-remote-member-e2e.test.ts the four remote-member assertions live in one it(), so removing SqliteProvider's anchorIsMissing guard fails at the SAME DATABASE read-back (line 165) and never reaches the raw stale-row check (line 181).",
+      "symbols": [
+        "anchorIsMissing",
+        "checkFreshness",
+        "kbStats"
+      ],
+      "source_files": [
+        "tests/knowledge/kb-remote-member-e2e.test.ts",
+        "src/services/knowledge/sqlite-provider.ts",
+        "src/tools/kb-stats.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-17T22:08:25.572Z"
+    },
+    {
+      "id": "ff6f9eff-1532-4e9a-85fb-f3b4778e4733",
+      "type": "knowledge",
+      "title": "One anchor policy, three branches: verbatim for read tools, hard-fail for kb_export",
+      "summary": "kb_session_prime and kb_stats pass a supplied repo_path to getKbProviders verbatim so an unreachable remote anchor stays honestly missing; kb_export deliberately keeps throwing instead, because it writes into repo_path -- and it throws before getKbProviders, so it never anchors at the server cwd either.",
+      "symbols": [
+        "kbStats",
+        "kbExport",
+        "kbSessionPrime",
+        "getKbProviders",
+        "resolveRepoPath"
+      ],
+      "source_files": [
+        "src/tools/kb-stats.ts",
+        "src/tools/kb-export.ts",
+        "src/tools/kb-session-prime.ts",
+        "src/services/knowledge/kb-providers.ts",
+        "tests/knowledge/kb-anchor-never-cwd.test.ts"
+      ],
+      "confidence": "CONFIRMED",
+      "updated_at": "2026-08-21T05:24:37.794Z"
     }
   ]
 }

--- a/docs/kb-bible-reconcile-2026-08-21.md
+++ b/docs/kb-bible-reconcile-2026-08-21.md
@@ -1,0 +1,180 @@
+# Bible reconcile, 2026-08-21
+
+A `/pm kb-reconcile` run of the ladder in
+[kb-reconcile-architecture.md](kb-reconcile-architecture.md) against merged
+`main`. `.fleet/kb-canonical.json` went from **36 entries to 24**. This file
+records the disposition of every drop; the pre-reconcile file remains in git
+history at `08ad5f15`.
+
+Companion to [kb-bible-rebuild-2026-08-04.md](kb-bible-rebuild-2026-08-04.md),
+which rebuilt the bible from scratch. This pass did not rebuild -- it ran the
+reconcile ladder and applied the same verification gate to what came out.
+
+## Why a reconcile was due
+
+The bible's own provenance recorded
+`commit aef342816f5c232202c0679e98dc814f11e0076f`, branch
+`chore/persistent-memory-disambiguation-rule`. **That commit does not exist in
+this repository.** The branch was squashed away, so the bible on `main` recorded
+a basis nobody could check. The v2 envelope exists precisely to make that
+checkable, and it was pointing at nothing.
+
+Verification also turned up **two CONFIRMED entries that contradict each other**,
+the same failure the 2026-08-04 rebuild was written to correct:
+
+- `256b2dc0` said 15 of the 16 `src/tools/kb-*.ts` tools spread
+  `...kbScopeFields`; `70077fb7` said only 3 of ~16 did. Main has 15 (only
+  `kb-setup` is excluded, by design), so `70077fb7` was retired.
+
+## The mass-stale trap, and why the sweep did not decide this pass
+
+Simulating `freshnessSweep` against `main` before touching anything showed only
+**10 of 61** live entries still had a matching hash basis. A by-the-book ladder
+run would therefore have exported a bible of ~10 and read as mass knowledge
+deletion.
+
+Most of those 51 were not false. `.gitignore`, `.claude/settings.json` and
+`deploy.md` had merely *changed content* since capture, and
+`src/services/knowledge/repo-config.ts` is branch-only, unmerged. Hash staleness
+means "re-verify", not "wrong" -- but `kb_export` treats stale as retired, so the
+two collapse into the same outcome unless a human intervenes.
+
+So the sweep ran (its verdict is honest and worth having), but it was not allowed
+to be the arbiter. Every entry it staled was read against main's source by hand,
+and the ones that survived that reading were re-captured onto a main-based basis
+rather than left to rot.
+
+## Method
+
+**Step 1, `kb_import` with `skip_sweep`.** Absorbed the merged bible:
+`{imported: 7, skipped: 19, linked: 9, flagged: 1, rejected: 0}`. The 7 were
+entries present only in the bible (they came from another machine's KB via the
+global-bible chain). The 9 "linked" were bible copies of live entries that AUDN
+admitted as refinements -- note these were **re-hashed against main at capture
+time**, which is why they survived the later sweep while their originals did not.
+
+**Step 2, `kb_freshness_sweep`.** `{checked: 100, staled: 49, unstaled: 0}`.
+
+**Step 3, `kb_reconcile_prefilter`.** `{pairs: 6, resolved: 0, left_for_agent: 6}`.
+Zero mechanical wins, exactly as the simulation predicted: with almost no basis
+matching main, the hashes could not settle anything.
+
+**Step 4, arbitration by hand.** Each pair was decided by reading the merged
+source, then written through `kb_resolve_contradiction`. Two pairs were left
+flagged (below).
+
+**Step 5, verification gate.** Every entry that would ship was read against the
+file it cites. Three were found false and two structurally duplicated. Survivors
+whose claim held but whose basis had drifted were re-captured via `kb_capture`
+(clamped to INFERRED) and earned CONFIRMED through `kb_promote` with the
+verification recorded in the promote note -- the same gate the 2026-08-04 rebuild
+used.
+
+**Step 6, `kb_export`.** 24 entries, auto-committed as `pm-kb`.
+
+## Contradictions resolved (7)
+
+| Winner | Loser | Arbitrated by |
+|---|---|---|
+| `0fb5edbf` | `cada27c9` | `project-slug.ts:5-8` -- `remoteUrl` short-circuits before any git shell-out; the loser described the shell-out as the sole mechanism |
+| `857d775e` | `155fbca9` | `check-sandbox-sync-remote.mjs:375-377` maps literal `null` to `[]`; the loser said the branch was absent |
+| `89906789` | `5062c062` | Four `resolveRepoPath` helpers exist, not three; the loser omits `kb-import` |
+| `494a1ec0` | `a640a45f` | Not a real contradiction -- `a640a45f` was a byte-identical row this run's own import created. AUDN's `hasOppositePolarity` fired on the entry's own phrase "not a vacuous test" |
+| `0e10e4ea` | `10e15056` | `src/types.ts:4` + `src/providers/index.ts:10-17` register **six** adapters; the loser claimed seven including a `gemini` that does not exist |
+| `4406ee08` | `d1d891d8` | `check-sandbox-sync-remote.test.ts:461-463` now branches on bd availability, closing the vacuous-pass hole the loser reports as open |
+| `96a63862` | `ec8b983b` | Same rule, corrected basis: `knownRepoRemoteUrl` moved to `src/services/member-remote-url.ts`; `execute-prompt.ts:253` only re-exports it |
+
+## Contradictions deliberately left flagged (2)
+
+The design's tiebreak says an undecidable pair stays flagged for `/pm kb-review`
+rather than being forced. Both of these are undecidable *on main*:
+
+- `f100e93f` vs `5a621658` -- **not actually a contradiction**. Both claims are
+  true on main: the confidence clamp really is enforced in
+  `SqliteProvider.capture` (`sqlite-provider.ts:889`), and capture really does
+  fail closed for a remote work folder, because `assertCheckableBasis` resolves
+  `source_files` against `this.repoPath` without consulting `anchorIsMissing()`.
+  AUDN paired them on polarity alone. Forcing a winner would supersede a true
+  claim.
+- `31acc2d6` vs `40132768` -- the code is **silent**:
+  `src/services/knowledge/repo-config.ts` does not exist on main. Resolving
+  would mint a CONFIRMED, non-stale entry citing a file that is not there,
+  because `resolveContradiction` clears stale but never sets it.
+
+## Judgment drops (verified false on main)
+
+Each of these cites files that still exist, so no mechanical rule would have
+caught them. Each was read against the current source.
+
+- `70077fb7` + `feb51d86` "only 3 of ~16 kb_* tools spread `repo_remote_url`" --
+  15 of 16 do. `70077fb7` is the more dangerous of the two: it is an **import
+  copy re-based onto main's hashes**, so it looked fresh while carrying a
+  pre-fix claim. The trusted-channel import keeps bible confidence, and a fresh
+  basis makes a false entry unfalsifiable by sweep.
+- `10e15056` "seven LLM providers ... gemini" -- six, and no `gemini.ts` exists.
+- `735f21d3` `{{secure.NAME}}` -- describes real behaviour but cites
+  `resolveSecurePlaceholders`, a symbol that appears **nowhere in `src/`**.
+- `40b95472` "the provider cache is still keyed by slug alone" -- `kb-providers.ts:88`
+  keys on `providerKey(slug, repoPath)`. Directly contradicted two entries that
+  are in the bible.
+- `0b2b63b1` "kb_export auto-commit is opt-in and defaults to off" --
+  `kb-export.ts` records `USER DIRECTIVE 2026-08-11: the default is TRUE`. This
+  entry preserved the setting that directive reversed.
+- `a2a0e499` "this repo's tracked settings.json now encodes the `--hook-json`
+  split" -- `.claude/settings.json` uses plain `bd prime` for both SessionStart
+  and PreCompact, and has no `permissions` block at all.
+- `229c96ee` + `d1d891d8` embeddeddolt vacuous pass -- closed on main.
+
+## Point-in-time sprint narration (dropped)
+
+Entries that record what happened during one sprint rather than what is true of
+the code:
+
+- `494a1ec0` "mutation test confirms b4g.2.2 pins the b4g.2.1 fix" -- records
+  that one sprint's mutation check found one test non-vacuous. It also cites
+  bead ids in LLM-facing text, which `CLAUDE.md` forbids. The durable claim
+  underneath it (`130bc73b`) is in the bible.
+- `254b18e2` "passes on both pre-fix and post-fix trees" -- a verdict about a
+  tree that no longer exists, carrying no claim about main.
+
+## Structural duplicates (dropped)
+
+Created by this run's own import, which AUDN admitted as refinements rather than
+deduping (AUDN needs symbol AND file overlap; these differed in neither, but
+arrived under new ids):
+
+- `6ef4939d` -- byte-identical to `f92f896f`
+- `17f8a922` -- byte-identical to `c2d3fa00`
+- `c9047868`, `eb1611af`, `857d775e` -- three rows for one `parseDoltRemoteList`
+  fact, consolidated into `1be49eaa`
+
+## Consolidations (re-captured against main)
+
+Five entries about the same `sprint-logs/` hazard were folded into `22e52be3`,
+which also records that **`.gitignore` now carries the prohibition inline** --
+so the lesson no longer depends on the KB to survive: `1ae4ce00`, `66075242`,
+`daf6fb22`, `bd281bfb`, `b368ad28`.
+
+## Dormant, not dropped: knowledge that needs the branch to land
+
+`fix/codeintel-optout-and-kb-repo-scope` is **13 commits unmerged**. Entries
+about it cite files absent from main (`src/services/knowledge/repo-config.ts`,
+`tests/knowledge/kb-session-prime-repo-optout.test.ts`) and are stale, not
+retired: `7df80206`, `f9f941be`, `31acc2d6`, `7b37d64d`, `27b1f487`, `e23e8d4e`.
+
+**They will not revive by themselves.** `freshnessRevivable` needs a FULL basis
+match, and these bases were hashed on the branch. When that branch merges, run
+the ladder again; the entries need re-capture, not just a sweep.
+
+The same caveat applies to entries staled by ordinary churn and not re-captured
+in this pass -- among them `0633ac36`, `2ff14a5c`, `62a26c94`, `696d42bc`,
+`c996a17a`. Their claims were not judged false; they were not individually
+re-verified, and promoting an unread claim is the failure this gate exists to
+prevent.
+
+## Note for whoever runs this next
+
+`kb_feedback` is a **permanent** retirement, not a pause: the `[feedback ...]`
+content marker is a durable exclusion from `freshnessRevivable`, so a downvoted
+entry never revives. Use it only for "wrong or valueless forever". For knowledge
+that is merely branch-only, let the sweep stale it and leave it alone.


### PR DESCRIPTION
Runs the `/pm kb-reconcile` ladder from `docs/kb-reconcile-architecture.md` against merged `main`, then applies the 2026-08-04 verification gate to the result. `.fleet/kb-canonical.json` goes from **36 entries to 24**.

Full disposition, with the reason and the file read for every drop: `docs/kb-bible-reconcile-2026-08-21.md`.

## Why now

The bible's v2 provenance recorded commit `aef34281` on branch `chore/persistent-memory-disambiguation-rule`. **That commit does not exist in this repository** -- the branch was squashed away, so the bible on `main` recorded a basis nobody could check. The envelope exists to make that checkable, and it was pointing at nothing.

It also held **two CONFIRMED entries that contradict each other**: one said 15 of the 16 `kb_*` tools spread `...kbScopeFields`, the other said 3 of ~16. Main has 15.

## The trap this PR deliberately avoids

Simulating the sweep first showed only **10 of 61** live entries still had a basis matching `main`. A by-the-book ladder run would have exported ~10 entries and read as mass knowledge deletion.

Most of those 51 were not false -- `.gitignore`, `.claude/settings.json` and `deploy.md` had merely changed content since capture, and `repo-config.ts` is branch-only. Hash staleness means "re-verify", not "wrong", but `kb_export` collapses both into "gone".

So the sweep ran and its verdict is recorded, but it was not the arbiter. Every entry it staled was read against main's source by hand; survivors were re-captured onto a main-based basis via `kb_capture` + `kb_promote` with the verification in the promote note.

## What changed

- **7 contradictions arbitrated** against merged code, all through the single `kb_resolve_contradiction` write path
- **2 left flagged on purpose.** `f100e93f`/`5a621658` is not actually a contradiction -- both claims are true on main, AUDN paired them on polarity. `31acc2d6`/`40132768` is undecidable because `repo-config.ts` does not exist on main; forcing a winner would mint a CONFIRMED entry citing a missing file
- **6 entries verified false** and retired, including one claiming a `gemini` provider that does not exist and one citing symbol `resolveSecurePlaceholders`, which appears nowhere in `src/`
- **2 point-in-time sprint narrations** dropped (one also cited bead ids in LLM-facing text, which `CLAUDE.md` forbids)
- **5 duplicate rows** consolidated, including three carrying one `parseDoltRemoteList` fact

## The finding worth reading

`70077fb7` was an **import copy re-based onto main's hashes while carrying a pre-fix claim**. The trusted-channel import keeps bible confidence and capture computes a *fresh* basis, so a false entry came out looking freshly verified and no sweep could ever falsify it. Worth knowing before the next import.

Also recorded: `kb_feedback` is a **permanent** retirement, not a pause -- the `[feedback ...]` marker is a durable exclusion from `freshnessRevivable`, so a downvoted entry never revives. Branch-only knowledge must be left stale instead.

## Not in this PR

`fix/codeintel-optout-and-kb-repo-scope` is 13 commits unmerged. Its entries are stale, not retired, and are listed in the doc. They need re-capture rather than a sweep when it lands, for the revival reason above.

## Verification

- `npx vitest run tests/knowledge/` -- **54 files, 546 tests, all passing**
- Bible is clean ASCII; new provenance is `08ad5f15`, a commit that exists on `main`
- Every line citation in the disposition doc re-checked against the tree

https://claude.ai/code/session_01LmjDVeqSGwSnbuPRokLkMU