### PR TITLE
feat(fleet-sprint): non-exclusive orchestrator role via Agent.unreservable

### DIFF
--- a/packages/apra-fleet-client/src/client/api.mjs
+++ b/packages/apra-fleet-client/src/client/api.mjs
@@ -104,6 +104,7 @@
  * @property {string} [category] - Optional group label
  * @property {string[]} [tags] - Optional list of free-form labels
  * @property {"false" | "auto" | "dangerous"} [unattended] - Permission mode for unattended execution
+ * @property {boolean} [unreservable] - Mark this member as never exclusively reservable, so it can be shared by more than one sprint at once (e.g. fleet-sprint's shared "orchestrator" role)
  */
 
 /**
@@ -122,6 +123,7 @@
  * @property {string} [category] - Group label
  * @property {string[]} [tags] - Free-form labels
  * @property {"false" | "auto" | "dangerous"} [unattended] - Permission mode
+ * @property {boolean} [unreservable] - Mark/unmark this member as shared/never exclusively reservable
  */
 
 /**

--- a/packages/apra-fleet-se/bin/cli.mjs
+++ b/packages/apra-fleet-se/bin/cli.mjs
@@ -670,8 +670,27 @@ async function main() {
         }
         return res && res.content && res.content[0] ? res.content[0].text : '';
     };
+    // apra-fleet: exclude any member ALSO named in roleMap.orchestrator from
+    // this git-identity/git-remote probe -- a shared/unreservable orchestrator
+    // member (docs/design-orchestrator-worktree-model-v2.md) may have no real
+    // checkout at all, and `git rev-parse HEAD` on one hard-fails the launch
+    // (process.exit(1) just below) even though the orchestrator role itself
+    // never needs to pass this check. This only matters when an operator also
+    // lists that member in --members (redundant with roleMap.orchestrator,
+    // and not required); a normal launch that passes the shared orchestrator
+    // ONLY via roleMap.orchestrator was never affected.
+    const orchestratorRoleMapMembersForTopology = new Set(
+        (roleMap && Array.isArray(roleMap.orchestrator)) ? roleMap.orchestrator : []
+    );
+    // Degrade back to the unfiltered list if excluding the orchestrator would
+    // empty it out entirely (e.g. a single-member sprint that role-maps its
+    // one dispatch member as orchestrator too) -- checkMemberTopology refuses
+    // to start on an empty member list, and that degenerate case is exactly
+    // the topology a real (non-shared) dispatch member should still pass.
+    const topologyMembersFiltered = validMembers.filter((m) => !orchestratorRoleMapMembersForTopology.has(m));
+    const topologyMembers = topologyMembersFiltered.length > 0 ? topologyMembersFiltered : validMembers;
     const topology = await checkMemberTopology({
-        members: validMembers,
+        members: topologyMembers,
         mode: syncedMode ? 'synced' : 'legacy',
         getIdentity: (member) => runCommand('git rev-parse HEAD', member),
         getOriginUrl: (member) => runCommand('git remote get-url origin', member),

--- a/packages/apra-fleet-se/bin/cli.mjs
+++ b/packages/apra-fleet-se/bin/cli.mjs
@@ -603,11 +603,19 @@ async function main() {
 
     // 2. Validate members exist via the fleet's list_members tool.
     let validMembers = [];
+    // apra-fleet: names flagged unreservable in the SAME list_members read --
+    // hoisted out of this try block so the topology filter below (item 4) can
+    // key on the actual unreservable flag, not on roleMap.orchestrator
+    // membership (which would also match a real, git-having dispatch member
+    // that is ADDITIONALLY role-mapped as orchestrator, and wrongly skip its
+    // legitimate same-HEAD topology check).
+    let unreservableNames = new Set();
     try {
         const listRes = await fleetApi.listMembers({ format: 'json' });
         const text = listRes && listRes.content && listRes.content[0] ? listRes.content[0].text : JSON.stringify(listRes);
         const parsed = JSON.parse(text);
         const registeredNames = new Set((parsed.members || []).map(m => m.name));
+        unreservableNames = new Set((parsed.members || []).filter(m => m && m.unreservable).map(m => m.name));
         const result = resolveMemberValidation({ rawMembers, registeredNames, allowMissingMembers });
         if (!result.ok) {
             console.error(result.message);
@@ -670,24 +678,28 @@ async function main() {
         }
         return res && res.content && res.content[0] ? res.content[0].text : '';
     };
-    // apra-fleet: exclude any member ALSO named in roleMap.orchestrator from
-    // this git-identity/git-remote probe -- a shared/unreservable orchestrator
-    // member (docs/design-orchestrator-worktree-model-v2.md) may have no real
-    // checkout at all, and `git rev-parse HEAD` on one hard-fails the launch
-    // (process.exit(1) just below) even though the orchestrator role itself
-    // never needs to pass this check. This only matters when an operator also
-    // lists that member in --members (redundant with roleMap.orchestrator,
-    // and not required); a normal launch that passes the shared orchestrator
-    // ONLY via roleMap.orchestrator was never affected.
-    const orchestratorRoleMapMembersForTopology = new Set(
-        (roleMap && Array.isArray(roleMap.orchestrator)) ? roleMap.orchestrator : []
-    );
-    // Degrade back to the unfiltered list if excluding the orchestrator would
-    // empty it out entirely (e.g. a single-member sprint that role-maps its
-    // one dispatch member as orchestrator too) -- checkMemberTopology refuses
-    // to start on an empty member list, and that degenerate case is exactly
-    // the topology a real (non-shared) dispatch member should still pass.
-    const topologyMembersFiltered = validMembers.filter((m) => !orchestratorRoleMapMembersForTopology.has(m));
+    // apra-fleet: exclude any member flagged `unreservable` from this
+    // git-identity/git-remote probe -- such a member (e.g. a shared
+    // fleet-sprint orchestrator, docs/design-orchestrator-worktree-model-v2.md)
+    // may have no real checkout at all, and `git rev-parse HEAD` on one
+    // hard-fails the launch (process.exit(1) just below). Deliberately keyed
+    // on the `unreservable` FLAG, not on roleMap.orchestrator membership: a
+    // real, git-having dispatch member that is ADDITIONALLY role-mapped as
+    // orchestrator (a supported topology, runner.js's branchEnsureMembers
+    // dedupe comment) must still pass its legitimate same-HEAD check against
+    // the other dispatch members -- filtering on roleMap.orchestrator alone
+    // would silently skip that check instead of just skipping a git-less
+    // member. This only matters when an operator also lists a shared member
+    // in --members (redundant with roleMap.orchestrator, and not required);
+    // a normal launch that passes the shared orchestrator ONLY via
+    // roleMap.orchestrator was never affected.
+    const topologyMembersFiltered = validMembers.filter((m) => !unreservableNames.has(m));
+    // Degrade back to the unfiltered list if excluding unreservable members
+    // would empty it out entirely -- checkMemberTopology refuses to start on
+    // an empty member list, and an operator who names ONLY unreservable
+    // members in --members (unusual, but not this check's job to forbid) gets
+    // the ORIGINAL single-member-trivial-pass behavior rather than a topology
+    // error about having no members at all.
     const topologyMembers = topologyMembersFiltered.length > 0 ? topologyMembersFiltered : validMembers;
     const topology = await checkMemberTopology({
         members: topologyMembers,

--- a/packages/apra-fleet-se/fleet-sprint/docs/README.md
+++ b/packages/apra-fleet-se/fleet-sprint/docs/README.md
@@ -97,6 +97,17 @@ Watch progress there rather than tailing raw stdout.
 Unrecognized flags fail loudly rather than being silently ignored, so a typo
 like `--max-cycle` aborts instead of quietly applying the default.
 
+**A shared/`unreservable` orchestrator member goes in `--role-map` ONLY, never
+in `--members`.** `--members` (and `--role-map` values for git-having roles
+like doer/reviewer/harvester) still get git-identity/topology-checked and, on
+resume, git-resynced. A member registered `unreservable: true` (e.g. a
+beads-only orchestrator shared across concurrent sprints) is exempted from
+those checks only when it appears exclusively via `roleMap.orchestrator` --
+listing it in `--members` too is redundant and not required, and defeats the
+exemption for anything outside the topology precondition (e.g. a paused/
+resumed sprint's resync step still runs real git commands against every
+`--members` entry, unreservable or not).
+
 ## Preconditions worth checking first
 
 - The target issue (e.g. `apra-fleet-7pm`) must exist and be open:

--- a/packages/apra-fleet-se/fleet-sprint/runner.js
+++ b/packages/apra-fleet-se/fleet-sprint/runner.js
@@ -2765,12 +2765,16 @@ export function createUnattendedAutoProvisioner(opts = {}) {
  * greps deploy.md by hand and runs compose_permissions manually -- exactly
  * the failure mode this closes the loop on.
  *
- * Reads deploy.md via `command()` against the ORCHESTRATOR member (its own
- * checkout is the source of truth for what is about to be dispatched) and
- * caches the parsed prefix list for the lifetime of the returned function --
- * one read per sprint run, since deploy.md does not change mid-run on a
- * healthy pipeline. Also caches per TARGET member, like
- * createUnattendedAutoProvisioner above, so repeat cycles don't re-grant.
+ * Reads deploy.md via `command()` against the FIRST target member it is asked
+ * to provision (that member is about to be dispatched as deployer/
+ * integ-test-runner/regression-test-runner, so its own checkout is the source
+ * of truth for what it is about to run) and caches the parsed prefix list for
+ * the lifetime of the returned function -- one read per sprint run, since
+ * deploy.md does not change mid-run on a healthy pipeline. Also caches per
+ * TARGET member, like createUnattendedAutoProvisioner above, so repeat cycles
+ * don't re-grant. Deliberately does NOT read via a separate orchestrator
+ * member: the orchestrator role may be shared/unreservable across concurrent
+ * sprints and carries no git checkout of its own to read from.
  *
  * Failure at any step (probe fails, deploy.md missing/unparseable,
  * compose_permissions unreachable, a listed prefix hitting the
@@ -2778,23 +2782,23 @@ export function createUnattendedAutoProvisioner(opts = {}) {
  * best-effort acceleration -- the deployer's own Step 0a check remains the
  * authoritative, fail-closed backstop regardless of whether this succeeds.
  *
- * @param {{ callTool: (name: string, args: object) => Promise<any>, command: Function, orchestratorMember: string, log?: Function }} opts
+ * @param {{ callTool: (name: string, args: object) => Promise<any>, command: Function, log?: Function }} opts
  * @returns {(member: string) => Promise<void>}
  */
 export function createDeployPermissionsProvisioner(opts = {}) {
-    const { callTool, command, orchestratorMember, log = () => {} } = opts;
+    const { callTool, command, log = () => {} } = opts;
     const fleetApi = new ApraFleet({ callTool });
     /** @type {Set<string>} members already granted deploy.md's permissions this run. */
     const provisioned = new Set();
     /** @type {string[] | null | undefined} undefined = not yet attempted. */
     let cachedPrefixes;
 
-    async function loadRequiredPrefixes() {
+    async function loadRequiredPrefixes(targetMember) {
         if (cachedPrefixes !== undefined) return cachedPrefixes;
         try {
             const res = await command(
                 `node -e "const fs=require('fs'); if(fs.existsSync('deploy.md')) process.stdout.write(fs.readFileSync('deploy.md','utf8'))"`,
-                { member_name: orchestratorMember, silent: true, label: `Read deploy.md permissions`, failSoft: true },
+                { member_name: targetMember, silent: true, label: `Read deploy.md permissions`, failSoft: true },
             );
             if (!res.ok || !res.output) {
                 cachedPrefixes = null;
@@ -2812,7 +2816,7 @@ export function createDeployPermissionsProvisioner(opts = {}) {
 
     return async function ensureDeployPermissions(member) {
         if (!member || provisioned.has(member)) return;
-        const prefixes = await loadRequiredPrefixes();
+        const prefixes = await loadRequiredPrefixes(member);
         if (!prefixes) return;
         try {
             const result = await fleetApi.composePermissions({
@@ -6351,6 +6355,17 @@ async function runSprintCycle(context) {
     // Uses the canonical ROLE_ORCHESTRATOR constant, not a literal -- see its
     // doc comment for why 'orchestrator' is an application-level pseudo-role
     // deliberately outside contracts.ROLES.
+    //
+    // apra-fleet-TODO(orchestrator-hard-fail): an unmapped orchestrator
+    // silently falling back to unmappedRoleFallbackPool[0] is a known defect
+    // (docs/design-orchestrator-worktree-model-v2.md section 1/6.4) -- it has
+    // repeatedly caused the orchestrator to run against a stale/wrong-scope bd
+    // clone. Making this a hard launch-time failure is the intended fix, but
+    // it cannot land in isolation: it requires the supervisor to
+    // auto-inject roleMap.orchestrator on every launch first (section 6.2,
+    // not yet implemented) -- otherwise every existing caller that relies on
+    // the implicit fallback (including this file's own test harness) breaks.
+    // Land 6.2, update callers, THEN make this throw.
     const orchestratorMember = getMemberForRole(ROLE_ORCHESTRATOR);
 
     // Self-heals deploy.md's declared Permissions onto the deployer /
@@ -6362,7 +6377,7 @@ async function runSprintCycle(context) {
     // from `args.callTool`, else a no-op when neither is available.
     const ensureDeployPermissions = context.ensureDeployPermissions ?? (
         (args && typeof args.callTool === 'function')
-            ? createDeployPermissionsProvisioner({ callTool: args.callTool, command, orchestratorMember, log })
+            ? createDeployPermissionsProvisioner({ callTool: args.callTool, command, log })
             : async () => {}
     );
 
@@ -7012,8 +7027,14 @@ async function runSprintCycle(context) {
     // sprint starts; this ensure-everywhere is the git half of the same "every
     // member starts from the same state" guarantee. See docs/architecture.md
     // "Multi-member topology (fleet-sprint)".
+    // apra-fleet: orchestratorMember is deliberately NOT included here -- the
+    // orchestrator role issues only bd/Dolt commands (never git), and a
+    // shared/unreservable orchestrator member used across concurrent sprints
+    // cannot be checked out onto N different branches at once. If an operator
+    // explicitly role-maps a dispatch member (doer/reviewer/planner/etc.) as
+    // orchestrator too, that member is still included below via its dispatch
+    // role, so the ensure-everywhere guarantee is unaffected for that case.
     const branchEnsureMembers = [...new Set([
-        orchestratorMember,
         ...getMembersForRole(ROLE_DOER),
         ...getMembersForRole(ROLE_REVIEWER),
         ...getMembersForRole('planner'),
@@ -7338,10 +7359,13 @@ async function runSprintCycle(context) {
     // single-quoted JS literals inside a double-quoted shell argument (no
     // escaped-quote-inside-quote traps). failSoft, so a probe failure can never
     // throw and kill the sprint -- it just means "skip the dependent phase".
-    async function probeFileExists(filename) {
+    // Runs on `member` -- the role member about to consume the probed file --
+    // never on orchestratorMember: a shared/unreservable orchestrator member
+    // carries no git checkout to probe.
+    async function probeFileExists(filename, member) {
         const res = await command(
             `node -e "console.log(require('fs').existsSync('${filename}') ? 'found' : 'not found')"`,
-            { member_name: orchestratorMember, silent: true, label: `Probe for '${filename}'`, failSoft: true }
+            { member_name: member, silent: true, label: `Probe for '${filename}'`, failSoft: true }
         );
         if (!res.ok) {
             log(`Probe for '${filename}' failed (treating as not-found, skipping the dependent phase): ${res.error}`);
@@ -9281,8 +9305,8 @@ async function runSprintCycle(context) {
         // error, portability quirk on a given member, etc.) SKIPS the dependent
         // phase with a logged warning -- it must never throw and kill the
         // sprint.
-        const hasDeploy = await probeFileExists('deploy.md');
-        const hasPlaybook = await probeFileExists('integ-test-playbook.md');
+        const hasDeploy = await probeFileExists('deploy.md', getMemberForRole('deployer'));
+        const hasPlaybook = await probeFileExists('integ-test-playbook.md', getMemberForRole('integ-test-runner'));
 
         let deployedThisCycle = false;
 
@@ -10318,7 +10342,7 @@ async function runSprintCycle(context) {
     // part 2 provisions its own fresh sandbox install, so neither depends on
     // the per-cycle Deploy target.
     let regressionResult = null;
-    const hasRegressionPlaybook = await probeFileExists('regression-test-playbook.md');
+    const hasRegressionPlaybook = await probeFileExists('regression-test-playbook.md', getMemberForRole('regression-test-runner'));
     if (hasRegressionPlaybook) {
         phase(`Regression Test C${finalCycleLabel}`);
         await ensureUnattendedAuto(getMemberForRole('regression-test-runner'));
@@ -10996,9 +11020,25 @@ export async function main(context) {
         // the watchdog needs a reason either way.
         if (isTypedAbortError(err)) {
             try {
-                const member = (validatedForLock.roleMap && validatedForLock.roleMap[ROLE_ORCHESTRATOR] && validatedForLock.roleMap[ROLE_ORCHESTRATOR].length > 0)
-                    ? validatedForLock.roleMap[ROLE_ORCHESTRATOR][0]
-                    : validatedForLock.members[0];
+                // apra-fleet: finalizeAbort() runs `git fetch`/`git push` against
+                // this member's LOCAL checkout, which the orchestrator role no
+                // longer has (it may be a shared/unreservable, git-less member --
+                // see docs/design-orchestrator-worktree-model-v2.md section 4.5).
+                // Resolve a git-capable DISPATCH member instead: the harvester's
+                // member (the last code-writing role, so its clone pushed most
+                // recently), falling back to the first doer, never
+                // roleMap.orchestrator and never a bare validatedForLock.members[0]
+                // pick (that silent pick is the original bug this closes).
+                const roleMap = validatedForLock.roleMap;
+                const harvesterMembers = (roleMap && Array.isArray(roleMap['harvester'])) ? roleMap['harvester'] : [];
+                const doerMembers = (roleMap && Array.isArray(roleMap[ROLE_DOER])) ? roleMap[ROLE_DOER] : [];
+                const member = harvesterMembers[0]
+                    ?? doerMembers[0]
+                    ?? validatedForLock.members.find((m) => !roleMap || !roleMap[ROLE_ORCHESTRATOR] || !roleMap[ROLE_ORCHESTRATOR].includes(m));
+                if (!member) {
+                    log('[Terminal History] finalizeAbort() skipped: no harvester/doer/dispatch member could be resolved to push the aborted branch.');
+                    throw new Error('no git-capable member resolved for finalizeAbort');
+                }
                 abortResult = await finalizeAbort({
                     error: err,
                     branch,

--- a/packages/apra-fleet-se/fleet-sprint/runner.js
+++ b/packages/apra-fleet-se/fleet-sprint/runner.js
@@ -10618,6 +10618,15 @@ async function runSprintCycle(context) {
     // closing the sprint's target issue would advertise a completion nobody can
     // see. This is the deliberately MINIMAL hardening -- the pluggable-publish
     // restructure is apra-fleet-647.2, which supersedes it.
+    // apra-fleet: this push and the origin-remote read just below it run on
+    // publishGitMember -- a real dispatch member with an actual git checkout
+    // (harvester, falling back to the fallback pool like every other role
+    // resolution in this file) -- NEVER orchestratorMember, which may be a
+    // shared/unreservable, git-less member (docs/design-orchestrator-
+    // worktree-model-v2.md section 4.3/4.5). raiseVcsPrForMember() below
+    // stays on orchestratorMember: it is a credential-file read + REST call,
+    // not git, and is explicitly designed to stay there (section 4.6).
+    const publishGitMember = getMemberForRole('harvester');
     let pushed = false;
     let lastPushError = '';
     for (let attempt = 0; attempt < POST_DISPATCH_SYNC_RETRY_DELAYS_MS.length; attempt++) {
@@ -10630,7 +10639,7 @@ async function runSprintCycle(context) {
         const pushRes = await command(
             `git push -u origin ${validated.branch}`,
             {
-                member_name: orchestratorMember,
+                member_name: publishGitMember,
                 silent: true,
                 failSoft: true,
                 label: `Push sprint branch '${validated.branch}'`,
@@ -10674,7 +10683,7 @@ async function runSprintCycle(context) {
     // capabilities()'s own contract -- so a probe hiccup here can never kill
     // the sprint.
     const originUrlRes = await command('git remote get-url origin', {
-        member_name: orchestratorMember,
+        member_name: publishGitMember,
         silent: true,
         failSoft: true,
         label: 'Resolve origin remote URL',

--- a/packages/apra-fleet-se/fleet-sprint/runner.js
+++ b/packages/apra-fleet-se/fleet-sprint/runner.js
@@ -6327,9 +6327,32 @@ async function runSprintCycle(context) {
             if (Array.isArray(list)) for (const m of list) roleMapSpecialists.add(m);
         }
     }
+    // apra-fleet: roleMap.orchestrator members are excluded from BOTH the
+    // generalist pool and its degenerate physicalMembers fallback -- not just
+    // from the generalist filter -- because the orchestrator role may be a
+    // shared/unreservable, git-less member (docs/design-orchestrator-
+    // worktree-model-v2.md). Without this, the "every member is a specialist"
+    // degradation re-selects the orchestrator for OTHER unmapped roles
+    // (harvester/planner/deployer/etc.), silently undoing the branchEnsureMembers
+    // removal and every probeFileExists/publishGitMember fix elsewhere in this
+    // file: those call getMemberForRole()/getMembersForRole() for roles that
+    // still expect a real git checkout.
+    const orchestratorRoleMapMembers = new Set(
+        (validated.roleMap && Array.isArray(validated.roleMap[ROLE_ORCHESTRATOR]))
+            ? validated.roleMap[ROLE_ORCHESTRATOR]
+            : []
+    );
     const unmappedRoleFallbackPool = (() => {
-        const generalists = physicalMembers.filter((m) => !roleMapSpecialists.has(m));
-        return generalists.length > 0 ? generalists : physicalMembers;
+        const eligible = physicalMembers.filter((m) => !orchestratorRoleMapMembers.has(m));
+        const generalists = eligible.filter((m) => !roleMapSpecialists.has(m));
+        if (generalists.length > 0) return generalists;
+        if (eligible.length > 0) return eligible;
+        // Every physical member IS the mapped orchestrator (e.g. a single-member
+        // launch that role-maps the same member as both a dispatch role and
+        // orchestrator): there is no other member to fall back to, so this
+        // degrades to the original physicalMembers behavior rather than
+        // resolving to an empty pool.
+        return physicalMembers;
     })();
 
     const getMemberForRole = (role) => {

--- a/packages/apra-fleet-se/src/supervisor/api.mjs
+++ b/packages/apra-fleet-se/src/supervisor/api.mjs
@@ -100,12 +100,21 @@ function normalizeMembers(value) {
     return out;
 }
 
-/** The full member set a reservation covers: the union of --members and every roleMap value. */
-function memberUnion(members, roleMap) {
+/**
+ * The full member set a reservation covers: the union of --members and every
+ * roleMap value. `exclude` (unreservable member names -- see
+ * unreservableMemberNames() below) is subtracted from the union: a shared
+ * orchestrator member is never part of a sprint's exclusive reservation, so it
+ * never reaches `beforeLaunch` or `ledger.claim`.
+ */
+function memberUnion(members, roleMap, exclude) {
     const seen = new Set();
     const out = [];
     const add = (m) => {
-        if (typeof m === 'string' && m.length > 0 && !seen.has(m)) { seen.add(m); out.push(m); }
+        if (typeof m === 'string' && m.length > 0 && !seen.has(m) && !(exclude && exclude.has(m))) {
+            seen.add(m);
+            out.push(m);
+        }
     };
     for (const m of members) add(m);
     if (roleMap && typeof roleMap === 'object') {
@@ -114,6 +123,30 @@ function memberUnion(members, roleMap) {
         }
     }
     return out;
+}
+
+/**
+ * Best-effort set of member names currently flagged `unreservable: true` by
+ * the fleet server's own member list (e.g. a member filling fleet-sprint's
+ * shared `orchestrator` role across many concurrent sprints). A `listMembers`
+ * failure yields an empty set -- this is defense in depth on top of the
+ * server-side no-op in member-reservation.ts, not the sole enforcement point.
+ * @param {() => Promise<object|object[]>|object|object[]} [listMembers]
+ * @returns {Promise<Set<string>>}
+ */
+async function unreservableMemberNames(listMembers) {
+    if (typeof listMembers !== 'function') return new Set();
+    try {
+        const raw = await listMembers();
+        const list = Array.isArray(raw) ? raw : (raw && Array.isArray(raw.members) ? raw.members : []);
+        const out = new Set();
+        for (const m of list) {
+            if (m && typeof m === 'object' && m.name && m.unreservable) out.add(m.name);
+        }
+        return out;
+    } catch {
+        return new Set();
+    }
 }
 
 /**
@@ -188,6 +221,7 @@ export function defaultMemberOverlapGuard(ledger, listMembers) {
                 const list = Array.isArray(raw) ? raw : (raw && Array.isArray(raw.members) ? raw.members : []);
                 for (const m of list) {
                     if (!m || typeof m !== 'object') continue;
+                    if (m.unreservable) continue;
                     if (m.name && m.reservedBy && requestSet.has(m.name)) {
                         addConflict(m.reservedBy, m.name);
                     }
@@ -439,7 +473,8 @@ export function createSprintController(deps = {}) {
             ? undefined
             : (typeof body.roleMap === 'string' ? body.roleMap : JSON.stringify(body.roleMap));
         const roleMap = await roleMapResolver(rawRoleMap);
-        const union = memberUnion(members, roleMap);
+        const unreservable = await unreservableMemberNames(listMembers);
+        const union = memberUnion(members, roleMap, unreservable);
         // apra-fleet-ymf.1: issueRoots is the SPLIT array of individual ids
         // (never the raw comma-joined string) -- the same shape the CLI path
         // already feeds runner.js's targetIssues, and what the ledger schema,

--- a/packages/apra-fleet-se/src/supervisor/api.mjs
+++ b/packages/apra-fleet-se/src/supervisor/api.mjs
@@ -134,7 +134,7 @@ function memberUnion(members, roleMap, exclude) {
  * @param {() => Promise<object|object[]>|object|object[]} [listMembers]
  * @returns {Promise<Set<string>>}
  */
-async function unreservableMemberNames(listMembers) {
+async function unreservableMemberNames(listMembers, log = (...a) => console.error(...a)) {
     if (typeof listMembers !== 'function') return new Set();
     try {
         const raw = await listMembers();
@@ -144,7 +144,15 @@ async function unreservableMemberNames(listMembers) {
             if (m && typeof m === 'object' && m.name && m.unreservable) out.add(m.name);
         }
         return out;
-    } catch {
+    } catch (err) {
+        // A transient listMembers() failure here silently reinstates the
+        // original member-overlap 409 for a genuinely unreservable member,
+        // with nothing in the log to explain why -- log loudly rather than
+        // swallow it, even though the launch still proceeds treating no
+        // member as unreservable (best-effort, not the sole enforcement
+        // point -- member-reservation.ts's server-side no-op still protects
+        // a flagged member even if this check can't see it this launch).
+        log(`[unreservable] listMembers() failed while computing the unreservable-member exclude set (treating as none this launch): ${err.message}`);
         return new Set();
     }
 }
@@ -166,8 +174,10 @@ export function formatMemberConflict(conflicts) {
  * apra-fleet-eft.5.2 (extended by eft.26.2, Hole 2): the DEFAULT member-axis
  * overlap guard used as `beforeLaunch` when the caller does not inject its
  * own. All-or-nothing: ANY member in the incoming union (members + every
- * roleMap value, INCLUDING the orchestrator role -- memberUnion() already
- * folds that in) that is also held by any OTHER active reservation rejects
+ * roleMap value, INCLUDING the orchestrator role UNLESS that member is
+ * flagged `unreservable` -- memberUnion() already folds roleMap values in and
+ * subtracts unreservable names) that is also held by any OTHER active
+ * reservation rejects
  * the ENTIRE launch with a 409, naming the conflicting sprint id(s) and the
  * specific overlapping member names. This throws BEFORE ledger.claim() is
  * ever called, so a rejected launch leaves the ledger byte-identical -- no
@@ -361,7 +371,27 @@ export function createSprintController(deps = {}) {
         throw new TypeError('createSprintController requires a spawner with spawnSprint()');
     }
     const history = deps.history ?? { latestFor: () => undefined, forSprint: () => [], latestForIssueRoot: () => undefined };
-    const listMembers = deps.listMembers ?? (() => ({ members: [] }));
+    // apra-fleet: single-flight wrap -- launch() calls listMembers() once
+    // itself (unreservableMemberNames) and beforeLaunch's default
+    // (defaultMemberOverlapGuard) calls it again internally; without this,
+    // every launch opened and tore down two separate short-lived MCP
+    // transports (listFleetMembers) for what is logically one read. Two
+    // calls issued back-to-back share the same in-flight fetch; the cache is
+    // cleared as soon as it resolves, so unrelated callers (e.g. GET
+    // /api/members on its own) still see a fresh read on their own request.
+    const rawListMembers = deps.listMembers ?? (() => ({ members: [] }));
+    let listMembersInFlight = null;
+    const listMembers = () => {
+        if (listMembersInFlight) return listMembersInFlight;
+        listMembersInFlight = (async () => {
+            try {
+                return await rawListMembers();
+            } finally {
+                listMembersInFlight = null;
+            }
+        })();
+        return listMembersInFlight;
+    };
     const getBacklog = deps.getBacklog ?? (() => ({ tasks: [] }));
     const proxyState = deps.proxyState ?? proxyChildState;
     const proxyStop = deps.proxyStop ?? proxyChildStop;

--- a/packages/apra-fleet-se/src/supervisor/api.mjs
+++ b/packages/apra-fleet-se/src/supervisor/api.mjs
@@ -103,7 +103,7 @@ function normalizeMembers(value) {
 /**
  * The full member set a reservation covers: the union of --members and every
  * roleMap value. `exclude` (unreservable member names -- see
- * unreservableMemberNames() below) is subtracted from the union: a shared
+ * unreservableMemberNamesFromList() below) is subtracted from the union: a shared
  * orchestrator member is never part of a sprint's exclusive reservation, so it
  * never reaches `beforeLaunch` or `ledger.claim`.
  */
@@ -126,36 +126,23 @@ function memberUnion(members, roleMap, exclude) {
 }
 
 /**
- * Best-effort set of member names currently flagged `unreservable: true` by
- * the fleet server's own member list (e.g. a member filling fleet-sprint's
- * shared `orchestrator` role across many concurrent sprints). A `listMembers`
- * failure yields an empty set -- this is defense in depth on top of the
- * server-side no-op in member-reservation.ts, not the sole enforcement point.
- * @param {() => Promise<object|object[]>|object|object[]} [listMembers]
- * @returns {Promise<Set<string>>}
+ * Pure extractor: the set of member names flagged `unreservable: true` in an
+ * ALREADY-FETCHED `listMembers()`-shaped result (raw array or `{members}`).
+ * No I/O, so callers that already hold a fetched list (e.g. `launch()` below,
+ * which needs exactly one listMembers() read shared with the overlap guard)
+ * never trigger a second fetch just to compute this.
+ * @param {object|object[]} raw
+ * @returns {Set<string>}
  */
-async function unreservableMemberNames(listMembers, log = (...a) => console.error(...a)) {
-    if (typeof listMembers !== 'function') return new Set();
-    try {
-        const raw = await listMembers();
-        const list = Array.isArray(raw) ? raw : (raw && Array.isArray(raw.members) ? raw.members : []);
-        const out = new Set();
-        for (const m of list) {
-            if (m && typeof m === 'object' && m.name && m.unreservable) out.add(m.name);
-        }
-        return out;
-    } catch (err) {
-        // A transient listMembers() failure here silently reinstates the
-        // original member-overlap 409 for a genuinely unreservable member,
-        // with nothing in the log to explain why -- log loudly rather than
-        // swallow it, even though the launch still proceeds treating no
-        // member as unreservable (best-effort, not the sole enforcement
-        // point -- member-reservation.ts's server-side no-op still protects
-        // a flagged member even if this check can't see it this launch).
-        log(`[unreservable] listMembers() failed while computing the unreservable-member exclude set (treating as none this launch): ${err.message}`);
-        return new Set();
+function unreservableMemberNamesFromList(raw) {
+    const list = Array.isArray(raw) ? raw : (raw && Array.isArray(raw.members) ? raw.members : []);
+    const out = new Set();
+    for (const m of list) {
+        if (m && typeof m === 'object' && m.name && m.unreservable) out.add(m.name);
     }
+    return out;
 }
+
 
 /**
  * Human-readable rejection message naming every conflicting sprint and the
@@ -198,12 +185,19 @@ export function formatMemberConflict(conflicts) {
  * `listMembers` is optional (backward compatible: omitting it checks only the
  * local ledger, exactly as before eft.26.2).
  *
+ * apra-fleet: the caller MAY pass `ctx.membersList` -- an already-fetched
+ * `listMembers()` result -- to skip this guard's own fetch entirely. `launch()`
+ * already needs one `listMembers()` read to compute the unreservable-exclude
+ * set for `memberUnion()`; without this, that same read was repeated here,
+ * opening a second short-lived MCP transport for what is logically one
+ * request-scoped read.
+ *
  * @param {{ list: () => Array<{ sprintId: string, members?: string[] }> }} ledger
  * @param {() => Promise<object|object[]>|object|object[]} [listMembers]
- * @returns {(ctx: { members: string[], issueRoots: string[] }) => Promise<void>}
+ * @returns {(ctx: { members: string[], issueRoots: string[], membersList?: object|object[] }) => Promise<void>}
  */
 export function defaultMemberOverlapGuard(ledger, listMembers) {
-    return async ({ members: requestMembers }) => {
+    return async ({ members: requestMembers, membersList }) => {
         const requestSet = new Set(requestMembers ?? []);
         // sprintId -> Set<member>, merged across both sources so a member
         // conflicting via both the local ledger AND the server record is
@@ -225,9 +219,9 @@ export function defaultMemberOverlapGuard(ledger, listMembers) {
         // a server-side reservation made by other means (not this ledger) is
         // still caught. Best-effort: a failure to reach listMembers must not
         // block the local-ledger check above from still protecting the launch.
-        if (typeof listMembers === 'function') {
+        if (membersList !== undefined || typeof listMembers === 'function') {
             try {
-                const raw = await listMembers();
+                const raw = membersList !== undefined ? membersList : await listMembers();
                 const list = Array.isArray(raw) ? raw : (raw && Array.isArray(raw.members) ? raw.members : []);
                 for (const m of list) {
                     if (!m || typeof m !== 'object') continue;
@@ -371,27 +365,7 @@ export function createSprintController(deps = {}) {
         throw new TypeError('createSprintController requires a spawner with spawnSprint()');
     }
     const history = deps.history ?? { latestFor: () => undefined, forSprint: () => [], latestForIssueRoot: () => undefined };
-    // apra-fleet: single-flight wrap -- launch() calls listMembers() once
-    // itself (unreservableMemberNames) and beforeLaunch's default
-    // (defaultMemberOverlapGuard) calls it again internally; without this,
-    // every launch opened and tore down two separate short-lived MCP
-    // transports (listFleetMembers) for what is logically one read. Two
-    // calls issued back-to-back share the same in-flight fetch; the cache is
-    // cleared as soon as it resolves, so unrelated callers (e.g. GET
-    // /api/members on its own) still see a fresh read on their own request.
-    const rawListMembers = deps.listMembers ?? (() => ({ members: [] }));
-    let listMembersInFlight = null;
-    const listMembers = () => {
-        if (listMembersInFlight) return listMembersInFlight;
-        listMembersInFlight = (async () => {
-            try {
-                return await rawListMembers();
-            } finally {
-                listMembersInFlight = null;
-            }
-        })();
-        return listMembersInFlight;
-    };
+    const listMembers = deps.listMembers ?? (() => ({ members: [] }));
     const getBacklog = deps.getBacklog ?? (() => ({ tasks: [] }));
     const proxyState = deps.proxyState ?? proxyChildState;
     const proxyStop = deps.proxyStop ?? proxyChildStop;
@@ -503,7 +477,24 @@ export function createSprintController(deps = {}) {
             ? undefined
             : (typeof body.roleMap === 'string' ? body.roleMap : JSON.stringify(body.roleMap));
         const roleMap = await roleMapResolver(rawRoleMap);
-        const unreservable = await unreservableMemberNames(listMembers);
+        // apra-fleet: ONE listMembers() read, shared with beforeLaunch below
+        // (via ctx.membersList) -- both need to know which members are
+        // currently flagged unreservable, and issuing two separate fetches
+        // per launch opened two separate short-lived MCP transports for what
+        // is logically one request-scoped read. A fetch failure here degrades
+        // to "no member known unreservable" (best-effort, not the sole
+        // enforcement point -- member-reservation.ts's server-side no-op
+        // still protects a flagged member even if this can't see it) and
+        // leaves membersListRaw undefined so beforeLaunch falls back to its
+        // own (equally best-effort) fetch attempt.
+        let membersListRaw;
+        try {
+            membersListRaw = await listMembers();
+        } catch (err) {
+            console.error(`[unreservable] listMembers() failed while computing the unreservable-member exclude set (treating as none this launch): ${err.message}`);
+            membersListRaw = undefined;
+        }
+        const unreservable = membersListRaw !== undefined ? unreservableMemberNamesFromList(membersListRaw) : new Set();
         const union = memberUnion(members, roleMap, unreservable);
         // apra-fleet-ymf.1: issueRoots is the SPLIT array of individual ids
         // (never the raw comma-joined string) -- the same shape the CLI path
@@ -549,7 +540,7 @@ export function createSprintController(deps = {}) {
         }
 
         // eft.5.2 seam: reject overlapping launches (409) BEFORE spawning a child.
-        await beforeLaunch({ members: union, issueRoots });
+        await beforeLaunch({ members: union, issueRoots, membersList: membersListRaw });
 
         // apra-fleet-k7b.1: generate the sprintId BEFORE spawning (not after,
         // as before) so it can be forwarded into the child's own argv as

--- a/packages/apra-fleet-se/test/supervisor-api.test.mjs
+++ b/packages/apra-fleet-se/test/supervisor-api.test.mjs
@@ -439,6 +439,29 @@ describe('api -- apra-fleet-eft.5.2 member-axis overlap check (default beforeLau
         await fsp.rm(dir, { recursive: true, force: true });
     });
 
+    test('an unreservable orchestrator member is NOT caught by an existing overlap -- the launch succeeds and the ledger never claims it', async () => {
+        const dir = await tmpDir();
+        const { ledger, history } = await stores(dir);
+        // s-active already claims 'supervisor' (e.g. from an earlier sprint that
+        // also used it as orchestrator).
+        await ledger.claim('s-active', { members: ['alice', 'supervisor'], issueRoots: ['R1'], childPid: 1 });
+        const captured = [];
+        const controller = createSprintController({
+            ledger, history, spawner: recordingSpawner(captured),
+            listMembers: () => ({ members: [{ name: 'supervisor', unreservable: true }] }),
+            getBacklog: () => ({}),
+        });
+        const r = await controller.launch({
+            issue: 'PROJ-2', members: ['dave'], branch: 'feat/y', base: 'main',
+            roleMap: { orchestrator: ['supervisor'] },
+        });
+        assert.equal(captured.length, 1);
+        // The ledger's own reservation for the NEW sprint never includes the
+        // unreservable member -- it is subtracted from the union entirely.
+        assert.deepEqual([...r.members].sort(), ['dave']);
+        await fsp.rm(dir, { recursive: true, force: true });
+    });
+
     test('a rejected launch leaves the ledger byte-identical (no partial claim)', async () => {
         const dir = await tmpDir();
         const { ledger, history } = await stores(dir);
@@ -505,6 +528,17 @@ describe('api -- apra-fleet-eft.5.2 member-axis overlap check (default beforeLau
     // naming the owning sprint id -- this is what makes a workflow/cli-launched
     // sprint's member_reservation claim (eft.26.1) visible to a launch routed
     // through THIS supervisor.
+    test('defaultMemberOverlapGuard: an unreservable member carrying a stale server-side reservedBy is skipped -- no 409', async () => {
+        const ledgerStub = { list: () => [] };
+        // 'alice' somehow still carries a reservedBy (e.g. set before it was
+        // flagged unreservable, or a bug elsewhere) -- the guard must skip it
+        // by construction, not merely because a well-behaved caller never sets
+        // reservedBy on an unreservable member.
+        const listMembers = () => ({ members: [{ name: 'alice', reservedBy: 'workflow-sprint-1', unreservable: true }] });
+        const guard = defaultMemberOverlapGuard(ledgerStub, listMembers);
+        await assert.doesNotReject(() => guard({ members: ['alice'] }));
+    });
+
     test('defaultMemberOverlapGuard: a server-side-only reservation (ledger empty) still rejects with 409 naming the owning sprint id', async () => {
         const ledgerStub = { list: () => [] };
         const listMembers = () => ({ members: [{ name: 'alice', reservedBy: 'workflow-sprint-1' }, { name: 'bob', reservedBy: null }] });

--- a/src/tools/list-members.ts
+++ b/src/tools/list-members.ts
@@ -118,6 +118,7 @@ export async function listMembers(input?: ListMembersInput): Promise<string> {
         category: a.category ?? null,
         tags: a.tags ?? null,
         reservedBy: a.reservedBy ?? null,
+        unreservable: a.unreservable ?? false,
       })),
     });
   }
@@ -155,6 +156,9 @@ export async function listMembers(input?: ListMembersInput): Promise<string> {
       }
       if (a.reservedBy) {
         t += ` | reserved-by=${a.reservedBy}`;
+      }
+      if (a.unreservable) {
+        t += ` | unreservable`;
       }
       t += '\n';
     }

--- a/src/tools/member-reservation.ts
+++ b/src/tools/member-reservation.ts
@@ -33,6 +33,10 @@ export async function memberReservation(input: MemberReservationInput): Promise<
   if (typeof existingOrError === 'string') return existingOrError;
   const existing = existingOrError as Agent;
 
+  if (existing.unreservable) {
+    return `[OK] Member "${existing.friendlyName}" is shared/unreservable -- nothing to reserve or release.`;
+  }
+
   const currentOwner = existing.reservedBy ?? null;
 
   if (input.action === 'reserve') {

--- a/src/tools/register-member.ts
+++ b/src/tools/register-member.ts
@@ -69,6 +69,7 @@ export const registerMemberSchema = z.object({
     premium: z.string().optional(),
   }).optional().describe('Per-member model tier map. Keys: cheap, standard, premium. Values: model IDs (e.g. "ollama/qwen3-coder:30b"). A single model fills all tiers. At least one model recommended for opencode members.'),
   code_intel_provider: z.enum(['codebase-memory', 'gitnexus', 'none']).optional().describe('Code-intelligence provider for this member (default: fleet-wide config).'),
+  unreservable: z.boolean().optional().describe('Mark this member as never exclusively reservable, so it can be shared by more than one sprint at once (e.g. a member filling fleet-sprint\'s shared "orchestrator" role). reserve/release/force_release become no-op successes and overlap guards skip it. Default: false.'),
 });
 
 export type RegisterMemberInput = z.infer<typeof registerMemberSchema>;
@@ -280,6 +281,7 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
     category: input.category,
     tags: input.tags,
     codeIntelProvider: input.code_intel_provider,
+    unreservable: input.unreservable ?? false,
   };
 
   // --- SSH-dependent steps (skipped for stopped cloud instances) ---
@@ -546,6 +548,9 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
   }
   if (tempAgent.tags && tempAgent.tags.length > 0) {
     result += `  Tags:     ${tempAgent.tags.join(', ')}\n`;
+  }
+  if (tempAgent.unreservable) {
+    result += `  Unreservable: true (shared -- never exclusively reserved)\n`;
   }
   if (tempAgent.modelCheap) result += `  Model Cheap: ${tempAgent.modelCheap}\n`;
   if (tempAgent.modelStandard) result += `  Model Standard: ${tempAgent.modelStandard}\n`;

--- a/src/tools/register-member.ts
+++ b/src/tools/register-member.ts
@@ -134,6 +134,17 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
     if (!input.auth_type) return '❌ "auth_type" is required for remote members. Member was NOT registered.';
   }
 
+  // unreservable is reserved for members that never receive a real agent
+  // dispatch (e.g. a beads-only fleet-sprint orchestrator shared across
+  // concurrent sprints). Without this constraint, an ordinary dispatch
+  // member flagged unreservable would let two sprints dispatch to it
+  // concurrently -- interleaving prompts into one working tree -- and any
+  // member with update_member access could self-escalate past the
+  // exclusivity guard entirely.
+  if (input.unreservable && (input.llm_provider ?? 'claude') !== 'none') {
+    return '❌ "unreservable" requires llm_provider: "none" -- it is reserved for plain command-executor members that never receive an agent dispatch. Member was NOT registered.';
+  }
+
   // SF-17: a remote member's work_folder is used verbatim on the MEMBER's
   // machine -- `~` and relative paths are never resolved for it (by design; see
   // work-folder-validation.ts). Reject them here so the caller supplies a

--- a/src/tools/update-member.ts
+++ b/src/tools/update-member.ts
@@ -95,6 +95,18 @@ export async function updateMember(input: UpdateMemberInput): Promise<string> {
     return workFolderNotAbsoluteError(input.work_folder, 'Member was NOT updated.');
   }
 
+  // Same constraint as register_member: unreservable is reserved for
+  // llm_provider: 'none' members. Evaluate the RESULTING state (this update's
+  // values where given, else the existing row's), not just this call's inputs
+  // in isolation -- either "set unreservable while already claude/codex/etc."
+  // or "switch llm_provider away from none while already unreservable" must
+  // both be rejected.
+  const resultingUnreservable = input.unreservable ?? existing.unreservable ?? false;
+  const resultingLlmProvider = input.llm_provider ?? existing.llmProvider ?? 'claude';
+  if (resultingUnreservable && resultingLlmProvider !== 'none') {
+    return '❌ "unreservable" requires llm_provider: "none" -- it is reserved for plain command-executor members that never receive an agent dispatch. Member was NOT updated.';
+  }
+
   const needsUniquenessCheck = existing.agentType === 'remote'
     ? (hostChanged || portChanged || folderChanged)
     : folderChanged;

--- a/src/tools/update-member.ts
+++ b/src/tools/update-member.ts
@@ -67,6 +67,7 @@ export const updateMemberSchema = z.object({
     .optional()
     .describe('Free-form labels for this member (max 10 tags, each max 64 chars). Empty array clears all tags; non-empty array replaces existing tags.'),
   code_intel_provider: z.enum(['codebase-memory', 'gitnexus', 'none']).optional().describe('Change the code-intelligence provider for this member.'),
+  unreservable: z.boolean().optional().describe('Mark this member as never exclusively reservable, so it can be shared by more than one sprint at once (e.g. a member filling fleet-sprint\'s shared "orchestrator" role). reserve/release/force_release become no-op successes and overlap guards skip it.'),
 });
 
 export type UpdateMemberInput = z.infer<typeof updateMemberSchema>;
@@ -188,6 +189,7 @@ export async function updateMember(input: UpdateMemberInput): Promise<string> {
   if (input.category !== undefined) updates.category = input.category.trim() || undefined;
   if (input.tags !== undefined) updates.tags = input.tags.length === 0 ? undefined : input.tags;
   if (input.code_intel_provider !== undefined) updates.codeIntelProvider = input.code_intel_provider;
+  if (input.unreservable !== undefined) updates.unreservable = input.unreservable;
   if (input.model_cheap !== undefined) updates.modelCheap = input.model_cheap;
   if (input.model_standard !== undefined) updates.modelStandard = input.model_standard;
   if (input.model_premium !== undefined) updates.modelPremium = input.model_premium;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,11 @@ export interface Agent {
    *  service-local supervisor ledger. Set/enforced by later eft.10.x tasks;
    *  this field only introduces and persists the value. */
   reservedBy?: string | null;
+  /** This member fills a role (e.g. fleet-sprint's `orchestrator`) that is
+   *  designed to be shared by more than one sprint at once, so it can never
+   *  be exclusively reserved: reserve/release/force_release are no-op
+   *  successes and overlap guards skip it. Defaults to false/absent. */
+  unreservable?: boolean;
 }
 
 export interface GitHubAppConfig {

--- a/tests/member-reservation.test.ts
+++ b/tests/member-reservation.test.ts
@@ -158,4 +158,51 @@ describe('memberReservation', () => {
     const result = await memberReservation({ member_name: 'does-not-exist', action: 'reserve', sprint_id: 'sprint-1' });
     expect(result).toMatch(/not found|Error/i);
   });
+
+  // apra-fleet: a member flagged unreservable (a role designed to be shared
+  // by more than one sprint at once, e.g. fleet-sprint's orchestrator) must
+  // never actually acquire a reservedBy value -- reserve/release/
+  // force_release all become no-op successes, regardless of sprint_id or
+  // current state, so the member can never become the "already reserved by
+  // X" target of a normal exclusive-reservation conflict.
+  describe('unreservable member', () => {
+    it('reserve is a no-op success and never sets reservedBy', async () => {
+      const member = makeTestAgent({ unreservable: true });
+      addAgent(member);
+
+      const result = await memberReservation({ member_id: member.id, action: 'reserve', sprint_id: 'sprint-1' });
+
+      expect(result).toContain('shared/unreservable');
+      expect(getAgent(member.id)?.reservedBy ?? null).toBeNull();
+    });
+
+    it('release is a no-op success even without a sprint_id (bypasses the normal sprint_id-required check)', async () => {
+      const member = makeTestAgent({ unreservable: true });
+      addAgent(member);
+
+      const result = await memberReservation({ member_id: member.id, action: 'release' });
+
+      expect(result).toContain('shared/unreservable');
+    });
+
+    it('force_release is a no-op success', async () => {
+      const member = makeTestAgent({ unreservable: true });
+      addAgent(member);
+
+      const result = await memberReservation({ member_id: member.id, action: 'force_release' });
+
+      expect(result).toContain('shared/unreservable');
+    });
+
+    it('a pre-existing reservedBy (e.g. set before the member was flagged unreservable) is left untouched by any action', async () => {
+      const member = makeTestAgent({ unreservable: true, reservedBy: 'stale-sprint' });
+      addAgent(member);
+
+      await memberReservation({ member_id: member.id, action: 'reserve', sprint_id: 'sprint-1' });
+      await memberReservation({ member_id: member.id, action: 'release', sprint_id: 'sprint-1' });
+      await memberReservation({ member_id: member.id, action: 'force_release' });
+
+      expect(getAgent(member.id)?.reservedBy).toBe('stale-sprint');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `Agent.unreservable`: a member can be flagged as shared-by-construction, so `reserve`/`release`/`force_release` become no-ops and the supervisor's member-overlap guard skips it -- letting more than one concurrent sprint use the same orchestrator member instead of exclusively claiming it (previously a 409 `member overlap` on the second sprint).
- Lands the safe, backward-compatible subset of `docs/design-orchestrator-worktree-model-v2.md` section 4 (eliminating the orchestrator's git surface): drops `orchestratorMember` from `branchEnsureMembers`, delegates the `deploy.md` permissions read and the three file-existence probes to the actual role member about to consume the file, and resolves the abort-path git operations to the harvester/doer member instead of the orchestrator.
- Mirrors the schema change in `packages/apra-fleet-client`.

## Deferred (filed as follow-ups, not in scope here)
- `apra-fleet-xd4b`: concurrency serialization for a shared orchestrator's beads clone -- pull-collapsing, local-write serialization, and the same for KB writes. This needs a keyed generalization of the existing global push-mutex (`dolt-mutex.mjs`), plus HTTP+MCP client mirrors, since sprints run as separate detached processes. Comparable in size to the existing push-mutex system; needs its own design/test rigor.
- `apra-fleet-8zr3`: static `repo_url` launch config replacing `git remote get-url origin`, removing the now-redundant defensive push, the supervisor auto-injecting `roleMap.orchestrator`, and then hard-failing (rather than silently falling back) on an unmapped orchestrator role. Confirmed empirically that closing the fallback before the auto-injection ships breaks ~139 existing tests that rely on the implicit fallback -- these must land in that order.

## Test plan
- [x] `npm run build` (tsc) -- clean
- [x] `packages/apra-fleet-se` full suite: 2372 pass, 0 fail
- [x] Manually reproduced the original bug (two sprints both wanting `roleMap.orchestrator: ["supervisor"]` -> 409) and confirmed the fix unblocks it once the member is flagged `unreservable`