### PR TITLE
fix(fleet-sprint): bead-snapshot staleness, Publish-PR push self-heal, backlog tree grouping

### DIFF
--- a/packages/apra-fleet-se/fleet-sprint/runner.js
+++ b/packages/apra-fleet-se/fleet-sprint/runner.js
@@ -10702,12 +10702,16 @@ async function runSprintCycle(context) {
     // non-fast-forward rejection ("fetch first") is deterministic, so all 3
     // attempts failed identically and the branch's work was stranded local-
     // only. syncMemberAfter() (this file, above) already implements the
-    // correct self-heal for exactly this failure shape -- one bounded
-    // pull-rebase retry, then Tier 2 conflict-resolution-agent dispatch when
-    // rebase hits a real content conflict, never a blind force-push -- and
-    // every OTHER post-dispatch G-push in this file already routes through
-    // it. Publish PR is the one push site that bypassed it. Route through it
-    // here too instead of the raw retry loop.
+    // correct self-heal for exactly this failure shape -- bounded transient
+    // retry, then one pull-rebase-then-re-push on a genuine non-fast-forward
+    // divergence, never a blind force-push -- and every OTHER post-dispatch
+    // G-push in this file already routes through it. Publish PR is the one
+    // push site that bypassed it. Route through it here too instead of the
+    // raw retry loop. NOTE: no `agent` is passed here, so a real content
+    // conflict during the rebase (not just a plain non-FF race) throws
+    // GitDivergedError directly rather than getting syncMemberAfter's
+    // optional Tier 2 conflict-resolution-agent dispatch -- same as the old
+    // loop, which had no Tier 2 either; not a regression.
     try {
         await syncMemberAfter(publishGitMember, {
             command, log, branch: validated.branch, remote: 'origin', setUpstream: true,
@@ -10718,7 +10722,7 @@ async function runSprintCycle(context) {
         lastPushError = pushErr.message;
     }
     if (!pushed) {
-        log(`[Publish Push Failed] Could not push sprint branch '${validated.branch}' to origin after ${POST_DISPATCH_SYNC_RETRY_DELAYS_MS.length} attempts -- the sprint's work is COMMITTED LOCALLY ONLY and is NOT on the remote. Skipping PR creation and target-issue closure (neither is meaningful for an unpushed branch); the sprint's own computed verdict (${finalVerdictResult.verdict}) is preserved and returned with pushed:false. Push the branch by hand and raise the PR, or re-run finalization once the remote is reachable. Last error: ${lastPushError}`);
+        log(`[Publish Push Failed] Could not push sprint branch '${validated.branch}' to origin (bounded transient retry, and a rebase-then-re-push if diverged, both exhausted) -- the sprint's work is COMMITTED LOCALLY ONLY and is NOT on the remote. Skipping PR creation and target-issue closure (neither is meaningful for an unpushed branch); the sprint's own computed verdict (${finalVerdictResult.verdict}) is preserved and returned with pushed:false. Push the branch by hand and raise the PR, or re-run finalization once the remote is reachable. Last error: ${lastPushError}`);
         endGroup();
         return {
             status: finalVerdictResult.verdict === 'PASS' ? 'success' : 'failed',

--- a/packages/apra-fleet-se/fleet-sprint/runner.js
+++ b/packages/apra-fleet-se/fleet-sprint/runner.js
@@ -910,7 +910,7 @@ export async function syncMemberBefore(member, opts = {}) {
 export async function syncMemberAfter(member, opts = {}) {
     const {
         command, pushCode = true, log = () => {}, maxTransientRetries = 1, remote = 'origin', branch,
-        agent, resolveConflictModel, onAuthFailure, resolveMemberProvider,
+        agent, resolveConflictModel, onAuthFailure, resolveMemberProvider, setUpstream = false,
     } = opts;
     if (typeof command !== 'function') {
         throw new Error("syncMemberAfter requires an injected command() in opts");
@@ -921,7 +921,15 @@ export async function syncMemberAfter(member, opts = {}) {
     }
     const provider = await resolveGitProviderForClassification(resolveMemberProvider, member, log);
 
-    const pushCmd = branch ? `git push ${remote} ${branch}` : 'git push';
+    // apra-fleet: `setUpstream` (opt-in, default false -- every existing
+    // caller's command text is byte-for-byte unchanged) is for Publish PR's
+    // push specifically: it needs `-u` to set the tracking branch on a brand
+    // new sprint branch's first push, AND that distinct spelling is what lets
+    // mock-sprint-publish-push-failure.test.mjs's `gitGhFailurePattern` (and
+    // any real-world log grep) target Publish's push in isolation from every
+    // OTHER per-dispatch G-push in the same sprint, which all share the plain
+    // `git push <remote> <branch>` spelling below.
+    const pushCmd = branch ? `git push${setUpstream ? ' -u' : ''} ${remote} ${branch}` : 'git push';
 
     let push = await runGitStep({
         command, member, cmd: pushCmd,
@@ -5998,13 +6006,34 @@ async function runSprintCycle(context) {
     // variable -- transparently goes through the wrapped version.
     //
     // The snapshot MUST be invalidated the instant the underlying data can
-    // have changed, so invalidation fires on BOTH:
+    // have changed, so invalidation fires on ALL of:
     //   1. every `phase()` call -- a new step must never inherit a stale view
-    //      from the step before it, and
+    //      from the step before it,
     //   2. every bd command that is not a known read (list/show/ready/config).
     //      Update/create/close/note/dep/dolt-pull are all mutations, and an
     //      unrecognized bd subcommand is conservatively assumed to mutate: the
-    //      failure mode is a redundant full fetch, never silently stale data.
+    //      failure mode is a redundant full fetch, never silently stale data,
+    //      and
+    //   3. every PLANNER dispatch that returns successfully (see the explicit
+    //      invalidateAllBeadsCache() calls right after dispatchPlanner()
+    //      below, in both the main Planning Loop and the in-cycle scoped
+    //      replan). The planner mutates beads on ITS OWN clone via its own
+    //      `bd create` tool calls, never through this orchestrator-side
+    //      `command()` wrapper -- so (2) alone cannot see it, and Execution
+    //      Prep runs later in the SAME "Plan C{cycle} R{round}" phase (no
+    //      intervening phase() call), so (1) cannot see it either. Without
+    //      (3), a planner that creates its task DAG inside one dispatch
+    //      leaves the very next Execution Prep step looking at the pre-plan
+    //      snapshot, which filters those tasks' still-unseen parent features
+    //      out as non-target features and finds nothing ready -- silently
+    //      skipping Develop for that whole cycle (apra-fleet-zmqm).
+    //      Deliberately scoped to the planner only, NOT every dispatch: an
+    //      unconditional per-dispatch invalidation was tried and reverted --
+    //      it defeats the "one full-DB fetch per phase" cost control
+    //      full-db-fetch-tripwire.test.mjs pins, for every OTHER role
+    //      (doer/reviewer/deployer/...) that has no same-phase reader
+    //      depending on its bead mutations the way Execution Prep depends on
+    //      the planner's.
     //      Non-bd commands (git, node probes) never touch beads state.
     let allBeadsSnapshot = null; // { beads } -- cleared by invalidateAllBeadsCache()
     function invalidateAllBeadsCache() { allBeadsSnapshot = null; }
@@ -7820,6 +7849,13 @@ async function runSprintCycle(context) {
                     const skipPreDispatchDoltPull =
                         i === 0 && cycle === 1 && planningRounds === 1 && plannerSharesOrchestratorClone;
                     await dispatchPlanner({ skipPreDispatchSync: skipPreDispatchSyncNext, skipPreDispatchDoltPull });
+                    // apra-fleet-zmqm: the planner just created/mutated beads on
+                    // its own clone via its own bd tool calls -- invisible to
+                    // this orchestrator's command()-wrapper invalidation (see
+                    // fetchAllBeadsShared()'s doc comment, point 3). Execution
+                    // Prep runs later in this SAME phase, so without this the
+                    // cache built before Plan silently survives into it.
+                    invalidateAllBeadsCache();
                     plannerErr = null;
                     break;
                 } catch (err) {
@@ -8273,6 +8309,14 @@ async function runSprintCycle(context) {
                         { timeoutS: DISPATCH_TIMEOUT_S, member: getMemberForRole('planner'), label: 'Scoped Replan Plan (interactive)', log }
                     ), { pushBeads: true });
                     log(`Scoped Replan Planner: ${scopedPlannerRes}`);
+                    // apra-fleet-zmqm: same reasoning as the main Planning
+                    // Loop's invalidateAllBeadsCache() call -- this dispatch
+                    // mutated beads on its own clone, and everything after it
+                    // in this same "Replan C{cycle} R{devRounds}" phase (the
+                    // scoped plan-reviewer, the resumed develop round) must
+                    // see those mutations, not the pre-replan snapshot taken
+                    // when this phase() started.
+                    invalidateAllBeadsCache();
                 } catch (err) {
                     scopedPlannerOk = false;
                     // Self-heal an LLM-auth failure so the next cycle's planner
@@ -10652,27 +10696,26 @@ async function runSprintCycle(context) {
     const publishGitMember = getMemberForRole('harvester');
     let pushed = false;
     let lastPushError = '';
-    for (let attempt = 0; attempt < POST_DISPATCH_SYNC_RETRY_DELAYS_MS.length; attempt++) {
-        if (POST_DISPATCH_SYNC_RETRY_DELAYS_MS[attempt] > 0) {
-            log(`Publish PR: pushing sprint branch '${validated.branch}' failed; retrying in ${POST_DISPATCH_SYNC_RETRY_DELAYS_MS[attempt] / 1000}s (attempt ${attempt + 1}/${POST_DISPATCH_SYNC_RETRY_DELAYS_MS.length}): ${lastPushError}`);
-            if (!mockInstantRetryBackoff()) {
-                await new Promise((resolve) => setTimeout(resolve, POST_DISPATCH_SYNC_RETRY_DELAYS_MS[attempt]));
-            }
-        }
-        const pushRes = await command(
-            `git push -u origin ${validated.branch}`,
-            {
-                member_name: publishGitMember,
-                silent: true,
-                failSoft: true,
-                label: `Push sprint branch '${validated.branch}'`,
-            }
-        );
-        if (pushRes.ok) {
-            pushed = true;
-            break;
-        }
-        lastPushError = pushRes.error;
+    // apra-fleet-9wdh-adjacent (Publish-PR push self-heal): this used to retry
+    // the byte-identical `git push` up to 3 times with no fetch/rebase step in
+    // between -- fine for a transient/busy-remote failure, but a genuine
+    // non-fast-forward rejection ("fetch first") is deterministic, so all 3
+    // attempts failed identically and the branch's work was stranded local-
+    // only. syncMemberAfter() (this file, above) already implements the
+    // correct self-heal for exactly this failure shape -- one bounded
+    // pull-rebase retry, then Tier 2 conflict-resolution-agent dispatch when
+    // rebase hits a real content conflict, never a blind force-push -- and
+    // every OTHER post-dispatch G-push in this file already routes through
+    // it. Publish PR is the one push site that bypassed it. Route through it
+    // here too instead of the raw retry loop.
+    try {
+        await syncMemberAfter(publishGitMember, {
+            command, log, branch: validated.branch, remote: 'origin', setUpstream: true,
+            onAuthFailure, resolveMemberProvider: resolveMemberVcsProvider,
+        });
+        pushed = true;
+    } catch (pushErr) {
+        lastPushError = pushErr.message;
     }
     if (!pushed) {
         log(`[Publish Push Failed] Could not push sprint branch '${validated.branch}' to origin after ${POST_DISPATCH_SYNC_RETRY_DELAYS_MS.length} attempts -- the sprint's work is COMMITTED LOCALLY ONLY and is NOT on the remote. Skipping PR creation and target-issue closure (neither is meaningful for an unpushed branch); the sprint's own computed verdict (${finalVerdictResult.verdict}) is preserved and returned with pushed:false. Push the branch by hand and raise the PR, or re-run finalization once the remote is reachable. Last error: ${lastPushError}`);

--- a/packages/apra-fleet-se/fleet-sprint/viewer-extensions.mjs
+++ b/packages/apra-fleet-se/fleet-sprint/viewer-extensions.mjs
@@ -89,20 +89,21 @@ export function renderProgressBarHtml(progress) {
  * header row and outer `<table>` wrapper always render regardless of which
  * (if either) section has content.
  *
- * apra-fleet-k7s: unlike Sprint (nested by `parent` containment), Backlog
- * has no shared parent/epic to nest under -- what it DOES sometimes have is
- * `blocks`-type dependency edges BETWEEN backlog items themselves (e.g. two
- * unplanned beads under the same stale epic, one blocking the other). When
- * present, those edges now drive nesting the same way `renderNode` nests
- * Sprint rows: the blocker renders as the parent row, the blocked item
- * nests as its child, using the identical indent/prefix/cycle-guard
- * mechanics. A backlog item with no blocks-edge to another IN-SET backlog
- * item (the common case -- most backlog beads are unrelated to each other)
- * remains a flat, top-level row, same as before -- nesting is only ever
- * drawn when a real edge justifies it, never implied. Root rows (including
- * every item with no in-set blocker) are still sorted priority-then-id for
- * scannability; a blocked item's DEPTH in the tree is what shows structure,
- * not its position in that sort.
+ * apra-fleet-k7s: Backlog nests the same way Sprint does -- by `parent`
+ * containment FIRST (an in-set parent-child edge, e.g. an epic's children
+ * that never made it into a sprint run) -- falling back to `blocks`-type
+ * dependency edges BETWEEN backlog items only for a genuinely parent-less
+ * item (e.g. two unplanned beads under the same stale epic, one blocking
+ * the other, with the epic itself out of this dataset). When a blocks-edge
+ * fallback fires, it drives nesting the same way `renderNode` nests Sprint
+ * rows: the blocker renders as the parent row, the blocked item nests as
+ * its child, using the identical indent/prefix/cycle-guard mechanics. A
+ * backlog item with neither an in-set parent nor a blocks-edge to another
+ * IN-SET backlog item remains a flat, top-level row -- nesting is only
+ * ever drawn when a real edge justifies it, never implied. Root rows
+ * (including every item with no in-set parent/blocker) are still sorted
+ * priority-then-id for scannability; a nested item's DEPTH in the tree is
+ * what shows structure, not its position in that sort.
  *
  * Every rendering decision here (status/type badges, tree placement) is
  * defensive by construction: unrecognized/missing status, type, model, or
@@ -475,15 +476,14 @@ export function renderBeadsHtml(sprintTasks, backlogTasks, collapsedIds) {
         return html;
     }
 
-    // apra-fleet-k7s: Backlog is built into a tree from `blocks`-type
-    // dependency edges BETWEEN backlog items (mirrors the doc-comment above
-    // and reuses renderNode's own indent/prefix/cycle-guard mechanics, just
-    // keyed off a separate `backlogMap`/`backlogChildrenOf` built from
-    // blocks-edges instead of Sprint's `map`/`childrenOf` built from
-    // `parent`). A blocker outside the backlog set (e.g. it's actually in
-    // this run's Sprint, or not part of this dataset at all) does not
-    // count -- same "only an in-dataset edge nests" rule Sprint applies to
-    // `parent`.
+    // apra-fleet-k7s: Backlog is built into a tree from `parent` containment
+    // FIRST, `blocks`-type dependency edges BETWEEN backlog items SECOND
+    // (mirrors the doc-comment above and reuses renderNode's own indent/
+    // prefix/cycle-guard mechanics, just keyed off a separate `backlogMap`/
+    // `backlogChildrenOf` rather than Sprint's `map`/`childrenOf`). A parent
+    // or blocker outside the backlog set (e.g. it's actually in this run's
+    // Sprint, or not part of this dataset at all) does not count -- same
+    // "only an in-dataset edge nests" rule Sprint applies to `parent`.
     const backlogMap = {};
     backlogTasks.forEach((t) => { backlogMap[t.id] = { ...t, blockedBy: [] }; });
 
@@ -496,7 +496,20 @@ export function renderBeadsHtml(sprintTasks, backlogTasks, collapsedIds) {
             .filter((d) => d && d.type === 'blocks' && backlogMap[d.depends_on_id])
             .map((d) => d.depends_on_id);
         backlogMap[t.id].blockedBy = blockerIds;
-        if (blockerIds.length > 0) {
+
+        // apra-fleet: containment (`parent`, in-set) nests FIRST, mirroring
+        // Sprint's `map`/`childrenOf` above -- most backlog beads have a real
+        // parent-child edge (an epic's children that never made it into a
+        // sprint run), and nesting those under a `blocks` edge instead left
+        // every parent-child-only bead rendering as a flat root alongside
+        // its own epic. `blocks`-edge nesting is now the FALLBACK, used only
+        // for a genuinely parent-less backlog item that still blocks/is
+        // blocked by another in-set item.
+        const parentId = t.parent;
+        if (parentId !== undefined && parentId !== null && backlogMap[parentId]) {
+            (backlogChildrenOf[parentId] = backlogChildrenOf[parentId] || []).push(t.id);
+            nestedBacklogIds.add(t.id);
+        } else if (blockerIds.length > 0) {
             // A node renders exactly once (cycle-guard below), so with
             // multiple in-set blockers only one can be the tree-parent --
             // the lowest-sorted blocker id wins, for deterministic output.

--- a/packages/apra-fleet-se/src/supervisor/backlog.mjs
+++ b/packages/apra-fleet-se/src/supervisor/backlog.mjs
@@ -840,9 +840,14 @@ export function createBacklog(deps = {}) {
             .filter((b) => b && typeof b.id === 'string' && b.id.length > 0);
         const normalized = rows.map(normalizeBead);
         const partialClaimById = computePartialClaimByBead(normalized, claimedBy);
+        // apra-fleet: stamp `parent` (the parent-child grouping edge,
+        // per parentIdOf's doc comment above) onto every row -- without it,
+        // renderBeadsHtml()'s Backlog branch has no containment info to nest
+        // by and every parent-child-only bead (no `blocks` edge) renders as
+        // a flat root sibling of its own epic, however deep its real nesting.
         const free = rows
             .filter((b) => !claimedBy.has(b.id))
-            .map((b) => ({ ...b, partialClaim: partialClaimById.get(b.id) ?? null }));
+            .map((b) => ({ ...b, parent: parentIdOf(b), partialClaim: partialClaimById.get(b.id) ?? null }));
         return applyBeadFilters(free, filters);
     }
 

--- a/packages/apra-fleet-se/test/dispatch-safety-guard.test.mjs
+++ b/packages/apra-fleet-se/test/dispatch-safety-guard.test.mjs
@@ -268,7 +268,7 @@ const RUNNER_PATH = path.join(__dirname, '../fleet-sprint/runner.js');
 // The two bumps above are independent (different commits, different
 // history) and both land in this rebase, so the deltas combine:
 // 40 - 3 + 1 + 1 = 39.
-const EXPECTED_COMMAND_COUNT = 40;
+const EXPECTED_COMMAND_COUNT = 39;
 // Bumped 9 -> 10 (2026-07-18): the doer max_turns-exhaustion resume path
 // (dispatchDoerResume) adds one new agent() call site -- a resume-and-continue
 // dispatch on the SAME session with an escalated max_turns, verified compliant

--- a/packages/apra-fleet-se/test/mock-sprint-publish-push-failure.test.mjs
+++ b/packages/apra-fleet-se/test/mock-sprint-publish-push-failure.test.mjs
@@ -14,18 +14,23 @@ const check = (cond, msg) => assert.ok(cond, msg);
 // step of a sprint that had already done all of its work -- turning a computed
 // PASS into `verdict: 'ABORTED'` over a network hiccup.
 //
-// The minimal hardening (the full pluggable-publish restructure is
-// apra-fleet-647.2, which supersedes this): failSoft + a bounded retry on the
-// existing POST_DISPATCH_SYNC_RETRY_DELAYS_MS backoff; on persistent failure,
-// log loudly, skip everything that is meaningless for an unpushed branch (PR
-// creation, target-issue closure), and return the COMPUTED verdict with
-// `pushed: false`.
-//
-// `gitGhFailurePattern` targets `git push -u origin` specifically -- that exact
-// command shape is used ONLY by the Publish/abort-publish steps; the
-// per-dispatch G-push uses `git push <remote> <branch>` (see syncMemberAfter),
-// so this injection cannot accidentally fail the sprint's ordinary sync
-// brackets.
+// apra-fleet (Publish-PR push self-heal, superseding the original minimal
+// hardening described below): Publish PR no longer issues its own bespoke
+// 3x-identical-retry loop -- it now routes through the SAME syncMemberAfter()
+// every other per-dispatch G-push already uses, via a new opt-in
+// `setUpstream: true` that keeps the `-u origin` spelling (so this scenario's
+// `gitGhFailurePattern` still targets ONLY Publish's push, not every other
+// G-push in the sprint, which stay on the plain `git push <remote> <branch>`
+// syncMemberAfter always used). Publish now gets the exact same bounded
+// transient-retry (maxTransientRetries, inside runGitStep) + one-shot
+// pull-rebase-then-re-push on a genuine non-fast-forward divergence, rather
+// than blindly repeating an identical push 3 times (which could never
+// self-heal a real "fetch first" rejection). A non-diverged failure (this
+// scenario's simulated "Could not resolve host", classified 'transient')
+// still fails after its bounded retry -- there is nothing to rebase against
+// for a transient/unknown failure -- so the original hardening goal
+// (failSoft, loud log, computed verdict preserved, `pushed: false`, PR
+// creation skipped) is unchanged; only the retry COUNT/shape changed.
 // =============================================================================
 
 test('mock sprint: a persistently failing Publish push keeps the computed verdict (pushed:false), skips gh pr create, and never reports ABORTED', { timeout: 180000 }, async () => {
@@ -60,12 +65,15 @@ test('mock sprint: a persistently failing Publish push keeps the computed verdic
             `expected no ABORTED terminal state for a publish-push failure, got: ${JSON.stringify(abortedStates)}`,
         );
 
-        // Bounded retry, not a single shot and not an unbounded loop: the push
-        // is attempted once per POST_DISPATCH_SYNC_RETRY_DELAYS_MS entry (3).
+        // Bounded retry, not a single shot and not an unbounded loop: a
+        // 'transient'-classified failure (this scenario's simulated DNS
+        // failure) gets syncMemberAfter's own bounded retry -- the initial
+        // attempt plus maxTransientRetries (default 1) -- then fails for
+        // good; there is no rebase to attempt against a non-diverged error.
         const publishPushes = scenario.commandLog.filter((c) => /^git push -u origin/.test(c));
         check(
-            publishPushes.length === 3,
-            `expected exactly 3 bounded publish-push attempts, got ${publishPushes.length}: ${JSON.stringify(publishPushes)}`,
+            publishPushes.length === 2,
+            `expected exactly 2 bounded publish-push attempts (1 initial + 1 transient retry), got ${publishPushes.length}: ${JSON.stringify(publishPushes)}`,
         );
 
         // Loud, not silent.

--- a/packages/apra-fleet-se/test/supervisor-backlog.test.mjs
+++ b/packages/apra-fleet-se/test/supervisor-backlog.test.mjs
@@ -217,6 +217,24 @@ describe('backlog -- createBacklog production default computes claimed scope in-
         await backlog.buildBacklogTasks();
         assert.equal(listAllBeadsCalls, 1, 'buildBacklogTasks() must call listAllBeads() exactly once');
     });
+
+    // apra-fleet: buildBacklogTasks()'s returned rows used to carry no
+    // `parent` field at all (only the raw `dependencies` array), so
+    // renderBeadsHtml()'s Backlog tree had nothing to nest a parent-child-only
+    // bead by and it rendered as a flat root alongside its own epic. Pins the
+    // `parent: parentIdOf(b)` stamp added to close that gap.
+    test('buildBacklogTasks() stamps `parent` (via parentIdOf) onto every free row', async () => {
+        const backlog = createBacklog({
+            ledger: fakeLedger([]),
+            listAllBeads: () => allBeads,
+        });
+        const { tasks } = await backlog.buildBacklogTasks();
+        const c1 = tasks.find((t) => t.id === 'c1');
+        const epic = tasks.find((t) => t.id === 'E');
+        assert.ok(c1, 'expected c1 to be present in the free backlog set');
+        assert.equal(c1.parent, 'E', "c1's stamped parent must match its parent-child dependency edge");
+        assert.equal(epic.parent, null, 'a root bead with no parent-child edge stamps parent: null, not undefined');
+    });
 });
 
 describe('backlog -- formatPartialClaim', () => {

--- a/packages/apra-fleet-se/test/viewer-extensions.test.mjs
+++ b/packages/apra-fleet-se/test/viewer-extensions.test.mjs
@@ -696,6 +696,50 @@ describe('renderBeadsHtml: collapsible/expandable tree nodes and sections (apra-
         assert.ok(expandedHtml.includes(childPrefix + '#BL-2</td>'), 'BL-2 renders normally when nothing is collapsed');
     });
 
+    // apra-fleet: a bead reachable ONLY via a parent-child dependency edge
+    // (no `blocks` edge to anything) used to render as a flat root sibling
+    // of its own epic in the Backlog section -- the tree builder nested
+    // Backlog exclusively by `blocks` edges, never by `parent` containment,
+    // even though Sprint's tree (built from `map`/`childrenOf`) always has.
+    // Regression coverage for the dashboard-side half of the fix (the other
+    // half stamps `parent` onto each row in backlog.mjs's buildBacklogTasks).
+    test('a Backlog bead reachable only via a parent-child edge (no blocks edge) nests under its parent, not as a flat root', () => {
+        const backlogTasks = [
+            { id: 'EPIC-1', title: '[epic] the epic', status: 'open' },
+            { id: 'CHILD-1', title: '[impl] a plain parent-child child', status: 'open', parent: 'EPIC-1', dependencies: [{ depends_on_id: 'EPIC-1', type: 'parent-child' }] },
+        ];
+        const html = renderBeadsHtml([], backlogTasks);
+        assert.ok(html.includes(childPrefix + '#CHILD-1</td>'), 'CHILD-1 must nest under EPIC-1 via the parent-child edge, not render as a flat root');
+    });
+
+    test('a Backlog bead with BOTH a parent-child edge and a blocks edge nests by containment (parent wins over the blocks-edge fallback)', () => {
+        const backlogTasks = [
+            { id: 'EPIC-1', title: '[epic] the epic', status: 'open' },
+            { id: 'OTHER-1', title: '[impl] an unrelated blocker', status: 'open' },
+            {
+                id: 'CHILD-1', title: '[impl] child of the epic, also blocked by OTHER-1', status: 'open', parent: 'EPIC-1',
+                dependencies: [{ depends_on_id: 'EPIC-1', type: 'parent-child' }, { depends_on_id: 'OTHER-1', type: 'blocks' }],
+            },
+        ];
+        const html = renderBeadsHtml([], backlogTasks);
+        const epicIdx = html.indexOf('>#EPIC-1</td>');
+        const childIdx = html.indexOf(childPrefix + '#CHILD-1</td>');
+        assert.ok(epicIdx !== -1 && childIdx !== -1 && childIdx > epicIdx, 'CHILD-1 must nest directly under EPIC-1, not under OTHER-1');
+        assert.ok(html.includes('blocked by: #OTHER-1'), 'the blocks edge is still surfaced as an inline annotation even though it did not decide nesting');
+    });
+
+    test('a Backlog bead with a parent OUTSIDE the dataset falls back to its blocks edge for nesting', () => {
+        const backlogTasks = [
+            { id: 'BLOCKER-1', title: '[impl] the blocker', status: 'open' },
+            {
+                id: 'CHILD-1', title: '[impl] child of an epic not in this dataset', status: 'open', parent: 'EPIC-NOT-HERE',
+                dependencies: [{ depends_on_id: 'EPIC-NOT-HERE', type: 'parent-child' }, { depends_on_id: 'BLOCKER-1', type: 'blocks' }],
+            },
+        ];
+        const html = renderBeadsHtml([], backlogTasks);
+        assert.ok(html.includes(childPrefix + '#CHILD-1</td>'), 'CHILD-1 must still nest under its in-dataset blocker when its parent is out of scope');
+    });
+
     test('the Sprint and Backlog section headers each carry their own toggle, collapsible via synthetic ids', () => {
         const html = renderBeadsHtml([{ id: 'S1', title: 'a sprint task', status: 'open' }], [{ id: 'B1', title: 'a backlog task', status: 'open' }]);
         assert.ok(html.includes('data-toggle-id="section:sprint"'));


### PR DESCRIPTION
## Summary

Three independent engine bugs found while investigating why sprint `apra-fleet-7dir` skipped Develop in cycle 1, failed final review, and left many child beads ungrouped in the supervisor dashboard.

1. **Bead-snapshot staleness (apra-fleet-zmqm)**: the orchestrator's shared full-DB bead snapshot wasn't invalidated after a planner dispatch that creates its task DAG mid-cycle, so the very next Execution Prep step (same phase) saw the pre-plan bead set and found nothing ready -- silently skipping Develop for the whole cycle. Fixed by invalidating right after a successful planner dispatch (main Planning Loop + in-cycle scoped replan), scoped narrowly to avoid breaking the "one full-DB fetch per phase" cost-control invariant `full-db-fetch-tripwire.test.mjs` pins for every other role.

2. **Publish-PR push self-heal**: Publish PR's push retried the byte-identical `git push -u origin <branch>` 3 times with no fetch/rebase -- unable to ever self-heal a real non-fast-forward rejection, unlike every other per-dispatch G-push in this file. Now routes through the same `syncMemberAfter()` self-heal (bounded transient retry, then one pull-rebase-then-re-push on genuine divergence), via a new opt-in `setUpstream` flag that preserves Publish's distinguishing `-u` command spelling.

3. **Dashboard backlog grouping**: the supervisor's Backlog tree nested exclusively by `blocks`-edges, never by `parent` containment, so a bead reachable only via a parent-child edge (the common case) rendered as a flat root beside its own epic. Beads data itself was already 100% correctly parented -- display-only bug. Fixed by stamping `parent` onto `buildBacklogTasks()` rows and nesting by containment first, blocks-edge fallback second.

## Test plan
- [x] `npm test` (apra-fleet-se): 2378 pass, 0 fail
- [x] `npm run build` (repo root): clean
- [x] New regression tests: 4 in `viewer-extensions.test.mjs`/`supervisor-backlog.test.mjs` for the grouping fix; existing `mock-sprint-publish-push-failure.test.mjs` updated for the new bounded-retry shape
- [ ] Independent Opus review in progress