### PR TITLE
Add knos to .mcp.json so agents share one decision record

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,13 @@
     "deepwiki": {
       "type": "http",
       "url": "https://mcp.deepwiki.com/mcp"
+    },
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
     }
   }
 }

--- a/examples/knos-decisions.example.md
+++ b/examples/knos-decisions.example.md
@@ -1,0 +1,18 @@
+# Decisions and current work
+
+<!-- Example record. `knos export` writes this file in an adopting repo;
+     it is plain markdown, so a fresh clone reads it with nothing installed. -->
+
+## Decisions
+
+- **fleet worktrees** - each agent gets its own worktree, so two agents never
+  share a checkout. _(source: CLAUDE.md)_
+- **hooks are advisory** - the pre-commit hook reports, it does not block.
+  _(source: CONTRIBUTING.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>Claims lapse after 30 minutes or on `knos done`.</sub>


### PR DESCRIPTION
apra-fleet runs several agents against one fleet, and `.mcp.json` already
carries a third-party server (`deepwiki`), so this follows that precedent.

**What this adds**

- `knos` in `.mcp.json` - a local MCP server (`pip install knos`, Python 3.10+).
  No network, no account, one SQLite file.
- `examples/knos-decisions.example.md` - the shape of the record it writes, so
  the format is visible without installing anything.

**Why it might be useful here**

When one agent claims a piece of work, another agent asking about that topic is
told who holds it instead of being handed the answer. Claims lapse after 30
minutes so a crashed agent cannot hold work forever.

**Runtime note:** the server needs Python 3.10+ and `pip install knos`. Nothing
else in the repo depends on it - if it is absent the example file still reads
normally and no other tooling changes.

Disclosure: I wrote knos. Happy to drop either half, or close this, if it is not
a fit for the project.
