### PR TITLE
feat(register-member): detect and self-heal a member's VCS provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] -- Member VCS-provider registration and dispatch-time self-heal
+
+Umbrella context: apra-fleet-5oo ("member sprint-role readiness is never
+provisioned or preflight-verified -- gaps surface reactively mid-sprint").
+
+`register_member` could fully register a dispatch-capable member
+(`llm_provider: "claude"`) while leaving its `vcsProvider` completely unset --
+registration never asked for or detected it. The gap only surfaced hours
+later, mid-sprint, as fleet-sprint's `VCSModule.resolveProvider()` throwing
+"member has no registered VCS provider" on the member's first push or PR, on a
+path whose own self-heal died on the same lookup and so could never heal it.
+
+- **`register_member` now takes `vcs_provider`** (`github` | `bitbucket` |
+  `azure-devops` | `none`), and `apra-fleet register-member` takes the matching
+  `--vcs-provider` flag. An explicit value always wins and skips all probing.
+- **Best-effort auto-detection at registration time.** With no explicit value,
+  the member's git `origin` remote is read and its host mapped to a provider
+  (`src/utils/vcs-provider-detect.ts`, covering https / ssh / scp-like URL
+  forms with anchored host matching). Modelled on the existing Windows
+  shell probe: it never blocks registration, and the result reports
+  `VCS Provider: <provider> (auto-detected from origin)`.
+- **A loud warning when detection fails.** Registering before cloning is a
+  normal flow, so registration still succeeds -- but a dispatch-capable member
+  with no resolvable provider now says so at registration time instead of
+  failing hours into an unattended sprint. `llm_provider: "none"` members and
+  an explicit `vcs_provider: "none"` are exempt.
+- **Dispatch-time self-heal for members already in that state**
+  (`provisionVcsAuthForMember`, fleet-sprint runner). When `resolveProvider`
+  throws, the provider is resolved from the git remote the function has
+  ALREADY read for its repos scope -- through the same provider registry every
+  other host decision uses, never a provider literal -- and the subsequent
+  `provision_vcs_auth` call persists it server-side as an existing side
+  effect. An unreadable or unrecognized remote still raises the original
+  error: there is nothing to detect, so nothing is guessed. Benefits both the
+  reactive self-heal and the proactive preflight, which share the call site.
+- **`BitbucketVCS` now declares `matchesHost`** (anchored to `bitbucket.org` /
+  `altssh.bitbucket.org`), so the host registry names it for a Bitbucket
+  remote instead of falling through to the `generic-git` catch-all. Required
+  for the fallback above to detect Bitbucket at all; behaviour-neutral for
+  `VCSModule.capabilities()`.
+
 ## [Unreleased] -- Azure DevOps VCS auth: credential assembly, PR publish path, and regression-sandbox hardening (sprint FAILED)
 
 Sprint goal: make `provision_vcs_auth` and the fleet-sprint VCS layer support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,31 @@ path whose own self-heal died on the same lookup and so could never heal it.
   error: there is nothing to detect, so nothing is guessed. Benefits both the
   reactive self-heal and the proactive preflight, which share the call site.
 - **`BitbucketVCS` now declares `matchesHost`** (anchored to `bitbucket.org` /
-  `altssh.bitbucket.org`), so the host registry names it for a Bitbucket
+  `www.bitbucket.org` / `altssh.bitbucket.org`, character-for-character in step
+  with `vcs-provider-detect.ts`), so the host registry names it for a Bitbucket
   remote instead of falling through to the `generic-git` catch-all. Required
   for the fallback above to detect Bitbucket at all; behaviour-neutral for
   `VCSModule.capabilities()`.
+- **Credential provisioning now resolves hosts through an ANCHORED matcher**
+  (security). `GitHubVCS.matchesHost()` is deliberately a substring test -- a
+  GitHub Enterprise Server install has no fixed domain, and that matcher
+  answers `capabilities()`'s "could a PR be opened here?", where a wrong yes
+  costs only a failed PR attempt. Auto-PROVISIONING is a different risk class:
+  it mints a real push credential, and a substring test would hand it to
+  `mygithubmirror.attacker.io`. GitHub now also declares
+  `matchesHostForAuth()` (`/^(?:www\.|ssh\.)?github\.com$/i`), and the
+  dispatch-time fallback resolves through a new
+  `resolveVcsAuthProviderForHost()` that asks that matcher, considers only
+  registered auth backends, and returns `null` -- never the `generic-git`
+  catch-all -- for an unclaimed host. GitHub Enterprise is therefore not
+  auto-provisioned on either layer; register those members with an explicit
+  `vcs_provider`.
+- **The dispatch-time fallback's catch is narrow.** `resolveProvider()` also
+  throws for a `member_detail` RPC failure, an unresolvable member name, and a
+  malformed registry response -- none of which a git remote can heal. It now
+  stamps `code: VCS_NO_REGISTERED_PROVIDER` on the one self-healable failure,
+  and the fallback triggers on that code alone; every other error propagates
+  unchanged instead of being papered over with a provider guess.
 
 ## [Unreleased] -- Azure DevOps VCS auth: credential assembly, PR publish path, and regression-sandbox hardening (sprint FAILED)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,23 @@ path whose own self-heal died on the same lookup and so could never heal it.
   stamps `code: VCS_NO_REGISTERED_PROVIDER` on the one self-healable failure,
   and the fallback triggers on that code alone; every other error propagates
   unchanged instead of being papered over with a provider guess.
+- **`update_member` now takes `vcs_provider`** too -- an explicit operator
+  override (never auto-detected) to correct a wrong auto-detect or set the
+  provider directly without provisioning credentials. `apra-fleet-client`'s
+  `UpdateMemberOptions` and both `docs/mcp-tools.md` /
+  `packages/apra-fleet-client/docs/api-reference.md` are updated to match.
+- **Fixed the "register this member again" remedy text.** Re-registering a
+  member's folder is rejected as a duplicate, so it was never an actual fix
+  for an undetermined `vcs_provider`. `register_member`'s warning (and the
+  matching `docs/mcp-tools.md` text) now points at `provision_vcs_auth`
+  (which already sets `vcsProvider` as a side effect of provisioning
+  credentials) and the new `update_member --vcs-provider` override.
+- **Clarified `remoteUrlOverride` provenance in fleet-sprint's runner.js.**
+  Several logs/comments claimed a detected provider came from "the member's
+  own git remote" even when `remoteUrlOverride` was supplied -- which can
+  carry a DIFFERENT member's origin (e.g. provisioning `orchestratorMember`
+  for a repo it has no checkout of). Reworded to state the URL's real
+  provenance without changing behavior.
 
 ## [Unreleased] -- Azure DevOps VCS auth: credential assembly, PR publish path, and regression-sandbox hardening (sprint FAILED)
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -116,7 +116,7 @@ Registers a new machine as a fleet member. This is the entry point for every mem
 - SSH connection fails: member is NOT registered, error returned
 - Duplicate folder: member is NOT registered
 - Claude CLI missing: member IS registered, but with a warning
-- VCS provider undetermined: member IS registered, but with a loud warning (it cannot push or open a PR until one is set -- re-register with an explicit `vcs_provider`, or call `provision_vcs_auth` with an explicit `provider` -- that tool requires one and never detects it. fleet-sprint's dispatch-time fallback can also heal it automatically once a git remote exists)
+- VCS provider undetermined: member IS registered, but with a loud warning (it cannot push or open a PR until one is set -- call `provision_vcs_auth` with an explicit `provider` (this also records `vcsProvider` as a side effect of provisioning credentials), or call `update_member` with `vcs_provider` set to record the provider directly without provisioning credentials. Re-registering the same folder path is rejected as a duplicate registration, so it is NOT a remedy. fleet-sprint's dispatch-time fallback can also heal it automatically once a git remote exists)
 
 ### `list_members`
 
@@ -159,6 +159,7 @@ Modifies an existing member's registration. All fields except `member_id` are op
 | `category` | string | no | Group label; empty string clears it |
 | `tags` | string[] | no | Replaces existing tags; empty array clears them (max 10 tags, 64 chars each) |
 | `git_access`, `git_repos` | - | no | Same shape as `register_member` |
+| `vcs_provider` | `"github"` \| `"bitbucket"` \| `"azure-devops"` \| `"none"` | no | Directly set (override) this member's VCS provider. An explicit operator value, never auto-detected -- use to correct a wrong auto-detect from `register_member`, or to set the provider without provisioning credentials. `"none"` clears it |
 | `model_cheap` / `model_standard` / `model_premium` / `model_tiers` | - | no | Same shape as `register_member` |
 | `code_intel_provider` | `"codebase-memory"` \| `"gitnexus"` \| `"none"` | no | Switch code-intelligence provider |
 | `shell` | `"gitbash"` \| `"pwsh7"` \| `"powershell5"` | no | Override the probed Windows shell |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -86,6 +86,7 @@ Registers a new machine as a fleet member. This is the entry point for every mem
 | `tags` | string[] | no | Free-form labels, max 10 tags of max 64 chars each. Used by `list_members` filtering and `compose_permissions` |
 | `git_access` | `"read"` \| `"push"` \| `"admin"` \| `"issues"` \| `"full"` | no | Git access level for this member |
 | `git_repos` | string[] | no | Repositories this member may access (e.g. `["Apra-Labs/ApraPipes"]`) |
+| `vcs_provider` | `"github"` \| `"bitbucket"` \| `"azure-devops"` \| `"none"` | no | VCS provider this member pushes to and opens PRs against. Omit to auto-detect it from the member's git `origin` remote (see step 8b below); pass `"none"` to declare the member deliberately has no VCS provider and suppress the warning |
 | `code_intel_provider` | `"codebase-memory"` \| `"gitnexus"` \| `"none"` | no | Code-intelligence provider. Defaults to the fleet-wide config |
 | `shell` | `"gitbash"` \| `"pwsh7"` \| `"powershell5"` | no | Override the probed Windows shell. Ignored for non-Windows members. See [windows-shell-selection.md](windows-shell-selection.md) |
 | `unreservable` | boolean | no | Mark the member as never exclusively reservable so several sprints can share it |
@@ -106,14 +107,16 @@ Registers a new machine as a fleet member. This is the entry point for every mem
 6. **Auth test (remote only)** -- for Claude members, runs a quick `claude -p "hello"` to verify authentication. For non-Claude providers, the version check from step 5 serves as the CLI availability check; auth is verified separately via `provision_llm_auth`. Skipped for local members since they inherit the current session's auth.
 7. **Creates working folder** -- `mkdir -p` (or equivalent) on the target.
 8. **Provisions role-agent files (remote only)** -- hashes the canonical set of PM role-agent files (planner, doer, reviewer, etc., plus `_shared/` and `schemas/`) against what is already on the remote box and uploads anything missing or stale. Skipped for local members (they share the operator's home directory) and for providers with no agents directory (codex, copilot). A provisioning failure is reported as a warning but never blocks registration.
-9. **Persists** -- saves the member to `~/.apra-fleet/data/registry.json` with a generated UUID, including the `llmProvider` field.
+8b. **Resolves the VCS provider** -- an explicit `vcs_provider` always wins and skips this step entirely. Otherwise the member's git `origin` remote is read (best effort) and its host mapped to a provider: `github.com` -> `github`, `bitbucket.org` -> `bitbucket`, `dev.azure.com` / `*.visualstudio.com` -> `azure-devops`. On success the result carries `VCS Provider: <provider> (auto-detected from origin)`. On failure (no git repo in the work folder yet, or an unrecognized host) registration still SUCCEEDS -- the common flow is to register a member and clone into its work folder afterwards -- but a loud warning is emitted saying the member will be UNABLE to push or open a PR until a provider is set. Members with `llm_provider: "none"` never dispatch an agent and are exempt. A GitHub Enterprise host has no fixed domain and is never auto-detected: register those with an explicit `vcs_provider`.
+9. **Persists** -- saves the member to `~/.apra-fleet/data/registry.json` with a generated UUID, including the `llmProvider` and `vcsProvider` fields.
 
-**Output:** Member ID, name, type, OS, folder, auth method, provider, latency, agent-file provisioning result, and any warnings (e.g. CLI not found, auth failed).
+**Output:** Member ID, name, type, OS, folder, auth method, LLM provider, VCS provider, latency, agent-file provisioning result, and any warnings (e.g. CLI not found, auth failed, VCS provider undetermined).
 
 **Failure modes:**
 - SSH connection fails: member is NOT registered, error returned
 - Duplicate folder: member is NOT registered
 - Claude CLI missing: member IS registered, but with a warning
+- VCS provider undetermined: member IS registered, but with a loud warning (it cannot push or open a PR until one is set -- re-register with an explicit `vcs_provider`, or let `provision_vcs_auth` / fleet-sprint's dispatch-time fallback set it once a git remote exists)
 
 ### `list_members`
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -116,7 +116,7 @@ Registers a new machine as a fleet member. This is the entry point for every mem
 - SSH connection fails: member is NOT registered, error returned
 - Duplicate folder: member is NOT registered
 - Claude CLI missing: member IS registered, but with a warning
-- VCS provider undetermined: member IS registered, but with a loud warning (it cannot push or open a PR until one is set -- re-register with an explicit `vcs_provider`, or let `provision_vcs_auth` / fleet-sprint's dispatch-time fallback set it once a git remote exists)
+- VCS provider undetermined: member IS registered, but with a loud warning (it cannot push or open a PR until one is set -- re-register with an explicit `vcs_provider`, or call `provision_vcs_auth` with an explicit `provider` -- that tool requires one and never detects it. fleet-sprint's dispatch-time fallback can also heal it automatically once a git remote exists)
 
 ### `list_members`
 

--- a/packages/apra-fleet-client/docs/api-reference.md
+++ b/packages/apra-fleet-client/docs/api-reference.md
@@ -366,6 +366,7 @@ Calls `register_member` -- adds a machine to the fleet.
 | `key_path` | `string?` | Path to SSH private key file. |
 | `git_access` | `"read" \| "push" \| "admin" \| "issues" \| "full"?` | Git access level for this member. |
 | `git_repos` | `string[]?` | Git repositories this member can access (e.g. ["Apra-Labs/ApraPipes"]). |
+| `vcs_provider` | `"github" \| "bitbucket" \| "azure-devops" \| "none"?` | VCS provider this member pushes to / opens PRs against. Omit to auto-detect from the member's git `origin` remote (registration warns loudly if detection fails); `"none"` declares the member deliberately has no VCS provider. |
 | `cloud_provider` | `"aws"?` | Cloud provider name (e.g. "aws"). When set, `cloud_instance_id` and `key_path` are required. |
 | `cloud_instance_id` | `string?` | EC2 instance ID (e.g. "i-0abc123def456789a"). Required when `cloud_provider` is set. |
 | `cloud_region` | `string?` | AWS region (default: "us-east-1"). |

--- a/packages/apra-fleet-client/docs/api-reference.md
+++ b/packages/apra-fleet-client/docs/api-reference.md
@@ -423,6 +423,7 @@ and means "new value for this field". Identifies the target member via
 | `code_intel_provider` | `"codebase-memory" \| "gitnexus" \| "none"?` | Change the code-intelligence provider for this member. |
 | `unreservable` | `boolean?` | Mark/unmark this member as shared or never exclusively reservable. |
 | `shell` | `"gitbash" \| "pwsh7" \| "powershell5"?` | Override the probed Windows shell for this member. Windows members only -- ignored for non-Windows members. |
+| `vcs_provider` | `"github" \| "bitbucket" \| "azure-devops" \| "none"?` | Directly set (override) this member's VCS provider. An explicit operator value, never auto-detected -- use to correct a wrong auto-detect from `register_member`, or to set the provider without provisioning credentials. `"none"` clears it. |
 
 #### `removeMember(options: RemoveMemberOptions)`
 

--- a/packages/apra-fleet-client/src/client/api.mjs
+++ b/packages/apra-fleet-client/src/client/api.mjs
@@ -102,6 +102,7 @@
  * @property {string} [key_path] - Path to SSH private key
  * @property {"read" | "push" | "admin" | "issues" | "full"} [git_access] - Git access level for this member
  * @property {string[]} [git_repos] - Git repositories this member can access (e.g. ["Apra-Labs/ApraPipes"])
+ * @property {"github" | "bitbucket" | "azure-devops" | "none"} [vcs_provider] - VCS provider this member pushes to and opens pull requests against. Omit to auto-detect it from the member's git "origin" remote; "none" declares the member deliberately has no VCS provider.
  * @property {"aws"} [cloud_provider] - Cloud provider. When set, cloud_instance_id and key_path are required.
  * @property {string} [cloud_instance_id] - EC2 instance ID (e.g. "i-0abc123def456789a"). Required when cloud_provider is set.
  * @property {string} [cloud_region] - AWS region (default: "us-east-1")

--- a/packages/apra-fleet-client/src/client/api.mjs
+++ b/packages/apra-fleet-client/src/client/api.mjs
@@ -153,6 +153,7 @@
  * @property {"false" | "auto" | "dangerous"} [unattended] - Permission mode
  * @property {boolean} [unreservable] - Mark/unmark this member as shared/never exclusively reservable
  * @property {"gitbash" | "pwsh7" | "powershell5"} [shell] - Override the probed Windows shell for this member. Windows members only -- ignored for non-windows members.
+ * @property {"github" | "bitbucket" | "azure-devops" | "none"} [vcs_provider] - Directly set (override) this member's VCS provider. An explicit operator value, never auto-detected -- use this to correct a wrong auto-detect from register_member, or to set the provider without provisioning credentials. "none" clears it.
  */
 
 /**

--- a/packages/apra-fleet-se/fleet-sprint/runner.js
+++ b/packages/apra-fleet-se/fleet-sprint/runner.js
@@ -2440,7 +2440,11 @@ async function provisionVcsAuthForMember({ fleetApi, command, member, log = () =
             repos = [scope.repo];
             derivedRepo = scope.repo;
         } else {
-            log(`${logPrefix}: could not derive an owner/repo from member '${member}' git remote (raw: '${remoteUrl}'); calling provision_vcs_auth without an explicit repos scope.`);
+            // remoteUrlOverride, when supplied, may belong to a DIFFERENT
+            // member/repo than `member` -- see the caller-note above -- so
+            // this log deliberately does not claim the URL is `member`'s own.
+            const remoteSource = remoteUrlOverride ? 'the supplied remote URL' : `member '${member}' git remote`;
+            log(`${logPrefix}: could not derive an owner/repo from ${remoteSource} (raw: '${remoteUrl}'); calling provision_vcs_auth without an explicit repos scope.`);
         }
     }
 
@@ -2466,9 +2470,14 @@ async function provisionVcsAuthForMember({ fleetApi, command, member, log = () =
     // no amount of retrying can heal it, because the self-heal path itself
     // dies on the same lookup.
     //
-    // So: when the registry has nothing, fall back to the member's OWN git
-    // remote, which this function has already read above for the repos scope
-    // (never a second dispatch). The host is mapped through the SAME provider
+    // So: when the registry has nothing, fall back to `remoteUrl` -- the
+    // remote this function already read/received above for the repos scope
+    // (never a second dispatch). That URL is `member`'s own git remote ONLY
+    // when no `remoteUrlOverride` was supplied; when it was (the [ABORTED]
+    // PR / Publish PR call sites can pass a different member's origin -- see
+    // their own comments), the detected provider is still correct for
+    // provisioning `member` against that URL's host, but the URL itself may
+    // not be `member`'s own remote. The host is mapped through the SAME provider
     // registry every other host decision goes through
     // (resolveVcsProviderForHost), so no provider literal appears here, and a
     // host claimed only by the generic-git catch-all is deliberately NOT
@@ -2503,7 +2512,8 @@ async function provisionVcsAuthForMember({ fleetApi, command, member, log = () =
         provider = detected;
         const impl = getVcsProvider(provider);
         authMode = isAuthBackend(impl) ? impl.defaultAuthMode : null;
-        log(`${logPrefix}: member '${member}' had no registered VCS provider; detected '${provider}' from its git remote and will provision it now`);
+        const remoteSource = remoteUrlOverride ? 'the supplied remote URL' : 'its git remote';
+        log(`${logPrefix}: member '${member}' had no registered VCS provider; detected '${provider}' from ${remoteSource} and will provision it now`);
     }
     // apra-fleet-5co8.2.1: the argument shape itself is now provider-owned.
     // What follows is the DEFAULT (GitHub-App) shape; a provider that declares
@@ -2882,7 +2892,8 @@ async function raiseVcsPrForMember({ fleetApi, command, member, base, head, titl
         return { ok: false, alreadyExists: false, prUrl: null, error: message, authFailure: true };
     }
     if (!repo) {
-        throw new Error(`Could not derive an owner/repo from member '${member}' git remote -- cannot build a VCSModule create-pull-request command without one.`);
+        const remoteSource = remoteUrlOverride ? 'the supplied remote URL' : `member '${member}' git remote`;
+        throw new Error(`Could not derive an owner/repo from ${remoteSource} -- cannot build a VCSModule create-pull-request command without one.`);
     }
     // apra-fleet-lzfv.5: resolve the member's OWN registered VCS provider
     // (VCSModule.resolveProvider(), never a hardcoded 'github' literal --

--- a/packages/apra-fleet-se/fleet-sprint/runner.js
+++ b/packages/apra-fleet-se/fleet-sprint/runner.js
@@ -33,7 +33,7 @@ import { parseUnmergedPaths, detectAndAbortRebaseConflict, dispatchConflictResol
 // hard-aborting the run at its readiness gate.
 import { buildSettleCallback } from './dolt-settle.mjs';
 import { acquireSprintLock } from './sprint-lock.mjs';
-import { buildCreatePrCommand, resolveProvider, capabilities as vcsCapabilities, classifyFailure, toGitVerdict, parseProviderRepoRef, getVcsProvider } from './vcs-module.mjs';
+import { buildCreatePrCommand, resolveProvider, capabilities as vcsCapabilities, classifyFailure, toGitVerdict, parseProviderRepoRef, getVcsProvider, resolveVcsProviderForHost, listVcsAuthProviders } from './vcs-module.mjs';
 import { getSeCommands } from './se-os-commands.mjs';
 
 // Re-exported so importers of parseUnmergedPaths from runner.js keep working;
@@ -2373,6 +2373,28 @@ function selfHealResultText(result) {
 // give every member standing pull_requests:write for the whole sprint.
 // @param {{ fleetApi: object, command: Function, member: string, log?: Function, logPrefix: string, gitAccess?: string, resolvedProvider?: { provider: string, authMode: string|null } }} opts
 // @returns {Promise<{ expiresAt: Date|null, repo: string|null }>}
+/**
+ * apra-fleet-5oo: map a member's git remote URL onto the VCS provider that
+ * hosts it, using the SAME registry that answers every other host question
+ * (vcs-module.mjs's capabilities() for the host parse, then
+ * resolveVcsProviderForHost() for the claim). Returns the provider NAME, or
+ * null when the URL has no host, or the claiming provider is not a
+ * member-facing auth backend -- resolveVcsProviderForHost() falls back to the
+ * 'generic-git' catch-all for an unclaimed host, and provisioning credentials
+ * against that would be a guess, not a detection.
+ *
+ * @param {unknown} remoteUrl
+ * @returns {string|null}
+ */
+function detectVcsProviderFromRemote(remoteUrl) {
+    const { host } = vcsCapabilities(remoteUrl);
+    if (!host) return null;
+    const impl = resolveVcsProviderForHost(host);
+    const name = impl && impl.name;
+    if (!name || !listVcsAuthProviders().includes(name)) return null;
+    return name;
+}
+
 async function provisionVcsAuthForMember({ fleetApi, command, member, log = () => {}, logPrefix, gitAccess = 'push', azdevopsPatSecretName, remoteUrlOverride, resolvedProvider }) {
     let repos;
     let derivedRepo = null;
@@ -2428,7 +2450,46 @@ async function provisionVcsAuthForMember({ fleetApi, command, member, log = () =
     // the self-heal callback's authRemedy hint lookup) can thread it through
     // via `resolvedProvider`, saving a second member_detail round trip. Falls
     // back to this function's own lookup when not supplied.
-    const { provider, authMode } = resolvedProvider || await resolveProvider(member, { fleetApi });
+    //
+    // apra-fleet-5oo (LAYER 2 -- dispatch-time self-heal). resolveProvider()
+    // throws for a member registered with NO vcsProvider at all, which is
+    // exactly the state register_member could leave a fully dispatch-capable
+    // member in before apra-fleet-5oo's registration-time detection landed.
+    // For every such member ALREADY registered, that throw arrives reactively
+    // -- typically hours into an unattended sprint, on the first push -- and
+    // no amount of retrying can heal it, because the self-heal path itself
+    // dies on the same lookup.
+    //
+    // So: when the registry has nothing, fall back to the member's OWN git
+    // remote, which this function has already read above for the repos scope
+    // (never a second dispatch). The host is mapped through the SAME provider
+    // registry every other host decision goes through
+    // (resolveVcsProviderForHost), so no provider literal appears here, and a
+    // host claimed only by the generic-git catch-all is deliberately NOT
+    // accepted -- listVcsAuthProviders() is the vocabulary resolveProvider
+    // itself validates against.
+    //
+    // No separate persistence call is needed: fleetApi.provisionVcsAuth()
+    // below already writes vcsProvider back to the member registry as an
+    // existing side effect (src/tools/provision-vcs-auth.ts), so the very
+    // next lookup for this member resolves normally.
+    //
+    // An unreadable or unrecognized remote re-throws the ORIGINAL error --
+    // that is a real failure with nothing to detect, and must stay loud.
+    let provider;
+    let authMode;
+    try {
+        ({ provider, authMode } = resolvedProvider || await resolveProvider(member, { fleetApi }));
+    } catch (resolveErr) {
+        const detected = (!remoteReadFailed && remoteUrl)
+            ? detectVcsProviderFromRemote(remoteUrl)
+            : null;
+        if (!detected) throw resolveErr;
+        provider = detected;
+        const impl = getVcsProvider(provider);
+        authMode = (impl && Object.prototype.hasOwnProperty.call(impl, 'defaultAuthMode')) ? impl.defaultAuthMode : null;
+        log(`${logPrefix}: member '${member}' had no registered VCS provider; detected '${provider}' from its git remote and will provision it now`);
+    }
     // apra-fleet-5co8.2.1: the argument shape itself is now provider-owned.
     // What follows is the DEFAULT (GitHub-App) shape; a provider that declares
     // a buildProvisionArgs hook replaces it wholesale -- see

--- a/packages/apra-fleet-se/fleet-sprint/runner.js
+++ b/packages/apra-fleet-se/fleet-sprint/runner.js
@@ -33,7 +33,7 @@ import { parseUnmergedPaths, detectAndAbortRebaseConflict, dispatchConflictResol
 // hard-aborting the run at its readiness gate.
 import { buildSettleCallback } from './dolt-settle.mjs';
 import { acquireSprintLock } from './sprint-lock.mjs';
-import { buildCreatePrCommand, resolveProvider, capabilities as vcsCapabilities, classifyFailure, toGitVerdict, parseProviderRepoRef, getVcsProvider, resolveVcsProviderForHost, listVcsAuthProviders } from './vcs-module.mjs';
+import { buildCreatePrCommand, resolveProvider, capabilities as vcsCapabilities, classifyFailure, toGitVerdict, parseProviderRepoRef, getVcsProvider, resolveVcsAuthProviderForHost, isAuthBackend, VCS_NO_REGISTERED_PROVIDER } from './vcs-module.mjs';
 import { getSeCommands } from './se-os-commands.mjs';
 
 // Re-exported so importers of parseUnmergedPaths from runner.js keep working;
@@ -2377,11 +2377,19 @@ function selfHealResultText(result) {
  * apra-fleet-5oo: map a member's git remote URL onto the VCS provider that
  * hosts it, using the SAME registry that answers every other host question
  * (vcs-module.mjs's capabilities() for the host parse, then
- * resolveVcsProviderForHost() for the claim). Returns the provider NAME, or
- * null when the URL has no host, or the claiming provider is not a
- * member-facing auth backend -- resolveVcsProviderForHost() falls back to the
- * 'generic-git' catch-all for an unclaimed host, and provisioning credentials
- * against that would be a guess, not a detection.
+ * resolveVcsAuthProviderForHost() for the claim). Returns the provider NAME,
+ * or null when the URL has no host or no registered AUTH BACKEND claims it --
+ * provisioning credentials against an unclaimed host would be a guess, not a
+ * detection.
+ *
+ * Note which resolver this uses. resolveVcsAuthProviderForHost() (not the
+ * capabilities-axis resolveVcsProviderForHost()) asks each provider its
+ * ANCHORED auth matcher and never falls back to the 'generic-git' catch-all.
+ * That distinction is the whole point here: the caller below mints a real push
+ * credential from whatever this returns, and GitHub's capabilities-axis
+ * matchesHost() is a deliberate substring test for GitHub Enterprise Server,
+ * which would otherwise let 'mygithubmirror.attacker.io' claim the credential.
+ * See vcs-providers/github.mjs's matchesHostForAuth().
  *
  * @param {unknown} remoteUrl
  * @returns {string|null}
@@ -2389,10 +2397,8 @@ function selfHealResultText(result) {
 function detectVcsProviderFromRemote(remoteUrl) {
     const { host } = vcsCapabilities(remoteUrl);
     if (!host) return null;
-    const impl = resolveVcsProviderForHost(host);
-    const name = impl && impl.name;
-    if (!name || !listVcsAuthProviders().includes(name)) return null;
-    return name;
+    const impl = resolveVcsAuthProviderForHost(host);
+    return (impl && impl.name) || null;
 }
 
 async function provisionVcsAuthForMember({ fleetApi, command, member, log = () => {}, logPrefix, gitAccess = 'push', azdevopsPatSecretName, remoteUrlOverride, resolvedProvider }) {
@@ -2476,18 +2482,27 @@ async function provisionVcsAuthForMember({ fleetApi, command, member, log = () =
     //
     // An unreadable or unrecognized remote re-throws the ORIGINAL error --
     // that is a real failure with nothing to detect, and must stay loud.
+    //
+    // So does every OTHER way resolveProvider() can fail. It throws for a
+    // member_detail RPC/network failure, for a member name that resolves to
+    // nothing, and for a malformed registry response, none of which the git
+    // remote can heal: falling back there would paper over a real fault with a
+    // provider guess. Only the one failure that carries
+    // VCS_NO_REGISTERED_PROVIDER (see vcs-module.mjs) is self-healable, and it
+    // is matched by that stable code rather than by its message text.
     let provider;
     let authMode;
     try {
         ({ provider, authMode } = resolvedProvider || await resolveProvider(member, { fleetApi }));
     } catch (resolveErr) {
+        if (!resolveErr || resolveErr.code !== VCS_NO_REGISTERED_PROVIDER) throw resolveErr;
         const detected = (!remoteReadFailed && remoteUrl)
             ? detectVcsProviderFromRemote(remoteUrl)
             : null;
         if (!detected) throw resolveErr;
         provider = detected;
         const impl = getVcsProvider(provider);
-        authMode = (impl && Object.prototype.hasOwnProperty.call(impl, 'defaultAuthMode')) ? impl.defaultAuthMode : null;
+        authMode = isAuthBackend(impl) ? impl.defaultAuthMode : null;
         log(`${logPrefix}: member '${member}' had no registered VCS provider; detected '${provider}' from its git remote and will provision it now`);
     }
     // apra-fleet-5co8.2.1: the argument shape itself is now provider-owned.

--- a/packages/apra-fleet-se/fleet-sprint/vcs-module.mjs
+++ b/packages/apra-fleet-se/fleet-sprint/vcs-module.mjs
@@ -37,6 +37,8 @@ import {
     getVcsProvider,
     resolveVcsProviderChain,
     resolveVcsProviderForHost,
+    resolveVcsAuthProviderForHost,
+    isAuthBackend,
 } from './vcs-providers/index.mjs';
 
 /**
@@ -117,6 +119,21 @@ export function buildCreatePrCommand(params) {
  * @param {{ fleetApi: { memberDetail: (opts: { member_name: string, format?: string }) => Promise<any> } }} opts
  * @returns {Promise<{ provider: string, authMode: string|null }>}
  */
+/**
+ * The `code` resolveProvider() stamps on the ONE failure that means "this
+ * member simply has no usable registered VCS provider" -- as opposed to a
+ * member_detail RPC failure, an unresolvable member name, or a malformed
+ * response, all of which resolveProvider() also throws for.
+ *
+ * A caller that wants to self-heal ONLY that case (runner.js's dispatch-time
+ * VCS-provider fallback) must be able to tell them apart: applying a
+ * git-remote-derived guess after a network blip would paper over a real
+ * failure with a possibly-wrong provider. Matching on the message text would
+ * make that wording load-bearing, so the signal is a stable property instead.
+ * @type {string}
+ */
+export const VCS_NO_REGISTERED_PROVIDER = 'VCS_NO_REGISTERED_PROVIDER';
+
 export async function resolveProvider(member, { fleetApi } = {}) {
     if (!fleetApi || typeof fleetApi.memberDetail !== 'function') {
         throw new Error(`ERROR: VCSModule: resolveProvider requires an injected fleetApi.memberDetail() -- cannot resolve a VCS provider for member '${member}' without one.`);
@@ -149,7 +166,11 @@ export async function resolveProvider(member, { fleetApi } = {}) {
 
     const provider = parsed && typeof parsed.vcsProvider === 'string' ? parsed.vcsProvider : null;
     if (!provider || !known.includes(provider)) {
-        throw new Error(`ERROR: VCSModule: resolveProvider: member '${member}' has no registered VCS provider (vcsProvider: ${provider ? `"${provider}"` : '(absent)'}) -- known providers: ${known.join(', ')}. Provision one via provision_vcs_auth with an explicit 'provider' before relying on resolveProvider.`);
+        const err = new Error(`ERROR: VCSModule: resolveProvider: member '${member}' has no registered VCS provider (vcsProvider: ${provider ? `"${provider}"` : '(absent)'}) -- known providers: ${known.join(', ')}. Provision one via provision_vcs_auth with an explicit 'provider' before relying on resolveProvider.`);
+        // See VCS_NO_REGISTERED_PROVIDER above: this is the only failure a
+        // caller may self-heal from, so it is the only one that carries a code.
+        err.code = VCS_NO_REGISTERED_PROVIDER;
+        throw err;
     }
 
     const impl = getVcsProvider(provider);
@@ -470,6 +491,9 @@ export const VCSModule = {
     listVcsAuthProviders,
     getVcsProvider,
     resolveVcsProviderForHost,
+    resolveVcsAuthProviderForHost,
+    isAuthBackend,
+    VCS_NO_REGISTERED_PROVIDER,
     DEFAULT_VCS_PROVIDER,
 };
 
@@ -487,6 +511,14 @@ export {
     // into ./vcs-providers/index.mjs directly -- same seam every other
     // provider-registry helper above is reached through.
     resolveVcsProviderForHost,
+    // apra-fleet-5oo review fix: the credential-provisioning sibling of the
+    // above (anchored host matching, auth backends only), plus the predicate
+    // that defines "auth backend" -- reached through this same seam rather
+    // than runner.js reaching past it into ./vcs-providers/index.mjs.
+    resolveVcsAuthProviderForHost,
+    isAuthBackend,
+    // VCS_NO_REGISTERED_PROVIDER is already exported at its `export const`
+    // declaration above -- listing it again here is a duplicate-export error.
 };
 
 export default VCSModule;

--- a/packages/apra-fleet-se/fleet-sprint/vcs-module.mjs
+++ b/packages/apra-fleet-se/fleet-sprint/vcs-module.mjs
@@ -469,6 +469,7 @@ export const VCSModule = {
     listVcsProviders,
     listVcsAuthProviders,
     getVcsProvider,
+    resolveVcsProviderForHost,
     DEFAULT_VCS_PROVIDER,
 };
 
@@ -481,6 +482,11 @@ export {
     listVcsProviders,
     listVcsAuthProviders,
     getVcsProvider,
+    // apra-fleet-5oo: re-exported so runner.js can ask "which registered
+    // provider claims this remote host?" without reaching past this module
+    // into ./vcs-providers/index.mjs directly -- same seam every other
+    // provider-registry helper above is reached through.
+    resolveVcsProviderForHost,
 };
 
 export default VCSModule;

--- a/packages/apra-fleet-se/fleet-sprint/vcs-providers/bitbucket.mjs
+++ b/packages/apra-fleet-se/fleet-sprint/vcs-providers/bitbucket.mjs
@@ -44,6 +44,9 @@ const AUTH_EXPIRED = [
  *  reasoning as ./azure-devops.mjs's HOST_RE, and unlike GitHub Enterprise
  *  Server which has no fixed domain):
  *    - bitbucket.org        https and ssh remotes
+ *    - www.bitbucket.org    the www alias (bitbucket.org redirects it, and a
+ *                           remote copy-pasted from a browser address bar can
+ *                           carry it)
  *    - altssh.bitbucket.org the alternate-port ssh host
  *  A self-hosted Bitbucket Data Center install has an arbitrary domain and is
  *  deliberately left to GenericGitVCS's catch-all rather than guessed at.
@@ -53,8 +56,12 @@ const AUTH_EXPIRED = [
  *  dispatch-time VCS-provider fallback detect it. Behaviour-neutral for
  *  VCSModule.capabilities(): this provider declares no capabilitiesForHost,
  *  and the caller's default (canOpenPullRequest:false) matches what
- *  GenericGitVCS returned for these hosts before. */
-const HOST_RE = /^(?:altssh\.)?bitbucket\.org$/i;
+ *  GenericGitVCS returned for these hosts before.
+ *
+ *  Kept character-for-character in step with
+ *  src/utils/vcs-provider-detect.ts's BITBUCKET_HOST_RE -- the two halves of
+ *  the same decision must never disagree about who owns a host. */
+const HOST_RE = /^(?:www\.|altssh\.)?bitbucket\.org$/i;
 
 function matchesHost(host) {
     return typeof host === 'string' && HOST_RE.test(host.trim());

--- a/packages/apra-fleet-se/fleet-sprint/vcs-providers/bitbucket.mjs
+++ b/packages/apra-fleet-se/fleet-sprint/vcs-providers/bitbucket.mjs
@@ -40,12 +40,33 @@ const AUTH_EXPIRED = [
     /Invalid or expired app password/i,
 ];
 
+/** Bitbucket Cloud's own hosts, ANCHORED (never a substring test -- the same
+ *  reasoning as ./azure-devops.mjs's HOST_RE, and unlike GitHub Enterprise
+ *  Server which has no fixed domain):
+ *    - bitbucket.org        https and ssh remotes
+ *    - altssh.bitbucket.org the alternate-port ssh host
+ *  A self-hosted Bitbucket Data Center install has an arbitrary domain and is
+ *  deliberately left to GenericGitVCS's catch-all rather than guessed at.
+ *
+ *  apra-fleet-5oo: declaring this makes resolveVcsProviderForHost() name
+ *  'bitbucket' for a Bitbucket remote, which is what lets runner.js's
+ *  dispatch-time VCS-provider fallback detect it. Behaviour-neutral for
+ *  VCSModule.capabilities(): this provider declares no capabilitiesForHost,
+ *  and the caller's default (canOpenPullRequest:false) matches what
+ *  GenericGitVCS returned for these hosts before. */
+const HOST_RE = /^(?:altssh\.)?bitbucket\.org$/i;
+
+function matchesHost(host) {
+    return typeof host === 'string' && HOST_RE.test(host.trim());
+}
+
 export const BitbucketVCS = Object.freeze({
     name: 'bitbucket',
     extends: 'generic-git',
     rules: Object.freeze({
         [K.AUTH_EXPIRED]: AUTH_EXPIRED,
     }),
+    matchesHost,
     defaultAuthMode: null,
     builders: null,
 });

--- a/packages/apra-fleet-se/fleet-sprint/vcs-providers/github.mjs
+++ b/packages/apra-fleet-se/fleet-sprint/vcs-providers/github.mjs
@@ -215,6 +215,34 @@ function matchesHost(host) {
     return typeof host === 'string' && /github/i.test(host);
 }
 
+/** github.com and its ssh/www aliases -- ANCHORED. Kept character-for-
+ *  character in step with src/utils/vcs-provider-detect.ts's
+ *  GITHUB_HOST_RE (the registration-time half of the same decision). */
+const AUTH_HOST_RE = /^(?:www\.|ssh\.)?github\.com$/i;
+
+/** Host-recognition for the CREDENTIAL-PROVISIONING axis
+ *  (resolveVcsAuthProviderForHost() in ./index.mjs), deliberately NARROWER
+ *  than matchesHost() above.
+ *
+ *  matchesHost() is a substring test on purpose: it answers "can this host
+ *  open a pull request?" for capabilities(), and a GitHub Enterprise Server
+ *  install has no fixed domain, so the vendor name in the hostname is the
+ *  only portable signal (pinned by test/vcs-capabilities-table.test.mjs).
+ *  Answering YES there costs nothing -- the worst case is a PR attempt that
+ *  fails.
+ *
+ *  Auto-PROVISIONING is a different risk class entirely: it mints a real
+ *  GitHub App push credential and points it at the host. A substring test
+ *  would let a lookalike domain ("mygithubmirror.attacker.io",
+ *  "github.com.evil.example") claim this provider and receive that
+ *  credential -- exactly the leak src/utils/vcs-provider-detect.ts anchors
+ *  against on the registration-time path. So GitHub Enterprise is NOT
+ *  auto-detected for auth on either side: an operator registers a GHE
+ *  member with an explicit `vcs_provider`. */
+function matchesHostForAuth(host) {
+    return typeof host === 'string' && AUTH_HOST_RE.test(host.trim());
+}
+
 /** Every host this provider matches can open a PR via the REST call
  *  buildGitHubCreatePrCommand() builds -- github.com and GitHub Enterprise
  *  Server alike speak the same `/repos/{owner}/{repo}/pulls` shape. */
@@ -230,6 +258,7 @@ export const GitHubVCS = Object.freeze({
     }),
     extractProviderCode,
     matchesHost,
+    matchesHostForAuth,
     capabilitiesForHost,
     // apra-fleet-647.1.5.1: GitHub's own default auth mode (App, never PAT --
     // see vcs-module.mjs resolveProvider()'s header note on why this must stay

--- a/packages/apra-fleet-se/fleet-sprint/vcs-providers/index.mjs
+++ b/packages/apra-fleet-se/fleet-sprint/vcs-providers/index.mjs
@@ -30,6 +30,19 @@
  *                                          // never owns a host (dolt), and
  *                                          // for the generic-git catch-all
  *                                          // it returns true unconditionally.
+ *     matchesHostForAuth: (host) => boolean // OPTIONAL; the CREDENTIAL-
+ *                                          // PROVISIONING axis, for
+ *                                          // resolveVcsAuthProviderForHost()
+ *                                          // below. Declare it ONLY when a
+ *                                          // provider's matchesHost() is
+ *                                          // deliberately wider than the set
+ *                                          // of hosts it is safe to auto-mint
+ *                                          // a push credential for (see
+ *                                          // ./github.mjs). Omitted means
+ *                                          // "matchesHost is already exactly
+ *                                          // right for auth too", which is
+ *                                          // the case for every anchored
+ *                                          // matcher.
  *     capabilitiesForHost: (host) => { canOpenPullRequest: boolean }  // OPTIONAL;
  *                                          // capabilities() axis. What a
  *                                          // claimed host supports. MUST stay
@@ -244,7 +257,7 @@ export function registerVcsProvider(impl) {
     // front for the same reason as `extractProviderCode` above -- a malformed
     // hook must fail at registration, not inside resolveVcsProviderForHost()
     // or a remote-URL preflight where the error would mask the real failure.
-    for (const hook of ['matchesHost', 'capabilitiesForHost', 'parseRepoRef', 'buildProvisionArgs']) {
+    for (const hook of ['matchesHost', 'matchesHostForAuth', 'capabilitiesForHost', 'parseRepoRef', 'buildProvisionArgs']) {
         if (impl[hook] != null && typeof impl[hook] !== 'function') {
             throw new Error(`ERROR: VCSModule: provider "${impl.name}" has a non-function \`${hook}\`.`);
         }
@@ -414,6 +427,39 @@ export function resolveVcsProviderForHost(host) {
         }
     }
     return registry.get('generic-git') || GenericGitVCS;
+}
+
+/**
+ * The CREDENTIAL-PROVISIONING sibling of resolveVcsProviderForHost().
+ *
+ * Same dispatch, one deliberate difference: a provider that declares
+ * `matchesHostForAuth` is asked THAT instead of `matchesHost`. Recognizing a
+ * host for capabilities() ("could a PR be opened here?") is cheap to get
+ * wrong -- the worst case is a PR attempt that fails. Recognizing it for auth
+ * is not: the caller mints a real push credential and points it at the host,
+ * so a substring matcher (see ./github.mjs's matchesHost, deliberately wide
+ * for GitHub Enterprise Server) would hand that credential to any lookalike
+ * domain containing the vendor name. Providers whose matcher is already
+ * anchored (bitbucket, azure-devops) declare no separate hook and are
+ * unaffected.
+ *
+ * Returns null rather than the generic-git catch-all: "no registered auth
+ * backend claims this host" is the answer a provisioning caller needs, and a
+ * catch-all descriptor there would read as a detection when it is a guess.
+ *
+ * @param {string|null} host
+ * @returns {object|null} an auth-backend provider descriptor, or null.
+ */
+export function resolveVcsAuthProviderForHost(host) {
+    for (const provider of [...registry.values()].reverse()) {
+        if (provider.name === 'generic-git') continue;
+        if (!isAuthBackend(provider)) continue;
+        const matcher = typeof provider.matchesHostForAuth === 'function'
+            ? provider.matchesHostForAuth
+            : provider.matchesHost;
+        if (typeof matcher === 'function' && matcher(host)) return provider;
+    }
+    return null;
 }
 
 for (const impl of BUILT_IN_PROVIDERS) registerVcsProvider(impl);

--- a/packages/apra-fleet-se/test/vcs-auth-preflight.test.mjs
+++ b/packages/apra-fleet-se/test/vcs-auth-preflight.test.mjs
@@ -243,7 +243,18 @@ describe('createVcsAuthPreflightCallback', () => {
         );
     });
 
-    test('a member with NO registered VCS provider degrades silently (typed error logged, never thrown) and never calls provision_vcs_auth -- no silent GitHub default', async () => {
+    // apra-fleet-5oo NARROWED THIS CASE. "No silent GitHub default" means no
+    // provider assumed with no evidence. provisionVcsAuthForMember now has ONE
+    // evidence-based fallback: the member's own git remote, already read for
+    // its repos scope. A remote no registered auth provider claims is still
+    // evidence of nothing, so this case now uses such a remote -- the
+    // healed-from-a-real-remote counterpart lives in
+    // test/vcs-provider-missing-selfheal.test.mjs.
+    const unclaimedRemoteCommand = async (cmd) => (cmd === 'git remote get-url origin'
+        ? { ok: true, output: 'https://gitlab.example.com/acme/widgets.git', error: null }
+        : { ok: true, output: '', error: null });
+
+    test('a member with NO registered VCS provider AND a remote no provider claims degrades silently (typed error logged, never thrown) and never calls provision_vcs_auth -- no silent GitHub default', async () => {
         const calls = [];
         const callTool = async (name, args) => {
             if (name === 'member_detail') return { content: [{ text: JSON.stringify({ vcsProvider: undefined }) }] };
@@ -251,7 +262,7 @@ describe('createVcsAuthPreflightCallback', () => {
             return { content: [{ text: `Provisioned.\n  expiresAt: ${farFutureExpiry()}` }] };
         };
         const logs = [];
-        const ensureVcsAuthFresh = createVcsAuthPreflightCallback({ callTool, command: remoteCommand, log: (m) => logs.push(m) });
+        const ensureVcsAuthFresh = createVcsAuthPreflightCallback({ callTool, command: unclaimedRemoteCommand, log: (m) => logs.push(m) });
 
         await assert.doesNotReject(() => ensureVcsAuthFresh('unprovisioned-member'));
 

--- a/packages/apra-fleet-se/test/vcs-auth-self-heal.test.mjs
+++ b/packages/apra-fleet-se/test/vcs-auth-self-heal.test.mjs
@@ -177,9 +177,18 @@ describe('createVcsAuthSelfHealCallback', () => {
         );
     });
 
-    test('a member with NO registered VCS provider throws a typed ASCII "ERROR:" naming the member and never calls provision_vcs_auth (no silent GitHub default)', async () => {
+    // apra-fleet-5oo NARROWED THIS CASE. The rule pinned here has always been
+    // "no silent GitHub DEFAULT" -- a provider assumed with no evidence.
+    // provisionVcsAuthForMember now has ONE evidence-based fallback: the
+    // member's own git remote, which it already reads for its repos scope. A
+    // remote whose host no registered auth provider claims (or one that cannot
+    // be read at all) is still evidence of nothing, and must still raise
+    // resolveProvider's typed ERROR rather than default to GitHub. The
+    // healed-from-a-real-remote counterpart lives in
+    // test/vcs-provider-missing-selfheal.test.mjs.
+    test('a member with NO registered VCS provider AND a remote no provider claims throws a typed ASCII "ERROR:" naming the member and never calls provision_vcs_auth (no silent GitHub default)', async () => {
         const calls = [];
-        const command = async () => ({ ok: true, output: 'https://github.com/acme/widgets.git', error: null });
+        const command = async () => ({ ok: true, output: 'https://gitlab.example.com/acme/widgets.git', error: null });
         const callTool = async (name, args) => {
             if (name === 'member_detail') return { content: [{ text: JSON.stringify({ vcsProvider: undefined }) }] };
             calls.push({ name, args });

--- a/packages/apra-fleet-se/test/vcs-provider-missing-selfheal.test.mjs
+++ b/packages/apra-fleet-se/test/vcs-provider-missing-selfheal.test.mjs
@@ -1,0 +1,169 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+
+import {
+    createVcsAuthPreflightCallback,
+    createVcsAuthSelfHealCallback,
+} from '../fleet-sprint/runner.js';
+
+// =============================================================================
+// apra-fleet-5oo (LAYER 2): provisionVcsAuthForMember's dispatch-time
+// self-heal for a member registered with NO vcsProvider at all.
+//
+// register_member could mint a fully dispatch-capable member (llm_provider
+// 'claude') while leaving Agent.vcsProvider unset -- nothing in registration
+// ever asked for or detected it. VCSModule.resolveProvider() then throws
+// "member has no registered VCS provider" on that member's first push/PR,
+// typically hours into an unattended sprint, and the self-heal path itself
+// dies on the same lookup, so retrying can never help. Layer 1 fixes new
+// registrations; this layer heals every member ALREADY in that state, by
+// falling back to the member's own git remote -- the SAME read
+// provisionVcsAuthForMember already performs to derive its repos scope.
+//
+// Both callbacks below funnel into provisionVcsAuthForMember, so the fallback
+// is exercised through the two real call sites (reactive self-heal and
+// proactive preflight) rather than a private function.
+//
+// Persistence needs no separate call: provision_vcs_auth already writes
+// vcsProvider back to the member registry (src/tools/provision-vcs-auth.ts),
+// so "the fallback persisted" is asserted as "provision_vcs_auth was called
+// with the detected provider".
+// =============================================================================
+
+/** member_detail for a member with NO registered vcsProvider -- exactly the
+ *  shape src/tools/member-detail.ts returns for one, and what makes
+ *  resolveProvider() throw its typed ERROR. */
+const MEMBER_DETAIL_NO_PROVIDER = { content: [{ text: JSON.stringify({ friendlyName: 'worker' }) }] };
+
+const remoteCommandFor = (url) => async (cmd) => {
+    if (cmd === 'git remote get-url origin') {
+        return url === null
+            ? { ok: false, output: '', error: 'not a git repository' }
+            : { ok: true, output: url, error: null };
+    }
+    return { ok: true, output: '', error: null };
+};
+
+const farFutureExpiry = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+function makeCallTool(calls) {
+    return async (name, args) => {
+        if (name === 'member_detail') return MEMBER_DETAIL_NO_PROVIDER;
+        calls.push({ name, args });
+        return { content: [{ text: `Provisioned VCS credential.\n  expiresAt: ${farFutureExpiry()}` }] };
+    };
+}
+
+describe('provisionVcsAuthForMember: VCS-provider fallback for a member with none registered (apra-fleet-5oo)', () => {
+    test('preflight: detects github from the member git remote, logs the self-heal, and provisions (which persists it)', async () => {
+        const calls = [];
+        const logs = [];
+        const ensureVcsAuthFresh = createVcsAuthPreflightCallback({
+            callTool: makeCallTool(calls),
+            command: remoteCommandFor('https://github.com/acme/widgets.git'),
+            log: (m) => logs.push(m),
+        });
+
+        await ensureVcsAuthFresh('worker');
+
+        assert.equal(calls.length, 1, `expected exactly one provision_vcs_auth call, got ${JSON.stringify(calls)}`);
+        assert.equal(calls[0].name, 'provision_vcs_auth');
+        assert.deepEqual(calls[0].args, {
+            member_name: 'worker',
+            provider: 'github',
+            github_mode: 'github-app',
+            git_access: 'push',
+            repos: ['acme/widgets'],
+        });
+        assert.ok(
+            logs.some((l) => /had no registered VCS provider; detected 'github' from its git remote/.test(l)),
+            `expected a self-heal log line naming the detected provider, got: ${JSON.stringify(logs)}`,
+        );
+    });
+
+    test("detects azure-devops (whose defaultAuthMode is null, so no '<provider>_mode' field is sent) from an scp-like remote", async () => {
+        const calls = [];
+        const ensureVcsAuthFresh = createVcsAuthPreflightCallback({
+            callTool: makeCallTool(calls),
+            command: remoteCommandFor('git@ssh.dev.azure.com:v3/acme/widgets/widgets'),
+        });
+
+        await ensureVcsAuthFresh('worker');
+
+        // Azure DevOps' own buildProvisionArgs hook makes an extra credential-
+        // store lookup of its own, so filter rather than index blindly.
+        const provisionCalls = calls.filter((c) => c.name === 'provision_vcs_auth');
+        assert.equal(provisionCalls.length, 1, `expected exactly one provision_vcs_auth call, got: ${JSON.stringify(calls)}`);
+        assert.equal(provisionCalls[0].args.provider, 'azure-devops');
+        assert.ok(!('azure-devops_mode' in provisionCalls[0].args), `no auth-mode field expected for azure-devops, got ${JSON.stringify(provisionCalls[0].args)}`);
+    });
+
+    test('detects bitbucket from a bitbucket.org remote', async () => {
+        const calls = [];
+        const ensureVcsAuthFresh = createVcsAuthPreflightCallback({
+            callTool: makeCallTool(calls),
+            command: remoteCommandFor('git@bitbucket.org:acme/widgets.git'),
+        });
+
+        await ensureVcsAuthFresh('worker');
+
+        const provisionCalls = calls.filter((c) => c.name === 'provision_vcs_auth');
+        assert.equal(provisionCalls.length, 1, `expected exactly one provision_vcs_auth call, got: ${JSON.stringify(calls)}`);
+        assert.equal(provisionCalls[0].args.provider, 'bitbucket');
+    });
+
+    test('the reactive self-heal path gets the same fallback (both callbacks share the call site)', async () => {
+        const calls = [];
+        const onAuthFailure = createVcsAuthSelfHealCallback({
+            callTool: makeCallTool(calls),
+            command: remoteCommandFor('git@github.com:acme/widgets.git'),
+        });
+
+        await onAuthFailure('worker');
+
+        assert.ok(
+            calls.some((c) => c.name === 'provision_vcs_auth' && c.args.provider === 'github'),
+            `expected a provision_vcs_auth call with the detected provider, got: ${JSON.stringify(calls)}`,
+        );
+    });
+
+    test('an UNREADABLE remote preserves the original resolveProvider throw -- nothing to detect, so nothing is guessed', async () => {
+        const command = async (cmd) => {
+            if (cmd === 'git remote get-url origin') throw new Error('ssh: connect to host worker port 22: Connection refused');
+            return { ok: true, output: '', error: null };
+        };
+        // The self-heal callback (not the preflight, which NEVER throws by
+        // design) is where a genuinely unresolvable provider must stay loud.
+        const onAuthFailure = createVcsAuthSelfHealCallback({ callTool: makeCallTool([]), command });
+
+        await assert.rejects(
+            () => onAuthFailure('worker'),
+            /has no registered VCS provider/,
+            'an unreadable remote must surface resolveProvider\'s own typed error, not a fallback guess',
+        );
+    });
+
+    test('an UNRECOGNIZED remote host preserves the original resolveProvider throw (generic-git is not an auth backend)', async () => {
+        const onAuthFailure = createVcsAuthSelfHealCallback({
+            callTool: makeCallTool([]),
+            command: remoteCommandFor('https://gitlab.example.com/group/repo.git'),
+        });
+
+        await assert.rejects(
+            () => onAuthFailure('worker'),
+            /has no registered VCS provider/,
+        );
+    });
+
+    test('an EMPTY remote (work folder with no git repo) preserves the original resolveProvider throw', async () => {
+        const onAuthFailure = createVcsAuthSelfHealCallback({
+            callTool: makeCallTool([]),
+            command: remoteCommandFor(null),
+        });
+
+        await assert.rejects(
+            () => onAuthFailure('worker'),
+            /has no registered VCS provider/,
+        );
+    });
+});

--- a/packages/apra-fleet-se/test/vcs-provider-missing-selfheal.test.mjs
+++ b/packages/apra-fleet-se/test/vcs-provider-missing-selfheal.test.mjs
@@ -5,6 +5,8 @@ import {
     createVcsAuthPreflightCallback,
     createVcsAuthSelfHealCallback,
 } from '../fleet-sprint/runner.js';
+import { resolveVcsAuthProviderForHost } from '../fleet-sprint/vcs-module.mjs';
+import { GitHubVCS } from '../fleet-sprint/vcs-providers/index.mjs';
 
 // =============================================================================
 // apra-fleet-5oo (LAYER 2): provisionVcsAuthForMember's dispatch-time
@@ -165,5 +167,113 @@ describe('provisionVcsAuthForMember: VCS-provider fallback for a member with non
             () => onAuthFailure('worker'),
             /has no registered VCS provider/,
         );
+    });
+});
+
+// =============================================================================
+// Review fixes on top of apra-fleet-5oo.
+// =============================================================================
+
+describe('the auth-axis host matcher is ANCHORED (credential-leak guard)', () => {
+    test("github's capabilities-axis matchesHost stays a substring test (GitHub Enterprise Server has no fixed domain)", () => {
+        // Pinned so the two axes are never collapsed back into one: this is
+        // what keeps a GHE host PR-capable (test/vcs-capabilities-table.test.mjs).
+        assert.equal(GitHubVCS.matchesHost('github.acme-corp.internal'), true);
+    });
+
+    test('the AUTH-axis matcher refuses lookalike hosts that merely contain "github"', () => {
+        for (const host of [
+            'mygithubmirror.attacker.io',
+            'github.com.evil.example',
+            'github.acme-corp.internal',   // real GHE: needs an explicit vcs_provider
+            'notgithub.com',
+            'githubb.com',
+        ]) {
+            assert.equal(GitHubVCS.matchesHostForAuth(host), false, `expected ${host} NOT to be claimed for auth`);
+            assert.equal(resolveVcsAuthProviderForHost(host), null, `expected no auth backend to claim ${host}`);
+        }
+    });
+
+    test('the AUTH-axis matcher still claims github.com and its aliases', () => {
+        for (const host of ['github.com', 'GitHub.com', 'www.github.com', 'ssh.github.com']) {
+            assert.equal(GitHubVCS.matchesHostForAuth(host), true, `expected ${host} to be claimed for auth`);
+            assert.equal(resolveVcsAuthProviderForHost(host).name, 'github');
+        }
+    });
+
+    test('bitbucket www. alias is claimed, matching src/utils/vcs-provider-detect.ts', () => {
+        for (const host of ['bitbucket.org', 'www.bitbucket.org', 'altssh.bitbucket.org']) {
+            assert.equal(resolveVcsAuthProviderForHost(host).name, 'bitbucket', `expected ${host} -> bitbucket`);
+        }
+        assert.equal(resolveVcsAuthProviderForHost('bitbucket.org.evil.example'), null);
+    });
+
+    test('a lookalike GitHub remote does NOT trigger the dispatch-time fallback -- no credential is provisioned', async () => {
+        const calls = [];
+        const onAuthFailure = createVcsAuthSelfHealCallback({
+            callTool: makeCallTool(calls),
+            command: remoteCommandFor('https://mygithubmirror.attacker.io/acme/widgets.git'),
+        });
+
+        await assert.rejects(
+            () => onAuthFailure('worker'),
+            /has no registered VCS provider/,
+            'a lookalike host must surface the original error, never be detected as github',
+        );
+        assert.equal(
+            calls.filter((c) => c.name === 'provision_vcs_auth').length,
+            0,
+            `no credential may be minted for a lookalike host, got: ${JSON.stringify(calls)}`,
+        );
+    });
+});
+
+describe('the fallback catch is NARROW: only "no registered VCS provider" self-heals', () => {
+    /** member_detail fails outright (network blip / RPC error). resolveProvider
+     *  wraps that in its own throw, which carries NO self-heal code. */
+    const failingMemberDetail = (calls, err) => async (name, args) => {
+        if (name === 'member_detail') throw err;
+        calls.push({ name, args });
+        return { content: [{ text: `Provisioned VCS credential.\n  expiresAt: ${farFutureExpiry()}` }] };
+    };
+
+    test('a member_detail RPC failure propagates instead of being papered over by the git-remote guess', async () => {
+        const calls = [];
+        const onAuthFailure = createVcsAuthSelfHealCallback({
+            callTool: failingMemberDetail(calls, new Error('socket hang up')),
+            // A perfectly detectable remote -- the fallback would happily fire
+            // here if the catch were still catching every error shape.
+            command: remoteCommandFor('https://github.com/acme/widgets.git'),
+        });
+
+        await assert.rejects(
+            () => onAuthFailure('worker'),
+            /could not read the member registry/,
+            'an RPC failure must surface as itself, not as a provider guess',
+        );
+        assert.equal(
+            calls.filter((c) => c.name === 'provision_vcs_auth').length,
+            0,
+            `no provision may follow an unrelated failure, got: ${JSON.stringify(calls)}`,
+        );
+    });
+
+    test('a member-not-found (non-JSON member_detail) response also propagates, with a detectable remote present', async () => {
+        const calls = [];
+        const callTool = async (name, args) => {
+            if (name === 'member_detail') return { content: [{ text: 'no member found matching "worker"' }] };
+            calls.push({ name, args });
+            return { content: [{ text: `Provisioned VCS credential.\n  expiresAt: ${farFutureExpiry()}` }] };
+        };
+        const onAuthFailure = createVcsAuthSelfHealCallback({
+            callTool,
+            command: remoteCommandFor('https://github.com/acme/widgets.git'),
+        });
+
+        await assert.rejects(
+            () => onAuthFailure('worker'),
+            /could not resolve member .* from the registry: no member found matching "worker"/,
+        );
+        assert.equal(calls.filter((c) => c.name === 'provision_vcs_auth').length, 0);
     });
 });

--- a/src/cli/register-member.ts
+++ b/src/cli/register-member.ts
@@ -42,6 +42,9 @@ Remote members:
 Git access:
   --git-access <level>     read|push|admin|issues|full
   --git-repos <a,b>        Comma-separated repos (e.g. "Apra-Labs/ApraPipes")
+  --vcs-provider <p>       github|bitbucket|azure-devops|none. Omit to auto-detect
+                           from the member's git "origin" remote; "none" declares
+                           the member deliberately has no VCS provider.
 
 Models:
   --model-cheap <id>       Curated cheap model
@@ -55,7 +58,7 @@ Models:
 const VALUE_FLAGS = new Set([
   '--name', '--path', '--type', '--llm', '--category', '--tags', '--unattended',
   '--host', '--port', '--username', '--auth', '--password', '--key-path',
-  '--git-access', '--git-repos',
+  '--git-access', '--git-repos', '--vcs-provider',
   '--model-cheap', '--model-standard', '--model-premium', '--model-tier',
 ]);
 
@@ -109,6 +112,7 @@ function buildRawInput(parsed: ParsedFlags): Record<string, unknown> {
     '--password': 'password',
     '--key-path': 'key_path',
     '--git-access': 'git_access',
+    '--vcs-provider': 'vcs_provider',
     '--model-cheap': 'model_cheap',
     '--model-standard': 'model_standard',
     '--model-premium': 'model_premium',

--- a/src/os/linux.ts
+++ b/src/os/linux.ts
@@ -317,6 +317,11 @@ export class LinuxCommands implements OsCommands {
     return `git -C "${escapeDoubleQuoted(folder)}" branch --show-current 2>/dev/null || true`;
   }
 
+  gitRemoteOrigin(folder: string): string {
+    const f = escapeDoubleQuoted(folder);
+    return `git -C "${f}" remote get-url origin 2>/dev/null || git -C "${f}" config --get remote.origin.url 2>/dev/null || true`;
+  }
+
   // --- Process management ---
 
   // apra-fleet-eft.13.3: `kill -9 <pid>` alone only signals that single

--- a/src/os/os-commands.ts
+++ b/src/os/os-commands.ts
@@ -86,6 +86,16 @@ export interface OsCommands {
   // --- Git ---
   gitCurrentBranch(folder: string): string;
 
+  /**
+   * Print the `origin` remote's URL for a checkout at `folder`, or NOTHING at
+   * all when there is no git repo / no `origin` (an expected, common case --
+   * e.g. a member registered before anything was cloned into its work folder).
+   * Never fails the command: callers treat empty output as "unknown", not as
+   * an error. Falls back to `git config --get remote.origin.url` for the older
+   * git builds that predate `remote get-url`.
+   */
+  gitRemoteOrigin(folder: string): string;
+
   // --- GPU activity ---
   gpuProcessCheck(): string;  // outputs "busy"|"idle", exits 2 if nvidia-smi not available
   gpuUtilization(): string;   // outputs GPU utilization 0-100 (integer), or empty if unavailable

--- a/src/os/windows.ts
+++ b/src/os/windows.ts
@@ -359,6 +359,11 @@ $merged | ConvertTo-Json -Depth 99 | Set-Content -Path $p -NoNewline;
     return `try { git -C "${escapeWindowsArg(folder)}" branch --show-current 2>$null } catch {}`;
   }
 
+  gitRemoteOrigin(folder: string): string {
+    const f = escapeWindowsArg(folder);
+    return `try { $u = git -C "${f}" remote get-url origin 2>$null; if (-not $u) { $u = git -C "${f}" config --get remote.origin.url 2>$null }; if ($u) { Write-Output $u } } catch {}`;
+  }
+
   // --- Process management ---
 
   killPid(pid: number): string {

--- a/src/tools/register-member.ts
+++ b/src/tools/register-member.ts
@@ -477,7 +477,7 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
   // llm_provider 'none' never dispatches an agent and never pushes, so it is
   // exempt; so is an explicit vcs_provider (including 'none').
   if (!tempAgent.vcsProvider && !input.vcs_provider && (input.llm_provider ?? 'claude') !== 'none') {
-    warnings.push('VCS provider could not be determined (no git remote found, or vcs_provider not supplied) -- this member will be UNABLE to push or open a PR until provisioned. Register this member again with vcs_provider set, or run provision_vcs_auth with an explicit provider (github/bitbucket/azure-devops) -- provision_vcs_auth requires the provider, it does not detect one.');
+    warnings.push('VCS provider could not be determined (no git remote found, or vcs_provider not supplied) -- this member will be UNABLE to push or open a PR until provisioned. Run provision_vcs_auth with an explicit provider (github/bitbucket/azure-devops) -- it requires the provider, it does not detect one, and sets vcsProvider as a side effect of provisioning credentials. Or run update_member with vcs_provider set to record the provider directly, without provisioning credentials. Re-registering this member is NOT a remedy -- the same folder path is rejected as a duplicate registration.');
   }
 
   // OS support warning for cloud members: cloud features are designed for Linux

--- a/src/tools/register-member.ts
+++ b/src/tools/register-member.ts
@@ -401,8 +401,6 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
       : strategy.execCommand(cmds.mkdir(input.work_folder), 10000)
           .catch(() => { warnings.push(`Could not create folder "${input.work_folder}"`); });
 
-    await Promise.all([versionCheck, authCheck, mkdirCheck]);
-
     // Step 3b: best-effort VCS-provider detection (apra-fleet-5oo).
     //
     // Registration could previously mint a fully dispatch-capable member with
@@ -417,22 +415,31 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
     // fails registration -- a work folder with no git repo in it yet is the
     // common "register before clone" case, not an error. It degrades to a
     // loud warning below instead.
-    if (!input.vcs_provider) {
-      try {
-        const remoteRes = await strategy.execCommand(cmds.gitRemoteOrigin(input.work_folder), 15000);
-        // Take stdout regardless of exit code: both OS builders swallow the
-        // failure ("|| true" / "try {} catch {}") so an absent repo yields
-        // empty output rather than a non-zero code, and stderr is never a URL.
-        const remoteUrl = String(remoteRes.stdout ?? '').trim().split(/\r?\n/)[0].trim();
-        const detected = detectVcsProviderFromRemoteUrl(remoteUrl);
-        if (detected) {
-          tempAgent.vcsProvider = detected;
-          vcsProviderAutoDetected = true;
-        }
-      } catch {
-        // Best effort -- fall through to the warning below.
-      }
-    }
+    //
+    // Runs INSIDE the Promise.all below rather than after it: the probe is
+    // independent of the CLI/auth/mkdir checks, so sequencing it behind them
+    // would add a whole extra SSH round trip to every registration for no
+    // ordering reason. Racing mkdirCheck is harmless in particular: a folder
+    // mkdir had to CREATE cannot contain a git repo, so the probe's answer is
+    // the same ("no remote") whichever of the two lands first.
+    const vcsProviderCheck = input.vcs_provider
+      ? Promise.resolve()
+      : strategy.execCommand(cmds.gitRemoteOrigin(input.work_folder), 15000)
+          .then(remoteRes => {
+            // Take stdout regardless of exit code: both OS builders swallow
+            // the failure ("|| true" / "try {} catch {}") so an absent repo
+            // yields empty output rather than a non-zero code, and stderr is
+            // never a URL.
+            const remoteUrl = String(remoteRes.stdout ?? '').trim().split(/\r?\n/)[0].trim();
+            const detected = detectVcsProviderFromRemoteUrl(remoteUrl);
+            if (detected) {
+              tempAgent.vcsProvider = detected;
+              vcsProviderAutoDetected = true;
+            }
+          })
+          .catch(() => { /* Best effort -- fall through to the warning below. */ });
+
+    await Promise.all([versionCheck, authCheck, mkdirCheck, vcsProviderCheck]);
 
     // --- Provision role-agent definition files (planner.md, doer.md, ...) ---
     // Remote members have their own home dir and never receive these via install() --
@@ -470,7 +477,7 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
   // llm_provider 'none' never dispatches an agent and never pushes, so it is
   // exempt; so is an explicit vcs_provider (including 'none').
   if (!tempAgent.vcsProvider && !input.vcs_provider && (input.llm_provider ?? 'claude') !== 'none') {
-    warnings.push('VCS provider could not be determined (no git remote found, or vcs_provider not supplied) -- this member will be UNABLE to push or open a PR until provisioned. Set vcs_provider explicitly, or run provision_vcs_auth once a git remote exists.');
+    warnings.push('VCS provider could not be determined (no git remote found, or vcs_provider not supplied) -- this member will be UNABLE to push or open a PR until provisioned. Register this member again with vcs_provider set, or run provision_vcs_auth with an explicit provider (github/bitbucket/azure-devops) -- provision_vcs_auth requires the provider, it does not detect one.');
   }
 
   // OS support warning for cloud members: cloud features are designed for Linux

--- a/src/tools/register-member.ts
+++ b/src/tools/register-member.ts
@@ -26,6 +26,7 @@ import { seedWorkspaceTrust } from '../utils/workspace-trust.js';
 import { composePermissions } from './compose-permissions.js';
 import { isFullyQualifiedPath, workFolderNotAbsoluteError } from '../utils/work-folder-validation.js';
 import { getMemberHomeDir } from '../services/member-home.js';
+import { detectVcsProviderFromRemoteUrl } from '../utils/vcs-provider-detect.js';
 
 export const registerMemberSchema = z.object({
   friendly_name: z.string()
@@ -42,6 +43,7 @@ export const registerMemberSchema = z.object({
   work_folder: z.string().regex(/^[^<>\n\r]+$/, 'work_folder must not contain angle brackets or newlines').describe('Working directory on the target machine. For remote members, must be a fully-qualified/absolute path (e.g. "/home/bella/repo" or "C:\\Users\\bella\\repo") -- "~" and relative paths are rejected, since they are never resolved for a remote member.'),
   git_access: z.enum(['read', 'push', 'admin', 'issues', 'full']).optional().describe('Git access level for this member'),
   git_repos: z.array(z.string()).optional().describe('Git repositories this member can access (e.g. ["Apra-Labs/ApraPipes"])'),
+  vcs_provider: z.enum(['github', 'bitbucket', 'azure-devops', 'none']).optional().describe('VCS provider this member pushes to and opens pull requests against. Omit to auto-detect it from the member\'s git "origin" remote; pass "none" to record that this member deliberately has no VCS provider (suppresses the auto-detect warning). A member with no VCS provider CANNOT push or open a PR.'),
   // Cloud fields
   cloud_provider: z.enum(['aws'], {
     errorMap: () => ({ message: "Only 'aws' is supported as a cloud provider. GCP and Azure support is planned." }),
@@ -284,6 +286,11 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
     createdAt: new Date().toISOString(),
     gitAccess: input.git_access,
     gitRepos: input.git_repos,
+    // apra-fleet-5oo: an explicitly-supplied provider always wins and is never
+    // probed for. 'none' is an explicit "this member has no VCS provider"
+    // declaration -- it is NOT an Agent.vcsProvider value (src/types.ts), so it
+    // is recorded as absent here and only suppresses the warning below.
+    vcsProvider: (input.vcs_provider && input.vcs_provider !== 'none') ? input.vcs_provider : undefined,
     cloud: cloudConfig,
     llmProvider: input.llm_provider ?? 'claude',
     modelCheap: input.model_cheap,
@@ -303,6 +310,10 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
   let claudeVersion: string | undefined;
   let connResult: { ok: boolean; latencyMs?: number; error?: string } = { ok: true };
   let agentProvisionResult: ProvisionResult | undefined;
+  // apra-fleet-5oo: true only when the provider below was resolved by probing
+  // the member's own git remote (never when the caller supplied it), so the
+  // result line can say where the value came from.
+  let vcsProviderAutoDetected = false;
 
   if (!skipSshOps) {
     const strategy = getStrategy(tempAgent);
@@ -392,6 +403,37 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
 
     await Promise.all([versionCheck, authCheck, mkdirCheck]);
 
+    // Step 3b: best-effort VCS-provider detection (apra-fleet-5oo).
+    //
+    // Registration could previously mint a fully dispatch-capable member with
+    // Agent.vcsProvider left unset -- nothing here ever asked for or detected
+    // it -- and the gap only surfaced hours later, mid-sprint, when
+    // fleet-sprint's VCSModule.resolveProvider() threw "member has no
+    // registered VCS provider" on the member's first push/PR.
+    //
+    // Modelled on the Windows shell probe above (shouldProbeShell /
+    // probeWindowsShell) in both spirit and failure behavior: an explicit
+    // operator value skips the probe entirely, and the probe itself NEVER
+    // fails registration -- a work folder with no git repo in it yet is the
+    // common "register before clone" case, not an error. It degrades to a
+    // loud warning below instead.
+    if (!input.vcs_provider) {
+      try {
+        const remoteRes = await strategy.execCommand(cmds.gitRemoteOrigin(input.work_folder), 15000);
+        // Take stdout regardless of exit code: both OS builders swallow the
+        // failure ("|| true" / "try {} catch {}") so an absent repo yields
+        // empty output rather than a non-zero code, and stderr is never a URL.
+        const remoteUrl = String(remoteRes.stdout ?? '').trim().split(/\r?\n/)[0].trim();
+        const detected = detectVcsProviderFromRemoteUrl(remoteUrl);
+        if (detected) {
+          tempAgent.vcsProvider = detected;
+          vcsProviderAutoDetected = true;
+        }
+      } catch {
+        // Best effort -- fall through to the warning below.
+      }
+    }
+
     // --- Provision role-agent definition files (planner.md, doer.md, ...) ---
     // Remote members have their own home dir and never receive these via install() --
     // only when connectivity is confirmed do we attempt the probe/push round trip.
@@ -418,6 +460,17 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
       warnings.push('Agent files not provisioned -- run update_member after the instance starts.');
       warnings.push('Workspace trust not seeded -- run update_member after the instance starts.');
     }
+  }
+
+  // apra-fleet-5oo: registration must never silently produce a dispatch-capable
+  // member that cannot push or open a PR. Registration is NOT refused (that
+  // would break the common "register the member, then clone into its work
+  // folder" flow), but the gap is surfaced HERE, loudly, at registration time
+  // rather than reactively hours into an unattended sprint. A member with
+  // llm_provider 'none' never dispatches an agent and never pushes, so it is
+  // exempt; so is an explicit vcs_provider (including 'none').
+  if (!tempAgent.vcsProvider && !input.vcs_provider && (input.llm_provider ?? 'claude') !== 'none') {
+    warnings.push('VCS provider could not be determined (no git remote found, or vcs_provider not supplied) -- this member will be UNABLE to push or open a PR until provisioned. Set vcs_provider explicitly, or run provision_vcs_auth once a git remote exists.');
   }
 
   // OS support warning for cloud members: cloud features are designed for Linux
@@ -577,6 +630,11 @@ export async function registerMember(input: RegisterMemberInput): Promise<string
   result += `  OS:      ${detectedOS}\n`;
   result += `  Folder:  ${tempAgent.workFolder}\n`;
   result += `  Provider: ${tempAgent.llmProvider ?? 'claude'}\n`;
+  if (tempAgent.vcsProvider) {
+    result += `  VCS Provider: ${tempAgent.vcsProvider}${vcsProviderAutoDetected ? ' (auto-detected from origin)' : ''}\n`;
+  } else if (input.vcs_provider === 'none') {
+    result += `  VCS Provider: none (declared explicitly -- this member cannot push or open a PR)\n`;
+  }
   if (tempAgent.category) {
     result += `  Category: ${tempAgent.category}\n`;
   }

--- a/src/tools/update-member.ts
+++ b/src/tools/update-member.ts
@@ -69,6 +69,7 @@ export const updateMemberSchema = z.object({
   code_intel_provider: z.enum(['codebase-memory', 'gitnexus', 'none']).optional().describe('Change the code-intelligence provider for this member.'),
   unreservable: z.boolean().optional().describe('Mark this member as never exclusively reservable, so it can be shared by more than one sprint at once (e.g. a member filling fleet-sprint\'s shared "orchestrator" role). reserve/release/force_release become no-op successes and overlap guards skip it.'),
   shell: z.enum(['gitbash', 'pwsh7', 'powershell5']).optional().describe('Override the probed Windows shell for this member (gitbash, pwsh7, or powershell5). Windows members only -- ignored for non-windows members.'),
+  vcs_provider: z.enum(['github', 'bitbucket', 'azure-devops', 'none']).optional().describe('Directly set (override) this member\'s VCS provider -- an explicit operator value, never auto-detected. Use this to correct a wrong auto-detect from register_member, or to set the provider for a member with no credentials to provision (so provision_vcs_auth is not required just to record it). Pass "none" to clear it, declaring the member deliberately has no VCS provider.'),
 });
 
 export type UpdateMemberInput = z.infer<typeof updateMemberSchema>;
@@ -204,6 +205,12 @@ export async function updateMember(input: UpdateMemberInput): Promise<string> {
   if (input.code_intel_provider !== undefined) updates.codeIntelProvider = input.code_intel_provider;
   if (input.unreservable !== undefined) updates.unreservable = input.unreservable;
   if (input.shell !== undefined) updates.shell = input.shell;
+  // Explicit operator override -- never auto-detected (that only happens in
+  // register_member). 'none' clears vcsProvider, matching how register_member
+  // records it (Agent.vcsProvider has no 'none' member -- see src/types.ts).
+  if (input.vcs_provider !== undefined) {
+    updates.vcsProvider = input.vcs_provider === 'none' ? undefined : input.vcs_provider;
+  }
   if (input.model_cheap !== undefined) updates.modelCheap = input.model_cheap;
   if (input.model_standard !== undefined) updates.modelStandard = input.model_standard;
   if (input.model_premium !== undefined) updates.modelPremium = input.model_premium;
@@ -297,6 +304,9 @@ export async function updateMember(input: UpdateMemberInput): Promise<string> {
     result += `  Auth:    ${updated.authType}\n`;
   }
   result += `  Provider: ${updated.llmProvider ?? 'claude'}\n`;
+  if (input.vcs_provider !== undefined) {
+    result += `  VCS Provider: ${updated.vcsProvider ?? 'none'}\n`;
+  }
   if (updated.modelCheap) result += `  Model Cheap: ${updated.modelCheap}\n`;
   if (updated.modelStandard) result += `  Model Standard: ${updated.modelStandard}\n`;
   if (updated.modelPremium) result += `  Model Premium: ${updated.modelPremium}\n`;

--- a/src/utils/vcs-provider-detect.ts
+++ b/src/utils/vcs-provider-detect.ts
@@ -1,0 +1,109 @@
+/**
+ * detectVcsProviderFromRemoteUrl -- map a git remote URL onto the VCS provider
+ * that hosts it (apra-fleet-5oo).
+ *
+ * WHY THIS EXISTS. `register_member` could fully register a dispatch-capable
+ * member (llm_provider: 'claude') while leaving Agent.vcsProvider unset --
+ * nothing in registration ever asked for or detected it. The gap only surfaced
+ * hours later, mid-sprint, when fleet-sprint's VCSModule.resolveProvider()
+ * threw "member has no registered VCS provider" on the first push/PR. This
+ * function is the registration-time half of the fix: a best-effort read of the
+ * member's own `origin` remote is mapped to a provider here, so the common case
+ * needs no operator input at all.
+ *
+ * PARALLEL IMPLEMENTATION, DELIBERATELY. The orchestrator-side (fleet-se)
+ * equivalent of this logic lives in
+ * packages/apra-fleet-se/fleet-sprint/vcs-module.mjs (parseRemote /
+ * parseProviderRepoRef) and each provider descriptor's own matchesHost()
+ * under packages/apra-fleet-se/fleet-sprint/vcs-providers/. That code is a
+ * separate package with its own registry and cannot be imported from the
+ * server's src/ tree. The host rules below are kept deliberately in step with
+ * those descriptors -- in particular azure-devops.mjs's anchored HOST_RE -- so
+ * the two halves never disagree about who owns a host.
+ *
+ * URL SHAPES. Every form git itself accepts for a hosted remote:
+ *   - https://host/owner/repo(.git)          scheme'd, optional userinfo/port
+ *   - http://host/owner/repo(.git)
+ *   - ssh://git@host(:port)/owner/repo(.git) scheme'd ssh
+ *   - git://host/owner/repo.git              the read-only git protocol
+ *   - git@host:owner/repo(.git)              scp-like shorthand (NO scheme --
+ *                                            `new URL()` cannot parse it)
+ * A `file://` remote, a local path, an empty/absent URL, or a host no provider
+ * below claims all return null: "unknown", never a guess. Callers must treat
+ * null as "could not determine", not as an error.
+ *
+ * Host matching is ANCHORED on purpose. A substring test would let
+ * `github.com.evil.example` or `dev.azure.com.attacker.test` claim a provider
+ * and send a member's freshly-minted push credential at the wrong host.
+ * GitHub Enterprise Server hosts (which have no fixed domain) are therefore
+ * NOT auto-detected here -- an operator registers those with an explicit
+ * `vcs_provider`.
+ *
+ * Pure: no I/O, no throwing, no mutation. ASCII only.
+ */
+
+/** The provider vocabulary Agent.vcsProvider accepts (src/types.ts). */
+export type DetectedVcsProvider = 'github' | 'bitbucket' | 'azure-devops';
+
+/** github.com and its ssh alias. Anchored -- see the header note on GHE. */
+const GITHUB_HOST_RE = /^(?:www\.|ssh\.)?github\.com$/i;
+
+/** bitbucket.org and its alternate-SSH host. */
+const BITBUCKET_HOST_RE = /^(?:www\.|altssh\.)?bitbucket\.org$/i;
+
+/** dev.azure.com, its v3 ssh host, and the legacy <org>.visualstudio.com.
+ *  Kept identical to azure-devops.mjs's HOST_RE. */
+const AZURE_DEVOPS_HOST_RE = /^(?:dev\.azure\.com|ssh\.dev\.azure\.com|(?:[a-z0-9-]+\.)*visualstudio\.com)$/i;
+
+const HOST_RULES: ReadonlyArray<{ provider: DetectedVcsProvider; re: RegExp }> = [
+  { provider: 'github', re: GITHUB_HOST_RE },
+  { provider: 'bitbucket', re: BITBUCKET_HOST_RE },
+  { provider: 'azure-devops', re: AZURE_DEVOPS_HOST_RE },
+];
+
+/**
+ * Extract the lowercased hostname from a git remote URL, for BOTH shapes git
+ * speaks. Returns null for a file:// remote, a bare local path, or anything
+ * unparseable -- mirroring vcs-module.mjs's parseRemote().
+ */
+export function parseRemoteHost(remoteUrl: unknown): string | null {
+  const url = String(remoteUrl ?? '').trim();
+  if (!url) return null;
+
+  // scp-like shorthand (git@github.com:owner/repo.git) has no `scheme://`
+  // prefix, which `new URL()` cannot parse. Guarded by the scheme test so a
+  // real `ssh://user@host/...` URL falls through to the URL branch below.
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+    const scp = /^[^@\s/]+@([^:\s/]+):/.exec(url);
+    if (scp) return scp[1].toLowerCase();
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const scheme = parsed.protocol.replace(/:$/, '').toLowerCase();
+  // A file:// remote has no host to attribute to any hosted provider.
+  if (scheme === 'file') return null;
+  return parsed.hostname ? parsed.hostname.toLowerCase() : null;
+}
+
+/**
+ * Resolve a git remote URL to the VCS provider that hosts it.
+ *
+ * @param remoteUrl a git remote URL in any of the shapes documented above.
+ * @returns 'github' | 'bitbucket' | 'azure-devops', or null when the URL is
+ *          absent/unparseable or its host is not one this function recognizes.
+ *          Null is "unknown", NEVER a default provider.
+ */
+export function detectVcsProviderFromRemoteUrl(remoteUrl: unknown): DetectedVcsProvider | null {
+  const host = parseRemoteHost(remoteUrl);
+  if (!host) return null;
+  for (const rule of HOST_RULES) {
+    if (rule.re.test(host)) return rule.provider;
+  }
+  return null;
+}

--- a/src/utils/vcs-provider-detect.ts
+++ b/src/utils/vcs-provider-detect.ts
@@ -18,8 +18,12 @@
  * under packages/apra-fleet-se/fleet-sprint/vcs-providers/. That code is a
  * separate package with its own registry and cannot be imported from the
  * server's src/ tree. The host rules below are kept deliberately in step with
- * those descriptors -- in particular azure-devops.mjs's anchored HOST_RE -- so
- * the two halves never disagree about who owns a host.
+ * those descriptors -- azure-devops.mjs's and bitbucket.mjs's anchored
+ * HOST_REs, and github.mjs's anchored matchesHostForAuth() -- so the two
+ * halves never disagree about who owns a host. Note that github.mjs ALSO
+ * exports a deliberately wider substring matchesHost(); that one answers the
+ * capabilities axis ("could a PR be opened here?", where GitHub Enterprise
+ * Server must say yes) and is NOT the matcher any credential decision uses.
  *
  * URL SHAPES. Every form git itself accepts for a hosted remote:
  *   - https://host/owner/repo(.git)          scheme'd, optional userinfo/port

--- a/tests/register-member-vcs-provider.test.ts
+++ b/tests/register-member-vcs-provider.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Wiring pins for register_member's VCS-provider detection (apra-fleet-5oo).
+ *
+ * Before this, a member could be fully registered with llm_provider 'claude'
+ * (i.e. fully dispatch-capable) while Agent.vcsProvider stayed unset -- nothing
+ * in registration ever asked for or detected it -- and the gap only surfaced
+ * reactively, hours into an unattended sprint, as fleet-sprint's
+ * "member has no registered VCS provider" throw on the first push/PR.
+ *
+ * Everything runs against a faked AgentStrategy (same approach as
+ * register-member-shell-probe.test.ts), so the suite is OS-independent.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
+import { registerMember } from '../src/tools/register-member.js';
+import { getAllAgents } from '../src/services/registry.js';
+import { LinuxCommands } from '../src/os/index.js';
+import type { SSHExecResult } from '../src/types.js';
+
+const mockExecCommand = vi.fn<(cmd: string, timeout?: number) => Promise<SSHExecResult>>();
+const mockTestConnection = vi.fn();
+
+vi.mock('../src/services/strategy.js', () => ({
+  getStrategy: () => ({
+    execCommand: mockExecCommand,
+    testConnection: mockTestConnection,
+    transferFiles: vi.fn(),
+    receiveFiles: vi.fn(),
+    deleteFiles: vi.fn(),
+    close: vi.fn(),
+  }),
+}));
+
+vi.mock('../src/services/statusline.js', () => ({
+  writeStatusline: vi.fn(),
+}));
+
+// compose_permissions writes (and reads back) a settings file ON THE MEMBER via
+// the strategy above; against a fake strategy that read-back can never succeed,
+// and register_member correctly refuses to report success when it fails. That
+// axis is already covered by register-member.test.ts -- stub it to a success
+// here so these cases test the VCS-provider axis alone. The literal is written
+// as an escape so this source file stays ASCII (repo convention).
+vi.mock('../src/tools/compose-permissions.js', () => ({
+  composePermissions: vi.fn(async () => '\u2705 Permissions composed (test stub).'),
+}));
+
+// Provisioning role-agent files and seeding workspace trust are separate,
+// already-covered SSH round trips that a fake strategy makes slow and
+// meaningless here.
+vi.mock('../src/services/agent-provisioner.js', () => ({
+  provisionAgents: vi.fn(async () => ({ pushed: [], skipped: [], warning: undefined })),
+}));
+vi.mock('../src/utils/workspace-trust.js', () => ({
+  seedWorkspaceTrust: vi.fn(async () => undefined),
+}));
+
+const FOLDER = '/srv/work';
+const REMOTE_CMD = new LinuxCommands().gitRemoteOrigin(FOLDER);
+
+/** A healthy Linux member whose `origin` remote reads back as `remote`
+ *  (pass null for "no git repo here yet" -- empty output, the common
+ *  register-before-clone case). */
+function useFakeMember(remote: string | null) {
+  mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 5 });
+  mockExecCommand.mockImplementation(async (cmd: string) => {
+    if (cmd === 'uname -s') return { stdout: 'Linux', stderr: '', code: 0 };
+    if (cmd === REMOTE_CMD) return { stdout: remote ?? '', stderr: '', code: 0 };
+    return { stdout: '', stderr: '', code: 0 };
+  });
+}
+
+function sentCommands(): string[] {
+  return mockExecCommand.mock.calls.map(c => c[0]);
+}
+
+function registeredProvider(name: string): string | undefined {
+  const agent = getAllAgents().find(a => a.friendlyName === name);
+  expect(agent, `member ${name} was not registered`).toBeTruthy();
+  return agent!.vcsProvider;
+}
+
+const WARNING = /VCS provider could not be determined/;
+
+const base = {
+  member_type: 'remote',
+  host: '10.0.0.5',
+  username: 'dev',
+  auth_type: 'password',
+  password: 'x',
+  work_folder: FOLDER,
+};
+
+describe('register_member: VCS-provider detection (apra-fleet-5oo)', () => {
+  beforeEach(() => {
+    backupAndResetRegistry();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    restoreRegistry();
+  });
+
+  it('an explicit vcs_provider is honored and suppresses the remote probe entirely', async () => {
+    useFakeMember('https://github.com/acme/widgets.git');
+    const result = await registerMember({
+      ...base, friendly_name: 'explicit-azdo', vcs_provider: 'azure-devops',
+    } as never);
+
+    expect(result).toContain('registered successfully');
+    // The explicit value wins over what the remote would have said.
+    expect(registeredProvider('explicit-azdo')).toBe('azure-devops');
+    expect(sentCommands()).not.toContain(REMOTE_CMD);
+    expect(result).toContain('VCS Provider: azure-devops');
+    expect(result).not.toContain('(auto-detected from origin)');
+    expect(result).not.toMatch(WARNING);
+  });
+
+  it('auto-detects the provider from the git origin remote and reports it as auto-detected', async () => {
+    useFakeMember('https://github.com/acme/widgets.git');
+    const result = await registerMember({ ...base, friendly_name: 'auto-gh' } as never);
+
+    expect(result).toContain('registered successfully');
+    expect(registeredProvider('auto-gh')).toBe('github');
+    expect(sentCommands()).toContain(REMOTE_CMD);
+    expect(result).toContain('VCS Provider: github (auto-detected from origin)');
+    expect(result).not.toMatch(WARNING);
+  });
+
+  it('auto-detects azure-devops from an scp-like ssh remote', async () => {
+    useFakeMember('git@ssh.dev.azure.com:v3/org/project/repo');
+    const result = await registerMember({ ...base, friendly_name: 'auto-azdo' } as never);
+
+    expect(registeredProvider('auto-azdo')).toBe('azure-devops');
+    expect(result).toContain('VCS Provider: azure-devops (auto-detected from origin)');
+  });
+
+  it('no git remote yet + default llm_provider (claude): registration SUCCEEDS but warns loudly', async () => {
+    useFakeMember(null);
+    const result = await registerMember({ ...base, friendly_name: 'no-remote' } as never);
+
+    expect(result).toContain('registered successfully');
+    expect(registeredProvider('no-remote')).toBeUndefined();
+    expect(result).toMatch(WARNING);
+    expect(result).toContain('UNABLE to push or open a PR');
+    expect(result).not.toContain('VCS Provider:');
+  });
+
+  it('an unrecognized remote host also warns rather than guessing a provider', async () => {
+    useFakeMember('https://gitlab.com/group/repo.git');
+    const result = await registerMember({
+      ...base, friendly_name: 'gitlab-remote', llm_provider: 'claude',
+    } as never);
+
+    expect(result).toContain('registered successfully');
+    expect(registeredProvider('gitlab-remote')).toBeUndefined();
+    expect(result).toMatch(WARNING);
+  });
+
+  it('a failing remote probe never sinks the registration', async () => {
+    mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 5 });
+    mockExecCommand.mockImplementation(async (cmd: string) => {
+      if (cmd === 'uname -s') return { stdout: 'Linux', stderr: '', code: 0 };
+      if (cmd === REMOTE_CMD) throw new Error('connection reset');
+      return { stdout: '', stderr: '', code: 0 };
+    });
+
+    const result = await registerMember({ ...base, friendly_name: 'broken-probe' } as never);
+
+    expect(result).toContain('registered successfully');
+    expect(registeredProvider('broken-probe')).toBeUndefined();
+    expect(result).toMatch(WARNING);
+  });
+
+  it('llm_provider "none" never triggers the warning -- it never dispatches and never pushes', async () => {
+    useFakeMember(null);
+    const result = await registerMember({
+      ...base, friendly_name: 'no-llm', llm_provider: 'none',
+    } as never);
+
+    expect(result).toContain('registered successfully');
+    expect(result).not.toMatch(WARNING);
+  });
+
+  it('an explicit vcs_provider "none" records no provider, suppresses the warning, and says so', async () => {
+    useFakeMember(null);
+    const result = await registerMember({
+      ...base, friendly_name: 'declared-none', vcs_provider: 'none',
+    } as never);
+
+    expect(result).toContain('registered successfully');
+    expect(registeredProvider('declared-none')).toBeUndefined();
+    expect(sentCommands()).not.toContain(REMOTE_CMD);
+    expect(result).not.toMatch(WARNING);
+    expect(result).toContain('VCS Provider: none (declared explicitly');
+  });
+});

--- a/tests/update-member.test.ts
+++ b/tests/update-member.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { makeTestAgent, makeTestLocalAgent, backupAndResetRegistry, restoreRegistry } from './test-helpers.js';
 import { addAgent, getAllAgents } from '../src/services/registry.js';
-import { updateMember } from '../src/tools/update-member.js';
+import { updateMember, updateMemberSchema } from '../src/tools/update-member.js';
 import { credentialSet, credentialDelete } from '../src/services/credential-store.js';
 import { ClaudeProvider } from '../src/providers/claude.js';
 import { invalidatePreflightCache } from '../src/services/preflight-check.js';
@@ -454,5 +454,74 @@ describe('updateMember -- invokes ensureWorkspaceTrusted (apra-fleet-eft.40.2)',
     expect(spy).toHaveBeenCalledWith(member.workFolder, expect.any(Function), member.os, member.shell);
     expect(mockTestConnection).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// vcs_provider: explicit operator override (never auto-detected -- see
+// register-member-vcs-provider.test.ts for the auto-detect path this is NOT).
+// ---------------------------------------------------------------------------
+
+describe('updateMember -- vcs_provider (explicit override)', () => {
+  beforeEach(() => {
+    backupAndResetRegistry();
+    mockExecCommand.mockReset();
+    mockTestConnection.mockReset();
+    mockUploadContentToHome.mockReset();
+    mockTestConnection.mockResolvedValue({ ok: false, error: 'not reachable in this test' });
+  });
+
+  afterEach(() => {
+    restoreRegistry();
+  });
+
+  it('sets a valid vcs_provider directly, with no remote probe', async () => {
+    const member = makeTestAgent({ vcsProvider: undefined });
+    addAgent(member);
+
+    const result = await updateMember({ member_id: member.id, vcs_provider: 'github' });
+
+    expect(result).toContain('Member "test-agent" updated.');
+    expect(result).toContain('VCS Provider: github');
+    expect(getAllAgents().find(a => a.id === member.id)?.vcsProvider).toBe('github');
+    expect(mockExecCommand).not.toHaveBeenCalled();
+  });
+
+  it('overrides an existing vcs_provider (correcting a wrong auto-detect)', async () => {
+    const member = makeTestAgent({ vcsProvider: 'github' });
+    addAgent(member);
+
+    const result = await updateMember({ member_id: member.id, vcs_provider: 'azure-devops' });
+
+    expect(result).toContain('VCS Provider: azure-devops');
+    expect(getAllAgents().find(a => a.id === member.id)?.vcsProvider).toBe('azure-devops');
+  });
+
+  it('setting vcs_provider to "none" clears it', async () => {
+    const member = makeTestAgent({ vcsProvider: 'github' });
+    addAgent(member);
+
+    const result = await updateMember({ member_id: member.id, vcs_provider: 'none' });
+
+    expect(result).toContain('VCS Provider: none');
+    expect(getAllAgents().find(a => a.id === member.id)?.vcsProvider).toBeUndefined();
+  });
+
+  it('leaves vcs_provider untouched when not passed', async () => {
+    const member = makeTestAgent({ vcsProvider: 'bitbucket' });
+    addAgent(member);
+
+    await updateMember({ member_id: member.id, category: 'doers' });
+
+    expect(getAllAgents().find(a => a.id === member.id)?.vcsProvider).toBe('bitbucket');
+  });
+
+  it('rejects an invalid vcs_provider enum value at the schema level', () => {
+    // updateMember() itself trusts its typed input (the MCP framework
+    // validates via updateMemberSchema before dispatch -- same contract as
+    // register_member's CLI wrapper) -- so the enum rejection is asserted
+    // directly against the schema here.
+    const result = updateMemberSchema.safeParse({ member_id: 'x', vcs_provider: 'gitlab' });
+    expect(result.success).toBe(false);
   });
 });

--- a/tests/vcs-provider-detect.test.ts
+++ b/tests/vcs-provider-detect.test.ts
@@ -35,6 +35,7 @@ describe('detectVcsProviderFromRemoteUrl', () => {
   describe('bitbucket', () => {
     const urls = [
       'https://bitbucket.org/team/repo.git',
+      'https://www.bitbucket.org/team/repo.git',
       'https://user@bitbucket.org/team/repo.git',
       'ssh://git@bitbucket.org/team/repo.git',
       'ssh://git@altssh.bitbucket.org:443/team/repo.git',
@@ -77,6 +78,7 @@ describe('detectVcsProviderFromRemoteUrl', () => {
       ['a bare local path', '/srv/bare/repo.git'],
       ['a Windows local path', 'C:\\src\\repo'],
       ['a lookalike github host', 'https://github.com.evil.example/Apra-Labs/apra-fleet.git'],
+      ['a github lookalike mirror (substring, not a suffix)', 'https://mygithubmirror.attacker.io/Apra-Labs/apra-fleet.git'],
       ['a lookalike azure host', 'https://dev.azure.com.attacker.test/org/project/_git/repo'],
       ['a lookalike bitbucket host', 'git@bitbucket.org.evil.example:team/repo.git'],
       ['a lookalike visualstudio host', 'https://visualstudio.com.evil.example/project/_git/repo'],

--- a/tests/vcs-provider-detect.test.ts
+++ b/tests/vcs-provider-detect.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit coverage for detectVcsProviderFromRemoteUrl (apra-fleet-5oo), the pure
+ * URL -> provider mapping register_member uses to auto-detect a member's
+ * vcsProvider from its git 'origin' remote.
+ *
+ * Mirrors the URL-form coverage of the orchestrator-side equivalents this
+ * function deliberately parallels: vcs-module.mjs's parseRemote() and each
+ * vcs-providers/*.mjs descriptor's matchesHost().
+ */
+import { describe, it, expect } from 'vitest';
+import { detectVcsProviderFromRemoteUrl, parseRemoteHost } from '../src/utils/vcs-provider-detect.js';
+
+describe('detectVcsProviderFromRemoteUrl', () => {
+  describe('github', () => {
+    const urls = [
+      'https://github.com/Apra-Labs/apra-fleet.git',
+      'https://github.com/Apra-Labs/apra-fleet',
+      'http://github.com/Apra-Labs/apra-fleet.git',
+      'https://user:token@github.com/Apra-Labs/apra-fleet.git',
+      'ssh://git@github.com/Apra-Labs/apra-fleet.git',
+      'ssh://git@ssh.github.com:443/Apra-Labs/apra-fleet.git',
+      'git://github.com/Apra-Labs/apra-fleet.git',
+      'git@github.com:Apra-Labs/apra-fleet.git',
+      'git@github.com:Apra-Labs/apra-fleet',
+      'GIT@GITHUB.COM:Apra-Labs/apra-fleet.git',
+      'https://GitHub.com/Apra-Labs/apra-fleet.git',
+    ];
+    for (const url of urls) {
+      it(`detects github from ${url}`, () => {
+        expect(detectVcsProviderFromRemoteUrl(url)).toBe('github');
+      });
+    }
+  });
+
+  describe('bitbucket', () => {
+    const urls = [
+      'https://bitbucket.org/team/repo.git',
+      'https://user@bitbucket.org/team/repo.git',
+      'ssh://git@bitbucket.org/team/repo.git',
+      'ssh://git@altssh.bitbucket.org:443/team/repo.git',
+      'git@bitbucket.org:team/repo.git',
+    ];
+    for (const url of urls) {
+      it(`detects bitbucket from ${url}`, () => {
+        expect(detectVcsProviderFromRemoteUrl(url)).toBe('bitbucket');
+      });
+    }
+  });
+
+  describe('azure-devops', () => {
+    const urls = [
+      'https://dev.azure.com/org/project/_git/repo',
+      'https://org@dev.azure.com/org/project/_git/repo',
+      'git@ssh.dev.azure.com:v3/org/project/repo',
+      'ssh://git@ssh.dev.azure.com:22/v3/org/project/repo',
+      'https://org.visualstudio.com/project/_git/repo',
+      'https://visualstudio.com/project/_git/repo',
+      'git@vs-ssh.visualstudio.com:v3/org/project/repo',
+    ];
+    for (const url of urls) {
+      it(`detects azure-devops from ${url}`, () => {
+        expect(detectVcsProviderFromRemoteUrl(url)).toBe('azure-devops');
+      });
+    }
+  });
+
+  describe('unrecognized -> null (never a guess)', () => {
+    const urls: Array<[string, unknown]> = [
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['undefined', undefined],
+      ['null', null],
+      ['a gitlab remote', 'https://gitlab.com/group/repo.git'],
+      ['a self-hosted gitlab remote', 'git@gitlab.example.com:group/repo.git'],
+      ['a GitHub Enterprise host (no fixed domain -- needs explicit vcs_provider)', 'https://github.acme-corp.net/team/repo.git'],
+      ['a file:// remote', 'file:///srv/bare/repo.git'],
+      ['a bare local path', '/srv/bare/repo.git'],
+      ['a Windows local path', 'C:\\src\\repo'],
+      ['a lookalike github host', 'https://github.com.evil.example/Apra-Labs/apra-fleet.git'],
+      ['a lookalike azure host', 'https://dev.azure.com.attacker.test/org/project/_git/repo'],
+      ['a lookalike bitbucket host', 'git@bitbucket.org.evil.example:team/repo.git'],
+      ['a lookalike visualstudio host', 'https://visualstudio.com.evil.example/project/_git/repo'],
+      ['garbage', 'not a url at all'],
+    ];
+    for (const [label, url] of urls) {
+      it(`returns null for ${label}`, () => {
+        expect(detectVcsProviderFromRemoteUrl(url)).toBeNull();
+      });
+    }
+  });
+});
+
+describe('parseRemoteHost', () => {
+  it('lowercases the host for every shape', () => {
+    expect(parseRemoteHost('https://GitHub.COM/a/b.git')).toBe('github.com');
+    expect(parseRemoteHost('GIT@GitHub.COM:a/b.git')).toBe('github.com');
+    expect(parseRemoteHost('SSH://git@GitHub.COM/a/b.git')).toBe('github.com');
+  });
+
+  it('strips the port from a scheme-d URL', () => {
+    expect(parseRemoteHost('ssh://git@ssh.github.com:443/a/b.git')).toBe('ssh.github.com');
+  });
+
+  it('returns null for a file:// remote and for unparseable input', () => {
+    expect(parseRemoteHost('file:///srv/bare.git')).toBeNull();
+    expect(parseRemoteHost('/srv/bare.git')).toBeNull();
+    expect(parseRemoteHost('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

A member can be fully registered via `register_member` with `llm_provider: 'claude'` -- i.e. fully dispatch-capable -- while its `vcsProvider` field is left completely unset. Nothing in registration ever asked for or detected it.

The gap only surfaces later, when fleet-sprint's engine needs to push or open a PR on that member's behalf: `VCSModule.resolveProvider(member)` throws `"member has no registered VCS provider"`. That arrives reactively, typically hours into an unattended run, and the self-heal path that is supposed to fix auth problems dies on the *same* lookup -- so it is a self-heal that can never heal.

Found live: member `worker` on a standalone fleet-mac install had no `vcsProvider`, producing repeated self-heal-that-can't-heal failures in a dispatch preflight.

Umbrella context: **`apra-fleet-5oo`** ("Member sprint-role readiness is never provisioned or preflight-verified... gaps surface reactively mid-sprint").

## The fix: two layers

### Layer 1 -- registration time (`src/tools/register-member.ts`)

- New optional `vcs_provider` field (`github` | `bitbucket` | `azure-devops` | `none`) on `registerMemberSchema`, plus a matching `--vcs-provider` flag on the shell CLI (`src/cli/register-member.ts`). An explicit value always wins and skips all probing.
- Otherwise the member's git `origin` remote is read **best-effort** via a new `OsCommands.gitRemoteOrigin(folder)` (Linux/gitbash + PowerShell implementations; `git remote get-url origin` with a `git config --get remote.origin.url` fallback, both failure-swallowing), and mapped to a provider by a new pure module `src/utils/vcs-provider-detect.ts`.
- Detection succeeds -> `tempAgent.vcsProvider` is set and the result carries `VCS Provider: github (auto-detected from origin)`.
- Detection fails (no repo cloned yet, or an unrecognized host) **and** `llm_provider !== 'none'` **and** no explicit `vcs_provider` -> registration still **succeeds** (register-before-clone is a normal flow), but a **loud warning** lands in the existing `Warnings:` block saying the member will be UNABLE to push or open a PR until provisioned.

Modelled on the existing `shouldProbeShell` / `probeWindowsShell` step in the same function, in both spirit and "never blocks, degrades with a warning" behavior.

`src/utils/vcs-provider-detect.ts` mirrors the URL-form coverage of the orchestrator-side equivalents (`vcs-module.mjs`'s `parseRemote` / `parseProviderRepoRef`, each `vcs-providers/*.mjs`'s `matchesHost`, `runner.js`'s `parseOwnerRepoFromRemoteUrl`) as a deliberate parallel TS implementation -- that code is a separate package and cannot be imported from `src/`. Host matching is **anchored**, so `github.com.evil.example` cannot claim a provider; GitHub Enterprise (no fixed domain) is deliberately not auto-detected and needs an explicit `vcs_provider`.

### Layer 2 -- dispatch time (`packages/apra-fleet-se/fleet-sprint/runner.js`)

`provisionVcsAuthForMember`'s `resolveProvider` call is now wrapped: on failure it falls back to detecting the provider from the git remote **the function has already read** for its repos scope (no second dispatch), via the existing provider registry (`resolveVcsProviderForHost`, newly re-exported from `vcs-module.mjs`) rather than any new provider literal. It then logs

```
[Sync] <prefix>: member 'X' had no registered VCS provider; detected 'github' from its git remote and will provision it now
```

and proceeds. **No separate persistence call**: the function's own downstream `fleetApi.provisionVcsAuth(...)` already writes `vcsProvider` server-side (`src/tools/provision-vcs-auth.ts`), so everything downstream works unchanged and the next lookup resolves normally.

An unreadable remote, or a host claimed only by the `generic-git` catch-all, still re-raises the **original** error -- a real failure with nothing to detect. Because this sits at the shared call site, both `createVcsAuthSelfHealCallback` (reactive) and `createVcsAuthPreflightCallback` (proactive) benefit automatically.

`BitbucketVCS` now declares an anchored `matchesHost` (`bitbucket.org` / `altssh.bitbucket.org`), without which the registry would never name it for a Bitbucket remote. Behaviour-neutral for `VCSModule.capabilities()` (it declares no `capabilitiesForHost`, and the caller's default matches what `generic-git` returned before).

## Client parity

`packages/apra-fleet-client`'s `RegisterMemberOptions` typedef and `docs/api-reference.md` gain `vcs_provider` -- required, not optional cleanup, and enforced by the existing `client-server-typedef-parity` test.

## Tests

- `tests/vcs-provider-detect.test.ts` (41 cases) -- the pure detector: https / http / ssh / git:// / scp-like forms for all three providers, case-insensitivity, ports, and null for gitlab, GHE, `file://`, local paths, and every lookalike host.
- `tests/register-member-vcs-provider.test.ts` (8 cases) -- explicit value honored without probing; auto-detect sets `vcsProvider` + informational note; auto-detect failure with the default `claude` provider warns but still registers; a throwing probe never sinks registration; `llm_provider: 'none'` and `vcs_provider: 'none'` never warn.
- `packages/apra-fleet-se/test/vcs-provider-missing-selfheal.test.mjs` (7 cases) -- fallback detection for github / azure-devops / bitbucket reaches `provision_vcs_auth` with the detected provider (which is what persists it); reactive and preflight paths both covered; unreadable / unrecognized / empty remotes still throw the original error.
- Two existing cases in `vcs-auth-preflight.test.mjs` / `vcs-auth-self-heal.test.mjs` were **narrowed**, not weakened: the rule they pin has always been "no silent GitHub *default*" -- a provider assumed with no evidence. They now use a remote no registered provider claims, so they still prove exactly that, while the evidence-based path is covered by the new file.

**Results:** `npm run build` clean. `tests/register-member*.test.ts` + `tests/vcs-provider-detect.test.ts`: 84/84. `packages/apra-fleet-se` VCS suites (module, preflight, self-heal, non-github self-heal, azure-devops repo-ref, new file): 110/110. `packages/apra-fleet-client`: 36/36.

## Deviations from the brief

- Added `OsCommands.gitRemoteOrigin(folder)` rather than inlining a shell string in the tool -- the repo forbids shell-level assumptions in member-bound commands, and this mirrors the existing `gitCurrentBranch(folder)`.
- Added `BitbucketVCS.matchesHost` (above); without it Layer 2 could never detect Bitbucket even though Layer 1 can.
- Layer 2's negative-path tests use the self-heal callback rather than the preflight one: the preflight **never throws** by design (it logs and swallows), so "preserves the original throw" is only observable on the self-heal path.
