### PR TITLE
fix(bd-replay): self-heal an incomplete bd-init template instead of reusing it forever

### DIFF
--- a/packages/apra-fleet-se/test/helpers/bd-replay.mjs
+++ b/packages/apra-fleet-se/test/helpers/bd-replay.mjs
@@ -358,15 +358,31 @@ function bdInitTemplateDir() {
 const bdInitTemplatePromises = new Map(); // templateDir -> Promise<{ err, stdout, stderr, templateDir }>
 let bdInitTemplateSpawns = 0;
 
-// A template directory counts as usable only once it holds the `.beads` dir
-// `bd init` creates -- the marker bd-init-templating.test.mjs itself asserts
-// on. Anything less is a leftover/partial directory, not a template.
+// A template directory counts as usable only once its embedded dolt store is
+// FULLY written, not merely once `.beads` exists. `bd init` creates `.beads`
+// early in its own sequence and writes `<embeddeddolt db dir>/.dolt/
+// repo_state.json` later; a `bd init` interrupted mid-flight (a killed
+// process, a machine sleep) can leave a `.beads` tree with no dolt schema at
+// all. Checking `.beads` alone let exactly that kind of half-written
+// directory get published as "the" template, silently and permanently:
+// every later real-bd test on the host then copied the same broken tree and
+// failed with "reading aux rekey sentinel ... system cannot find file
+// specified" trying to open a `repo_state.json` that was never there
+// (reproduced 15/15 runs against a week-old broken template on this
+// machine). The embedded db subdirectory's name is derived from the
+// directory basename (not fixed), so scan for ANY entry under
+// `.beads/embeddeddolt/` that has one, rather than hardcoding a path.
 const templateIsReady = (dir) => {
+    let entries;
     try {
-        return fs.statSync(path.join(dir, '.beads')).isDirectory();
+        entries = fs.readdirSync(path.join(dir, '.beads', 'embeddeddolt'), { withFileTypes: true });
     } catch {
         return false;
     }
+    return entries.some((entry) => {
+        if (!entry.isDirectory()) return false;
+        return fs.existsSync(path.join(dir, '.beads', 'embeddeddolt', entry.name, '.dolt', 'repo_state.json'));
+    });
 };
 
 async function createBdInitTemplate(templateDir) {
@@ -384,11 +400,38 @@ async function createBdInitTemplate(templateDir) {
         await fs.promises.rm(staging, { recursive: true, force: true }).catch(() => {});
         return { ...res, templateDir };
     }
+    if (!templateIsReady(staging)) {
+        // `bd init` reported success (exit 0, no res.err) but the embedded
+        // dolt store never finished writing -- publishing this would corrupt
+        // the shared template for every later caller on this host, exactly
+        // as happened before this fix. Surface it as a real failure instead
+        // of a false success; the caller (realBdInitTemplated) propagates it
+        // to the test as `bd init` failing, which is the truth.
+        await fs.promises.rm(staging, { recursive: true, force: true }).catch(() => {});
+        return {
+            err: new Error(
+                `bd init into ${staging} exited 0 but produced no repo_state.json under .beads/embeddeddolt/**/.dolt -- ` +
+                    'the embedded dolt store never finished writing (process killed mid-init? disk stall?). ' +
+                    'Refusing to publish an incomplete template.',
+            ),
+            stdout: res.stdout,
+            stderr: res.stderr,
+            templateDir,
+        };
+    }
 
-    // Publish. Two things can make the rename fail, and they need opposite
-    // handling:
-    //   - the destination already exists  -> another process won the race;
-    //     drop ours and use theirs.
+    // Publish. Three things can make the rename fail, and they need
+    // different handling:
+    //   - the destination is a READY template -> another process already
+    //     published a good one; drop ours and use theirs (checked by the
+    //     loop condition below, every iteration).
+    //   - the destination exists but is NOT ready -> a stale/broken template
+    //     from an earlier interrupted run occupies the path. Reclaim it by
+    //     removing it, rather than retrying rename against it forever (that
+    //     used to fall back to a private per-staging template every time,
+    //     which fixed nothing for the next caller -- the broken shared
+    //     template just sat there permanently, which is exactly how this
+    //     host ended up with a week-old broken one).
     //   - EBUSY/EPERM on the SOURCE       -> Windows only: the just-exited
     //     `bd init` child (or a scanner) still holds a handle inside the
     //     staging tree for a moment. Retry briefly; this is the same
@@ -399,6 +442,9 @@ async function createBdInitTemplate(templateDir) {
     let published = false;
     for (let attempt = 0; attempt < 10 && !published; attempt += 1) {
         if (templateIsReady(templateDir)) break;
+        if (fs.existsSync(templateDir)) {
+            await fs.promises.rm(templateDir, { recursive: true, force: true }).catch(() => {});
+        }
         try {
             await fs.promises.rename(staging, templateDir);
             published = true;


### PR DESCRIPTION
## Summary

Root-causes and fixes the intermittently-failing `bd-replay-read-cache.test.mjs` (real-mode "read cache invalidation" regression test, `apra-fleet-5co8.7`), which has failed on and off across sessions on at least one dev machine.

**Root cause**: `packages/apra-fleet-se/test/helpers/bd-replay.mjs`'s real-mode `bd init` templating (apra-fleet-3ei / apra-fleet-u87n.1) publishes ONE shared, host-wide `bd init` bootstrap and copies it into every scenario's tempDir instead of re-spawning `bd init` per test. Its readiness check (`templateIsReady`) only verified a `.beads` directory existed -- which `bd init` creates early in its own sequence, well before it finishes writing the embedded dolt schema (`.dolt/repo_state.json`). A `bd init` interrupted mid-flight (killed process, machine sleep) published a half-written template that looked permanently "ready": every later real-bd test on that host copied the same broken tree and failed with `reading aux rekey sentinel ... system cannot find file specified` opening a `repo_state.json` that was never written. Nothing ever re-validated the published template, so once broken it stayed broken across every future test run and every future session on that host -- explaining the flake's on-and-off, session-spanning pattern rather than a live per-run race.

Reproduced 15/15 fails against a real, week-old broken template found on a Windows dev machine. 15/15 pass after the fix, and a simulated-corruption run confirms the self-heal path (a broken template is detected and reclaimed rather than reused).

**Fix**:
- `templateIsReady()` now scans `.beads/embeddeddolt/*/.dolt` for an actual `repo_state.json`, not just `.beads`'s existence.
- `createBdInitTemplate()` verifies its own freshly-built staging copy is complete before publishing, surfacing a genuine `bd init` failure instead of a false success.
- The publish loop now reclaims (deletes + replaces) a stale/broken template already occupying the shared path instead of retrying `rename` against it forever with no way to heal.

Follow-up bead filed for tracking: apra-fleet-m7xe.

## Test plan
- [x] Reproduced the flake deterministically: 15/15 fails against the real broken template found on disk
- [x] 15/15 pass after the fix (clean rebuild of the template)
- [x] Simulated-corruption run: an artificially incomplete template is detected and reclaimed, not silently reused
- [x] Confirmed a normal (non-broken) first-time template publish still succeeds cleanly
- [x] `bd-init-templating.test.mjs` unaffected (uses its own private, isolated template namespace; skip status on this machine confirmed pre-existing/unrelated)
- [x] `npm run build` clean
- [x] Full `npm test --workspace=@apralabs/apra-fleet-se`: 2803 pass / 0 fail (previously 1 fail, this exact test)