### PR TITLE
fix: stop misreading a stale-Dolt-clone push as a VCS credential failure, and stop provision_vcs_auth clobbering its own registration

### DIFF
--- a/packages/apra-fleet-se/fleet-sprint/dolt-sync.mjs
+++ b/packages/apra-fleet-se/fleet-sprint/dolt-sync.mjs
@@ -748,8 +748,19 @@ async function runDoltStep({ command, member, cmd, label, log, maxTransientRetri
         // through, so a degraded read/write is always visible to whoever is
         // watching a live sprint -- independent of whether the caller treats
         // it as fatal.
+        //
+        // `selfHealed` reports whether the bounded one-shot auth self-heal
+        // above actually RAN TO COMPLETION for this step -- i.e. credentials
+        // were re-provisioned and the command was then retried and STILL
+        // failed. It is deliberately false on the `catch (healErr)` path
+        // above (that returns early): a self-heal that THREW never
+        // re-provisioned anything, so a credential problem remains a live
+        // explanation there. Callers use this to tell "the credentials are
+        // stale" apart from "the credentials were just refreshed and the
+        // failure text is lying" -- see doltPushGuarded's post-reconcile
+        // re-push branch.
         log(`[Dolt] ${label} FAILED (${kind}) -- reads/writes for member '${member}' may be stale until this is resolved. Raw: ${error}`);
-        return { ok: false, output: res ? res.output : '', error, kind };
+        return { ok: false, output: res ? res.output : '', error, kind, selfHealed: authHealAttempted };
     }
 }
 
@@ -1659,14 +1670,95 @@ export async function doltPushAfter(member, opts = {}) {
         return { ok: true, member, pushed: true, reconciled: true };
     }
 
-    if (push.kind === 'auth') {
+    if (push.kind === 'auth' && !push.selfHealed) {
         // apra-fleet-spp.3: same mislabel class as the first-push/pull paths,
         // just reached via the post-reconcile re-push -- a credential that
         // lapsed mid-reconcile is not a data divergence, so it must not be
         // folded into DoltDivergedError below.
+        //
+        // Reached only when the bounded self-heal did NOT re-provision (no
+        // onAuthFailure wired, or the self-heal itself threw). With no
+        // evidence that the credentials were refreshed, a stale credential is
+        // still the best explanation and this stays an auth terminal.
         throw new DoltSyncError(
             `[Dolt] D-push re-push after reconcile for member '${member}' failed on VCS CREDENTIALS, not a data divergence -- re-provision the member's VCS auth (provision_vcs_auth) and retry. Raw: ${push.error}`,
             { member, doltOutput: push.error, details: { kind: 'auth', operation: 'push-reconcile-repush' } },
+        );
+    }
+
+    if (push.kind === 'auth') {
+        // AUTH-SHAPED BUT PROVABLY NOT AUTH (live 2026-09-11, fleet-lin-dev1).
+        //
+        // Reaching this line means ALL THREE of the following already
+        // happened, in this order, against this same remote:
+        //   1. the FIRST push was rejected non-fast-forward ('diverged') --
+        //      which is itself PROOF the remote authenticated this clone:
+        //      a remote cannot compare refs and reject a push it never let in;
+        //   2. the bounded reconcile D-pull SUCCEEDED;
+        //   3. the re-push failed auth-shaped, runDoltStep's one-shot
+        //      self-heal re-provisioned the credentials (`selfHealed`), and
+        //      the retry with the FRESH credentials failed identically.
+        //
+        // So the credentials are demonstrably fine and re-minting them again
+        // cannot help. Dolt's chunk-upload phase ('addTableFiles,
+        // updateManifestAddFiles') reports a stale/unfinished-reconcile push
+        // with git's credential-prompt text ("could not read Username"),
+        // which classifyDoltFailure -- correctly, in isolation -- reads as
+        // auth. Treating it as auth here is what produced the observed
+        // production pathology: the engine looped provision_vcs_auth (51
+        // repeated failures across one run's logs, each reporting
+        // "provision_vcs_auth succeeded" and then failing identically) and
+        // terminated with the misleading "failed on VCS CREDENTIALS, not a
+        // data divergence" reason, when the actual cause was a local Dolt
+        // clone behind the remote that a plain pull-then-push cleared.
+        //
+        // Do NOT fix this by loosening the 'auth' patterns: each message
+        // classifies correctly on its own, and widening them would regress
+        // apra-fleet-spp (a real credential failure being read as
+        // divergence). The signal is the SEQUENCE, so it is judged here.
+        //
+        // Remedy = the reconcile that did not finish: ONE more bounded
+        // D-pull + re-push cycle, deliberately WITHOUT `onAuthFailure`, so
+        // this path can never re-enter the credential-reprovision loop it
+        // exists to break. Still bounded (two cycles total, never a loop),
+        // keeping apra-fleet-417.3's first-successful-pusher-wins contract.
+        log(`[Dolt] D-push re-push after reconcile for member '${member}' failed with auth-shaped text, but VCS credentials are provably NOT the cause: the first push's non-fast-forward rejection proves the remote authenticated this clone moments earlier, and the credentials have since been re-provisioned and still fail identically. Treating it as an unfinished reconcile (a local clone behind the remote) and running ONE more bounded D-pull + re-push, with credential self-heal disabled. Raw: ${push.error}`);
+
+        const secondReconcile = await runDoltStep({
+            command, member, cmd: 'bd dolt pull',
+            label: `D-push second reconcile pull for '${member}'`, log, maxTransientRetries, sleep, backoffBaseMs, timeoutS, spawnOutageBudgetMs, now,
+        });
+        if (!secondReconcile.ok) {
+            if (secondReconcile.kind === 'diverged') {
+                return await surfaceDivergence(
+                    new DoltDivergedError(
+                        `[Dolt] D-push second reconcile pull for member '${member}' hit an unmergeable beads conflict -- must not be retried blindly: ${secondReconcile.error}`,
+                        { member, doltOutput: secondReconcile.error, operation: 'push-reconcile' },
+                    ),
+                    'push-reconcile',
+                );
+            }
+            throw new DoltSyncError(
+                `[Dolt] D-push second reconcile pull for member '${member}' failed: ${secondReconcile.error}`,
+                { member, doltOutput: secondReconcile.error },
+            );
+        }
+
+        push = await runDoltStep({
+            command, member, cmd: 'bd dolt push',
+            label: `D-push second re-push after reconcile for '${member}'`, log, maxTransientRetries, sleep, backoffBaseMs, timeoutS, spawnOutageBudgetMs, now,
+        });
+        if (push.ok) {
+            forgetTipAfterPush();
+            return { ok: true, member, pushed: true, reconciled: true };
+        }
+
+        return await surfaceDivergence(
+            new DoltDivergedError(
+                `[Dolt] D-push for member '${member}' still rejected after TWO bounded reconcile pulls -- refusing to retry further. The failure text names VCS credentials, but they were re-provisioned mid-ladder and the remote authenticated this clone earlier in the same ladder, so this is a stale/unmergeable clone, not a credential problem: ${push.error}`,
+                { member, doltOutput: push.error, operation: 'push' },
+            ),
+            'push',
         );
     }
 

--- a/packages/apra-fleet-se/test/dolt-sync-fault-tolerance.test.mjs
+++ b/packages/apra-fleet-se/test/dolt-sync-fault-tolerance.test.mjs
@@ -190,6 +190,112 @@ test('apra-fleet-spp.4 negative: reconcile-then-still-diverged re-push still sur
 });
 
 // -----------------------------------------------------------------------------
+// AUTH-SHAPED BUT PROVABLY NOT AUTH -- the live 2026-09-11 fleet-lin-dev1 run.
+//
+// spp.3/spp.4 (above) made an auth-shaped post-reconcile re-push a credential
+// terminal. That is right when nothing has re-provisioned the credentials, but
+// production threads an `onAuthFailure` self-heal into every step, and there
+// the same branch produced a pathology: the first push was rejected
+// non-fast-forward (which PROVES the remote authenticated this clone -- a
+// remote cannot compare refs and reject a push it never let in), the reconcile
+// pull succeeded, and the re-push then reported git's credential-prompt text
+// from Dolt's chunk-upload phase. runDoltStep re-provisioned, retried, and got
+// the identical failure -- and the engine reported "failed on VCS CREDENTIALS,
+// not a data divergence" and looped provision_vcs_auth (51 repeated failures
+// across one run's logs, each logging "provision_vcs_auth succeeded" and then
+// failing identically). The real cause was a local Dolt clone behind the
+// remote, cleared by a plain pull-then-push.
+//
+// The classifier is NOT the thing to loosen -- each message classifies
+// correctly in isolation, and widening the auth patterns would regress
+// apra-fleet-spp. The signal is the SEQUENCE, so doltPushGuarded judges it.
+// -----------------------------------------------------------------------------
+
+// Verbatim stderr from the live 2026-09-11 fleet-lin-dev1 D-push failures
+// (epic apra-fleet-hzeb, branch fleet-sprint/hzeb-usage-limit-pause).
+const LIVE_2026_09_11_CHUNK_UPLOAD_STDERR =
+    'Error: push to origin/main: Error 1105: unknown push error; addTableFiles, '
+    + "updateManifestAddFiles: fatal: could not read Username for "
+    + "'https://github.com/Apra-Labs/apra-fleet.git': No such device or address\n"
+    + 'hint: dolt does not support interactive credential prompts\n'
+    + 'hint: configure git credentials (credential helper, token) for HTTPS remotes';
+
+// Verbatim non-fast-forward rejection from that same run's FIRST push.
+const LIVE_2026_09_11_DIVERGENCE_STDERR =
+    'Error: push to origin/main: Error 1105: To git+https://github.com/Apra-Labs/apra-fleet.git\n'
+    + ' ! [rejected]            main -> main (non-fast-forward)\n'
+    + "error: failed to push some refs to 'git+https://github.com/Apra-Labs/apra-fleet.git'\n"
+    + 'hint: Updates were rejected because the tip of your current branch is behind\n'
+    + "hint: its remote counterpart. Integrate the remote changes (e.g. 'dolt pull ...') before pushing again.";
+
+test('the live 2026-09-11 chunk-upload stderr still classifies as auth in isolation (the classifier is not the bug)', () => {
+    assert.equal(classifyDoltFailure(LIVE_2026_09_11_CHUNK_UPLOAD_STDERR), 'auth');
+    assert.equal(classifyDoltFailure(LIVE_2026_09_11_DIVERGENCE_STDERR), 'diverged');
+});
+
+test('diverged push then a self-healed auth-shaped re-push reconciles instead of looping on credentials', async () => {
+    clearDegradedSyncRecords();
+    let healCalls = 0;
+    const { command } = makeCommandMock({
+        // 1: first push rejected non-fast-forward -> reconcile ladder.
+        // 2: re-push reports the chunk-upload credential text -> self-heal.
+        // 3: retry with FRESH credentials fails identically -> provably not auth.
+        // 4: the second bounded reconcile's re-push finally lands.
+        'bd dolt push': [
+            fail(LIVE_2026_09_11_DIVERGENCE_STDERR),
+            fail(LIVE_2026_09_11_CHUNK_UPLOAD_STDERR),
+            fail(LIVE_2026_09_11_CHUNK_UPLOAD_STDERR),
+            OK,
+        ],
+        'bd dolt pull': [OK],
+    });
+
+    const outcome = await doltPushAfter('fleet-lin-dev1', {
+        command,
+        checkSyncRemoteConfigured: remoteConfigured,
+        sleep: async () => {},
+        onAuthFailure: async () => { healCalls += 1; },
+    });
+
+    assert.equal(outcome.ok, true, 'the pull+push reconcile must recover the push');
+    assert.equal(outcome.pushed, true);
+    assert.equal(outcome.reconciled, true);
+    // The whole point: credentials are re-provisioned AT MOST ONCE, by
+    // runDoltStep's own bounded one-shot self-heal. The second reconcile cycle
+    // runs with self-heal disabled, so this can never become the observed loop.
+    assert.equal(healCalls, 1, 'provision_vcs_auth must not be called repeatedly');
+    clearDegradedSyncRecords();
+});
+
+test('a self-healed auth-shaped re-push that stays broken is a divergence terminal, never a credentials one', async () => {
+    clearDegradedSyncRecords();
+    let healCalls = 0;
+    const { command } = makeCommandMock({
+        // Never recovers: the last queue entry repeats for every later call.
+        'bd dolt push': [fail(LIVE_2026_09_11_DIVERGENCE_STDERR), fail(LIVE_2026_09_11_CHUNK_UPLOAD_STDERR)],
+        'bd dolt pull': [OK],
+    });
+
+    await assert.rejects(
+        () => doltPushAfter('fleet-lin-dev1', {
+            command,
+            checkSyncRemoteConfigured: remoteConfigured,
+            sleep: async () => {},
+            onAuthFailure: async () => { healCalls += 1; },
+        }),
+        (err) => {
+            assert.ok(err instanceof DoltDivergedError, 'must be the divergence terminal, not a credentials one');
+            assert.match(err.message, /TWO bounded reconcile pulls/);
+            assert.doesNotMatch(err.message, /failed on VCS CREDENTIALS/);
+            assert.equal(err.details.operation, 'push');
+            return true;
+        },
+    );
+    assert.equal(healCalls, 1, 'the terminal path must not keep re-provisioning credentials');
+    clearDegradedSyncRecords();
+});
+
+// -----------------------------------------------------------------------------
 // AC1/AC2: structured outcome, and an unresolvable conflict degrades instead of
 // aborting.
 // -----------------------------------------------------------------------------

--- a/src/os/linux.ts
+++ b/src/os/linux.ts
@@ -269,6 +269,13 @@ export class LinuxCommands implements OsCommands {
     return `printf '#!/bin/sh\\necho "protocol=https"\\necho "host=${escapedHost}"\\necho "username=${escapedUser}"\\necho "password=${escapedToken}"\\n' > "${credFile}" && chmod 600 "${credFile}" && chmod +x "${credFile}" && git config --global --replace-all "credential.${credUrl}.helper" "" && git config --global --add "credential.${credUrl}.helper" "${credFile}"`;
   }
 
+  gitCredentialHelperRemoveLegacyFile(): string {
+    // File only -- deliberately no `git config --unset-all`. $HOME (not `~`)
+    // for the same reason gitCredentialHelperWrite uses it: `~` is not
+    // tilde-expanded inside double quotes.
+    return `rm -f "$HOME/.fleet-git-credential"`;
+  }
+
   gitCredentialHelperRemove(host: string, label?: string, scopeUrl?: string): string {
     const escapedHost = escapeDoubleQuoted(host);
     const credFile = label ? `$HOME/.fleet-git-credential-${escapeDoubleQuoted(label)}` : '$HOME/.fleet-git-credential';

--- a/src/os/os-commands.ts
+++ b/src/os/os-commands.ts
@@ -82,6 +82,14 @@ export interface OsCommands {
   gitCredentialHelperWrite(host: string, username: string, token: string, label?: string, scopeUrl?: string): string;
   gitCredentialHelperRemove(host: string, label?: string, scopeUrl?: string): string;
 
+  /** Delete ONLY the pre-label, single-file credential helper
+   *  (`.fleet-git-credential`, no label suffix) left behind by installs that
+   *  predate labeled credentials. Touches NO git config: the credential-helper
+   *  config key is host/scope-scoped rather than label-scoped, so unsetting it
+   *  here would clobber whatever credential is CURRENTLY registered for that
+   *  host -- see provision-vcs-auth.ts's legacy-migration call site. */
+  gitCredentialHelperRemoveLegacyFile(): string;
+
   /** Log the `gh` CLI itself into GitHub with `token` (persists to gh's own config,
    *  e.g. ~/.config/gh/hosts.yml), independent of the git credential helper above --
    *  `gh` never reads that file. No-ops (does not throw) when `gh` is not installed;

--- a/src/os/windows-gitbash.ts
+++ b/src/os/windows-gitbash.ts
@@ -206,6 +206,13 @@ export class WindowsGitBashCommands extends LinuxCommands {
     ].join('; ');
   }
 
+  override gitCredentialHelperRemoveLegacyFile(): string {
+    // The Git-Bash helper is a `.bat` (see gitCredentialHelperWrite above), so
+    // the legacy unlabeled file carries that suffix too. File only --
+    // deliberately no `git config --unset-all`.
+    return `rm -f "$HOME/.fleet-git-credential.bat"`;
+  }
+
   override gitCredentialHelperRemove(host: string, label?: string, scopeUrl?: string): string {
     const credFileName = label ? `.fleet-git-credential-${escapeDoubleQuoted(label)}` : '.fleet-git-credential';
     const credUrl = scopeUrl ? escapeDoubleQuoted(scopeUrl) : `https://${escapeDoubleQuoted(host)}`;

--- a/src/os/windows.ts
+++ b/src/os/windows.ts
@@ -310,6 +310,11 @@ $merged | ConvertTo-Json -Depth 99 | Set-Content -Path $p -NoNewline;
     ].join('; ');
   }
 
+  gitCredentialHelperRemoveLegacyFile(): string {
+    // File only -- deliberately no `git config --unset-all`.
+    return `Remove-Item "$env:USERPROFILE\\.fleet-git-credential.bat" -Force -ErrorAction SilentlyContinue`;
+  }
+
   gitCredentialHelperRemove(host: string, label?: string, scopeUrl?: string): string {
     const escapedHost = escapeWindowsArg(host).replace(/'/g, "''");
     const credFileName = label ? `.fleet-git-credential-${escapeWindowsArg(label).replace(/'/g, "''")}` : '.fleet-git-credential';

--- a/src/tools/provision-vcs-auth.ts
+++ b/src/tools/provision-vcs-auth.ts
@@ -144,9 +144,35 @@ export async function provisionVcsAuth(input: ProvisionVcsAuthInput): Promise<st
     return result.stdout;
   };
 
-  // Legacy migration: remove old single-file credential helpers
+  // Legacy migration: remove the pre-label, single-file credential helper
+  // (`.fleet-git-credential`, no label suffix) left by installs predating
+  // labeled credentials.
+  //
+  // This used to call gitCredentialHelperRemove(host) with NO label, which
+  // additionally ran `git config --global --unset-all
+  // credential.https://<host>.helper`. That was actively destructive, and
+  // scoping the call to `label` would NOT have fixed it: the credential-helper
+  // config key is HOST/SCOPE-scoped, not label-scoped (the same fact PR #473
+  // turned on), so every variant of that call unsets the registration for
+  // whatever credential is currently live on that host. Because this ran
+  // unconditionally BEFORE the deploy, any failure in between -- a dropped
+  // connection, a GitHub App mint error, a racing second provision for the
+  // same member -- left the member with its credential FILE present and fresh
+  // but NO git-config registration, which is exactly the state observed
+  // repeatedly on fleet-lin-dev1 on 2026-09-11 (git and `bd dolt push` both
+  // failing with "could not read Username" while the token on disk was still
+  // valid for the better part of an hour).
+  //
+  // Dropping the config half costs nothing: gitCredentialHelperWrite's own
+  // `git config --global --replace-all "credential.<url>.helper" ""` already
+  // clears every existing value of that key before re-adding the new one, on
+  // all three OS command implementations. So the unset was pure redundancy
+  // with a destructive failure mode. The FILE removal is kept (rather than
+  // dropping the step wholesale) so a pre-label install does not keep an
+  // orphaned, still-valid token on disk -- the security wart PR #473 called
+  // out.
   try {
-    await exec(cmds.gitCredentialHelperRemove(host));
+    await exec(cmds.gitCredentialHelperRemoveLegacyFile());
   } catch { /* best-effort */ }
 
   // The agent record only tracks ONE active (label, scopeUrl) pair for

--- a/tests/provision-vcs-auth.test.ts
+++ b/tests/provision-vcs-auth.test.ts
@@ -389,6 +389,66 @@ describe('provisionVcsAuth', () => {
     expect(execCmds.filter(cmd => cmd.includes('fleet-git-credential-stable-label') && (cmd.includes('rm -f') || cmd.includes('Remove-Item'))).length).toBe(0);
   });
 
+  // --- legacy-migration step must never drop a live credential registration ---
+  //
+  // Regression for the live 2026-09-11 fleet-lin-dev1 failure. The
+  // legacy-migration step that runs BEFORE every deploy used to call
+  // gitCredentialHelperRemove(host) with no label, which emits
+  // `git config --global --unset-all credential.https://<host>.helper`. That
+  // key is HOST-scoped, not label-scoped, so it dropped the registration of
+  // whatever credential was currently live -- and because it ran before the
+  // deploy, any failure in between left the member with a fresh credential
+  // FILE on disk but no git-config registration ("could not read Username"
+  // while the token was still valid). Scoping that call to the label would NOT
+  // have helped: every variant unsets the same host-scoped key. The step now
+  // removes only the legacy unlabeled FILE and touches no git config.
+
+  it('github: the pre-deploy legacy migration never unsets the git-config credential helper key', async () => {
+    const member = makeTestAgent({ friendlyName: 'gh-legacy-migration' });
+    addAgent(member);
+    mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 5 });
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: '', code: 0 });
+
+    await provisionVcsAuth({
+      member_id: member.id, provider: 'github',
+      github_mode: 'pat', token: 'ghp_first_ever', label: 'only-label',
+    });
+
+    const execCmds = mockExecCommand.mock.calls.map(c => String(c[0]));
+    expect(execCmds.some(cmd => cmd.includes('--unset-all'))).toBe(false);
+    // ...but the legacy UNLABELED credential file is still cleaned up, so a
+    // pre-label install does not keep an orphaned, still-valid token on disk.
+    expect(
+      execCmds.some(cmd =>
+        /\.fleet-git-credential(\.bat)?"/.test(cmd) && (cmd.includes('rm -f') || cmd.includes('Remove-Item'))),
+    ).toBe(true);
+  });
+
+  it('github: a live credential registration survives a same-label refresh (no --unset-all)', async () => {
+    const member = makeTestAgent({ friendlyName: 'gh-registration-survives' });
+    addAgent(member);
+    mockTestConnection.mockResolvedValue({ ok: true, latencyMs: 5 });
+    mockExecCommand.mockResolvedValue({ stdout: '', stderr: '', code: 0 });
+
+    await provisionVcsAuth({
+      member_id: member.id, provider: 'github',
+      github_mode: 'pat', token: 'ghp_v1', label: 'live-label',
+    });
+    mockExecCommand.mockClear();
+
+    await provisionVcsAuth({
+      member_id: member.id, provider: 'github',
+      github_mode: 'pat', token: 'ghp_v2', label: 'live-label',
+    });
+
+    const execCmds = mockExecCommand.mock.calls.map(c => String(c[0]));
+    // A plain refresh fires no supersession revoke, so NOTHING in this deploy
+    // may unset the host-scoped helper key: the re-registration is done
+    // in-place by gitCredentialHelperWrite's own --replace-all + --add.
+    expect(execCmds.some(cmd => cmd.includes('--unset-all'))).toBe(false);
+    expect(execCmds.some(cmd => cmd.includes('--replace-all') && cmd.includes('--add'))).toBe(true);
+  });
+
   // --- {{secure.NAME}} token resolution ---
 
   it('resolves {{secure.NAME}} token in github pat token field', async () => {


### PR DESCRIPTION
Two fixes for the same live incident: fleet-lin-dev1 failing every fleet-sprint run against epic apra-fleet-hzeb, roughly every 15-30 minutes, even minutes after a verified `provision_vcs_auth`.

## Root cause (investigated live on the box, not inferred)

The "credential helper keeps getting unregistered" premise was wrong. Nothing on that box removes it -- no cron, no systemd timer, no rc file, no second process, and both the orchestrator and the member's own fleet server are `v0.4.3_d6c1f8` (so #473 is not recurring). The real sequence, from the sprint logs:

1. Preflight `provision_vcs_auth` succeeds -- credentials fine.
2. First D-push fails **`(diverged)`**: `! [rejected] main -> main (non-fast-forward) ... your branch is behind its remote counterpart`.
3. Engine reconciles (D-pull, re-push).
4. Re-push fails with `addTableFiles, updateManifestAddFiles: fatal: could not read Username`.
5. Self-heal calls `provision_vcs_auth`, it reports success, retries, fails identically -- **51 times** across the logs.

A credential revoked later cannot "succeed, then instantly fail, three times, seconds apart". Verified live: `git credential fill` returned the token, `git ls-remote` worked, and `bd dolt push` authenticated and was rejected **only** as non-fast-forward. The member's local Dolt clone had fallen behind `origin/main`; `bd dolt pull` then `bd dolt push` cleared it (both "complete"), which is the operational fix already applied to that box.

## 1. `dolt-sync.mjs` -- auth misclassification at the sequence level

Reaching the post-reconcile re-push branch *requires* the first push to have been rejected non-fast-forward, which is itself proof the remote authenticated the clone -- a remote cannot compare refs and reject a push it never let in. Production also threads an `onAuthFailure` self-heal into every step, so by that point credentials have been re-provisioned and the retry has failed identically. Credentials are therefore provably not the cause.

`runDoltStep` now reports `selfHealed`. The re-push branch keeps the existing apra-fleet-spp.3/spp.4 credential terminal when `!selfHealed`, and otherwise runs **one** more bounded D-pull + re-push with self-heal **disabled**, so it can never re-enter the reprovision loop it exists to break. Still bounded (two cycles, never a loop), preserving apra-fleet-417.3's first-successful-pusher-wins contract. An unrecovered outcome becomes a divergence terminal naming two reconcile pulls instead of a misleading credentials one.

**The classifier is deliberately untouched** -- each message classifies correctly in isolation, and widening the auth patterns would regress apra-fleet-spp (a real credential failure read as divergence). The signal is the sequence.

## 2. `provision-vcs-auth.ts` -- the legacy-migration step

It ran `gitCredentialHelperRemove(host)` unconditionally before every deploy, which with no label emits both the intended `rm -f $HOME/.fleet-git-credential` *and* `git config --global --unset-all credential.https://<host>.helper`. Running before the deploy, any failure in between left a credential file present and fresh but no git-config registration -- the exact state seen on fleet-lin-dev1.

**Scoping it to the label would not have worked**: the config key is host/scope-scoped, not label-scoped (the same asymmetry #473 turned on), so every variant unsets the live registration; scoping would only change which *file* was deleted. **Dropping the step wholesale** would leave a pre-label install with an orphaned still-valid token at `~/.fleet-git-credential` -- the security wart #473 called out.

So the step keeps its file half and loses its config half. The config half was pure redundancy with a destructive failure mode: `gitCredentialHelperWrite` already opens with `--replace-all "credential.<url>.helper" ""` before re-adding, on all three OS command implementations. Adds `gitCredentialHelperRemoveLegacyFile()` to `OsCommands` with Linux/macOS, Windows PowerShell and Windows Git-Bash implementations.

## Tests

New regression coverage, both mutation-checked (per this repo's convention):

- `dolt-sync-fault-tolerance.test.mjs`: pins the **verbatim** live 2026-09-11 stderr (both the chunk-upload text and the non-fast-forward rejection); asserts the recovery path reconciles and that provision is called **exactly once**; asserts the unrecovered path is a divergence terminal, never a credentials one. Forcing `selfHealed:false` fails both; the existing spp.4 pair (which wires no `onAuthFailure`) is unaffected.
- `provision-vcs-auth.test.ts`: asserts no `--unset-all` on a first-ever provision or a same-label refresh, while the legacy unlabeled file is still removed. Restoring the old call fails both.

`npm test`: 2 failures, both confirmed **pre-existing** -- re-running with this worktree's source checked out to `origin/main` reproduces both, and a clean `origin/main` worktree passes 2424/0. They are `resolveSchemasDir` (missing `dist/agents/schemas` build artifact) and `kb-remote-anchor-freshness`, neither related to these files. Targeted suites: 122 vitest + 182 node all pass, including `generic-boundary-guard`.

No `packages/apra-fleet-client` change needed: `provision_vcs_auth`'s schema and response contract are unchanged; the client only forwards the call.
